### PR TITLE
Checked each $wpdb, added phpcs:ignore

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -23,11 +23,11 @@ class PLL_Admin_Base extends PLL_Base {
 		load_plugin_textdomain( 'polylang', false, basename( POLYLANG_DIR ) . '/languages' );
 
 		// Adds the link to the languages panel in the WordPress admin menu
-		add_action( 'admin_menu', array( $this, 'add_menus' ) );
+		add_action( 'admin_menu', [ $this, 'add_menus' ] );
 
 		// Setup js scripts and css styles
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-		add_action( 'admin_print_footer_scripts', array( $this, 'admin_print_footer_scripts' ), 0 ); // High priority in case an ajax request is sent by an immediately invoked function
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
+		add_action( 'admin_print_footer_scripts', [ $this, 'admin_print_footer_scripts' ], 0 ); // High priority in case an ajax request is sent by an immediately invoked function
 
 		// Lingotek
 		if ( ! defined( 'POLYLANG_PRO' ) && ( ! defined( 'PLL_LINGOTEK_AD' ) || PLL_LINGOTEK_AD ) ) {
@@ -46,17 +46,17 @@ class PLL_Admin_Base extends PLL_Base {
 			return;
 		}
 
-		$this->links = new PLL_Admin_Links( $this ); // FIXME needed here ?
-		$this->static_pages = new PLL_Admin_Static_Pages( $this ); // FIXME needed here ?
+		$this->links         = new PLL_Admin_Links( $this ); // FIXME needed here ?
+		$this->static_pages  = new PLL_Admin_Static_Pages( $this ); // FIXME needed here ?
 		$this->filters_links = new PLL_Filters_Links( $this ); // FIXME needed here ?
 
 		// Filter admin language for users
 		// We must not call user info before WordPress defines user roles in wp-settings.php
-		add_filter( 'setup_theme', array( $this, 'init_user' ) );
-		add_filter( 'request', array( $this, 'request' ) );
+		add_filter( 'setup_theme', [ $this, 'init_user' ] );
+		add_filter( 'request', [ $this, 'request' ] );
 
 		// Adds the languages in admin bar
-		add_action( 'admin_bar_menu', array( $this, 'admin_bar_menu' ), 100 ); // 100 determines the position
+		add_action( 'admin_bar_menu', [ $this, 'admin_bar_menu' ], 100 ); // 100 determines the position
 	}
 
 	/**
@@ -66,7 +66,7 @@ class PLL_Admin_Base extends PLL_Base {
 	 */
 	public function add_menus() {
 		// Prepare the list of tabs
-		$tabs = array( 'lang' => __( 'Languages', 'polylang' ) );
+		$tabs = [ 'lang' => __( 'Languages', 'polylang' ) ];
 
 		// Only if at least one language has been created
 		if ( $this->model->get_languages_list() ) {
@@ -91,7 +91,7 @@ class PLL_Admin_Base extends PLL_Base {
 				add_menu_page( $title, __( 'Languages', 'polylang' ), 'manage_options', $page, null, 'dashicons-translation' );
 			}
 
-			add_submenu_page( $parent, $title, $title, 'manage_options', $page, array( $this, 'languages_page' ) );
+			add_submenu_page( $parent, $title, $title, 'manage_options', $page, [ $this, 'languages_page' ] );
 		}
 	}
 
@@ -114,12 +114,12 @@ class PLL_Admin_Base extends PLL_Base {
 		// 2 => 1 if loaded even if languages have not been defined yet, 0 otherwise
 		// 3 => 1 if loaded in footer
 		// FIXME: check if I can load more scripts in footer
-		$scripts = array(
-			'post'  => array( array( 'post', 'media', 'async-upload', 'edit' ), array( 'jquery', 'wp-ajax-response', 'post', 'jquery-ui-autocomplete' ), 0, 0 ),
-			'media' => array( array( 'upload' ), array( 'jquery' ), 0, 1 ),
-			'term'  => array( array( 'edit-tags', 'term' ), array( 'jquery', 'wp-ajax-response', 'jquery-ui-autocomplete' ), 0, 1 ),
-			'user'  => array( array( 'profile', 'user-edit' ), array( 'jquery' ), 0, 0 ),
-		);
+		$scripts = [
+			'post'  => [ [ 'post', 'media', 'async-upload', 'edit' ], [ 'jquery', 'wp-ajax-response', 'post', 'jquery-ui-autocomplete' ], 0, 0 ],
+			'media' => [ [ 'upload' ], [ 'jquery' ], 0, 1 ],
+			'term'  => [ [ 'edit-tags', 'term' ], [ 'jquery', 'wp-ajax-response', 'jquery-ui-autocomplete' ], 0, 1 ],
+			'user'  => [ [ 'profile', 'user-edit' ], [ 'jquery' ], 0, 0 ],
+		];
 
 		foreach ( $scripts as $script => $v ) {
 			if ( in_array( $screen->base, $v[0] ) && ( $v[2] || $this->model->get_languages_list() ) ) {
@@ -127,7 +127,7 @@ class PLL_Admin_Base extends PLL_Base {
 			}
 		}
 
-		wp_enqueue_style( 'polylang_admin', plugins_url( '/css/admin' . $suffix . '.css', POLYLANG_FILE ), array(), POLYLANG_VERSION );
+		wp_enqueue_style( 'polylang_admin', plugins_url( '/css/admin' . $suffix . '.css', POLYLANG_FILE ), [], POLYLANG_VERSION );
 	}
 
 	/**
@@ -147,13 +147,13 @@ class PLL_Admin_Base extends PLL_Base {
 	public function admin_print_footer_scripts() {
 		global $post_ID, $tag_ID;
 
-		$params = array( 'pll_ajax_backend' => 1 );
+		$params = [ 'pll_ajax_backend' => 1 ];
 		if ( ! empty( $post_ID ) ) {
-			$params = array_merge( $params, array( 'pll_post_id' => (int) $post_ID ) );
+			$params = array_merge( $params, [ 'pll_post_id' => (int) $post_ID ] );
 		}
 
 		if ( ! empty( $tag_ID ) ) {
-			$params = array_merge( $params, array( 'pll_term_id' => (int) $tag_ID ) );
+			$params = array_merge( $params, [ 'pll_term_id' => (int) $tag_ID ] );
 		}
 
 		$str = http_build_query( $params );
@@ -216,11 +216,9 @@ class PLL_Admin_Base extends PLL_Base {
 			$this->curlang = $lang;
 		} elseif ( 'post-new.php' === $GLOBALS['pagenow'] && ( empty( $_GET['post_type'] ) || $this->model->is_translated_post_type( $_GET['post_type'] ) ) ) {
 			$this->curlang = empty( $_GET['new_lang'] ) ? $this->pref_lang : $this->model->get_language( $_GET['new_lang'] );
-		}
-
-		// Edit Term
+		} // Edit Term
 		// FIXME 'edit-tags.php' for backward compatibility with WP < 4.5
-		elseif ( in_array( $GLOBALS['pagenow'], array( 'edit-tags.php', 'term.php' ) ) && isset( $_GET['tag_ID'] ) && $lang = $this->model->term->get_language( (int) $_GET['tag_ID'] ) ) {
+		elseif ( in_array( $GLOBALS['pagenow'], [ 'edit-tags.php', 'term.php' ] ) && isset( $_GET['tag_ID'] ) && $lang = $this->model->term->get_language( (int) $_GET['tag_ID'] ) ) {
 			$this->curlang = $lang;
 		} elseif ( isset( $_REQUEST['pll_term_id'] ) && $lang = $this->model->term->get_language( (int) $_REQUEST['pll_term_id'] ) ) {
 			$this->curlang = $lang;
@@ -247,7 +245,7 @@ class PLL_Admin_Base extends PLL_Base {
 		// Backend locale
 		// FIXME: Backward compatibility with WP < 4.7
 		if ( version_compare( $GLOBALS['wp_version'], '4.7alpha', '<' ) ) {
-			add_filter( 'locale', array( $this, 'get_locale' ) );
+			add_filter( 'locale', [ $this, 'get_locale' ] );
 		}
 
 		// Language for admin language filter: may be empty
@@ -329,11 +327,11 @@ class PLL_Admin_Base extends PLL_Base {
 	 * @param object $wp_admin_bar
 	 */
 	public function admin_bar_menu( $wp_admin_bar ) {
-		$all_item = (object) array(
+		$all_item = (object) [
 			'slug' => 'all',
 			'name' => __( 'Show all languages', 'polylang' ),
 			'flag' => '<span class="ab-icon"></span>',
-		);
+		];
 
 		$selected = empty( $this->filter_lang ) ? $all_item : $this->filter_lang;
 
@@ -344,25 +342,29 @@ class PLL_Admin_Base extends PLL_Base {
 			esc_html( $selected->name )
 		);
 
-		$wp_admin_bar->add_menu( array(
-			'id'     => 'languages',
-			'title'  => $selected->flag . $title,
-			'href'   => esc_url( add_query_arg( 'lang', $selected->slug, remove_query_arg( 'paged' ) ) ),
-			'meta'   => array( 'title' => __( 'Filters content by language', 'polylang' ) ),
-		) );
+		$wp_admin_bar->add_menu(
+			[
+				'id'     => 'languages',
+				'title'  => $selected->flag . $title,
+				'href'   => esc_url( add_query_arg( 'lang', $selected->slug, remove_query_arg( 'paged' ) ) ),
+				'meta'   => [ 'title' => __( 'Filters content by language', 'polylang' ) ],
+			]
+		);
 
-		foreach ( array_merge( array( $all_item ), $this->model->get_languages_list() ) as $lang ) {
+		foreach ( array_merge( [ $all_item ], $this->model->get_languages_list() ) as $lang ) {
 			if ( $selected->slug === $lang->slug ) {
 				continue;
 			}
 
-			$wp_admin_bar->add_menu( array(
-				'parent' => 'languages',
-				'id'     => $lang->slug,
-				'title'  => $lang->flag . esc_html( $lang->name ),
-				'href'   => esc_url( add_query_arg( 'lang', $lang->slug, remove_query_arg( 'paged' ) ) ),
-				'meta'   => 'all' === $lang->slug ? array() : array( 'lang' => esc_attr( $lang->get_locale( 'display' ) ) ),
-			) );
+			$wp_admin_bar->add_menu(
+				[
+					'parent' => 'languages',
+					'id'     => $lang->slug,
+					'title'  => $lang->flag . esc_html( $lang->name ),
+					'href'   => esc_url( add_query_arg( 'lang', $lang->slug, remove_query_arg( 'paged' ) ) ),
+					'meta'   => 'all' === $lang->slug ? [] : [ 'lang' => esc_attr( $lang->get_locale( 'display' ) ) ],
+				]
+			);
 		}
 	}
 }

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -122,7 +122,7 @@ class PLL_Admin_Base extends PLL_Base {
 		];
 
 		foreach ( $scripts as $script => $v ) {
-			if ( in_array( $screen->base, $v[0] ) && ( $v[2] || $this->model->get_languages_list() ) ) {
+			if ( in_array( $screen->base, $v[0], true ) && ( $v[2] || $this->model->get_languages_list() ) ) {
 				wp_enqueue_script( 'pll_' . $script, plugins_url( '/js/' . $script . $suffix . '.js', POLYLANG_FILE ), $v[1], POLYLANG_VERSION, $v[3] );
 			}
 		}
@@ -160,10 +160,10 @@ class PLL_Admin_Base extends PLL_Base {
 		$arr = json_encode( $params );
 ?>
 <script type="text/javascript">
-	if (typeof jQuery != 'undefined') {
+	if (typeof jQuery !== 'undefined') {
 		(function($){
 			$.ajaxPrefilter(function (options, originalOptions, jqXHR) {
-				if ( -1 != options.url.indexOf( ajaxurl ) || -1 != ajaxurl.indexOf( options.url ) ) {
+				if ( -1 !== options.url.indexOf( ajaxurl ) || -1 !== ajaxurl.indexOf( options.url ) ) {
 					if ( 'undefined' === typeof options.data ) {
 						options.data = ( 'get' === options.type.toLowerCase() ) ? '<?php echo $str; ?>' : <?php echo $arr; ?>;
 					} else {
@@ -218,7 +218,7 @@ class PLL_Admin_Base extends PLL_Base {
 			$this->curlang = empty( $_GET['new_lang'] ) ? $this->pref_lang : $this->model->get_language( $_GET['new_lang'] );
 		} // Edit Term
 		// FIXME 'edit-tags.php' for backward compatibility with WP < 4.5
-		elseif ( in_array( $GLOBALS['pagenow'], [ 'edit-tags.php', 'term.php' ] ) && isset( $_GET['tag_ID'] ) && $lang = $this->model->term->get_language( (int) $_GET['tag_ID'] ) ) {
+		elseif ( in_array( $GLOBALS['pagenow'], [ 'edit-tags.php', 'term.php' ], true ) && isset( $_GET['tag_ID'] ) && $lang = $this->model->term->get_language( (int) $_GET['tag_ID'] ) ) {
 			$this->curlang = $lang;
 		} elseif ( isset( $_REQUEST['pll_term_id'] ) && $lang = $this->model->term->get_language( (int) $_REQUEST['pll_term_id'] ) ) {
 			$this->curlang = $lang;

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -17,31 +17,31 @@ class PLL_Admin_Filters_Columns {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
-		$this->links = &$polylang->links;
-		$this->model = &$polylang->model;
+		$this->links       = &$polylang->links;
+		$this->model       = &$polylang->model;
 		$this->filter_lang = &$polylang->filter_lang;
 
 		// add the language and translations columns in 'All Posts', 'All Pages' and 'Media library' panels
 		foreach ( $this->model->get_translated_post_types() as $type ) {
 			// use the latest filter late as some plugins purely overwrite what's done by others :(
 			// specific case for media
-			add_filter( 'manage_' . ( 'attachment' == $type ? 'upload' : 'edit-' . $type ) . '_columns', array( $this, 'add_post_column' ), 100 );
-			add_action( 'manage_' . ( 'attachment' == $type ? 'media' : $type . '_posts' ) . '_custom_column', array( $this, 'post_column' ), 10, 2 );
+			add_filter( 'manage_' . ( 'attachment' == $type ? 'upload' : 'edit-' . $type ) . '_columns', [ $this, 'add_post_column' ], 100 );
+			add_action( 'manage_' . ( 'attachment' == $type ? 'media' : $type . '_posts' ) . '_custom_column', [ $this, 'post_column' ], 10, 2 );
 		}
 
 		// quick edit and bulk edit
-		add_filter( 'quick_edit_custom_box', array( $this, 'quick_edit_custom_box' ), 10, 2 );
-		add_filter( 'bulk_edit_custom_box', array( $this, 'quick_edit_custom_box' ), 10, 2 );
+		add_filter( 'quick_edit_custom_box', [ $this, 'quick_edit_custom_box' ], 10, 2 );
+		add_filter( 'bulk_edit_custom_box', [ $this, 'quick_edit_custom_box' ], 10, 2 );
 
 		// adds the language column in the 'Categories' and 'Post Tags' tables
 		foreach ( $this->model->get_translated_taxonomies() as $tax ) {
-			add_filter( 'manage_edit-' . $tax . '_columns', array( $this, 'add_term_column' ) );
-			add_filter( 'manage_' . $tax . '_custom_column', array( $this, 'term_column' ), 10, 3 );
+			add_filter( 'manage_edit-' . $tax . '_columns', [ $this, 'add_term_column' ] );
+			add_filter( 'manage_' . $tax . '_custom_column', [ $this, 'term_column' ], 10, 3 );
 		}
 
 		// ajax responses to update list table rows
-		add_action( 'wp_ajax_pll_update_post_rows', array( $this, 'ajax_update_post_rows' ) );
-		add_action( 'wp_ajax_pll_update_term_rows', array( $this, 'ajax_update_term_rows' ) );
+		add_action( 'wp_ajax_pll_update_post_rows', [ $this, 'ajax_update_post_rows' ] );
+		add_action( 'wp_ajax_pll_update_term_rows', [ $this, 'ajax_update_term_rows' ] );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class PLL_Admin_Filters_Columns {
 	 */
 	protected function add_column( $columns, $before ) {
 		if ( $n = array_search( $before, array_keys( $columns ) ) ) {
-			$end = array_slice( $columns, $n );
+			$end     = array_slice( $columns, $n );
 			$columns = array_slice( $columns, 0, $n );
 		}
 
@@ -109,7 +109,7 @@ class PLL_Admin_Filters_Columns {
 	 */
 	public function post_column( $column, $post_id ) {
 		$inline = wp_doing_ajax() && isset( $_REQUEST['action'], $_POST['inline_lang_choice'] ) && 'inline-save' === $_REQUEST['action'];
-		$lang = $inline ? $this->model->get_language( $_POST['inline_lang_choice'] ) : $this->model->post->get_language( $post_id );
+		$lang   = $inline ? $this->model->get_language( $_POST['inline_lang_choice'] ) : $this->model->post->get_language( $post_id );
 
 		if ( false === strpos( $column, 'language_' ) || ! $lang ) {
 			return;
@@ -149,8 +149,7 @@ class PLL_Admin_Filters_Columns {
 					esc_html( sprintf( __( 'This item is in %s', 'polylang' ), $language->name ) )
 				);
 			}
-		}
-		// link to add a new translation
+		} // link to add a new translation
 		else {
 			echo $this->links->new_post_translation_link( $post_id, $language );
 		}
@@ -170,7 +169,12 @@ class PLL_Admin_Filters_Columns {
 
 			$elements = $this->model->get_languages_list();
 			if ( current_filter() == 'bulk_edit_custom_box' ) {
-				array_unshift( $elements, (object) array( 'slug' => -1, 'name' => __( '&mdash; No Change &mdash;' ) ) );
+				array_unshift(
+					$elements, (object) [
+						'slug' => -1,
+						'name' => __( '&mdash; No Change &mdash;' ),
+					]
+				);
 			}
 
 			$dropdown = new PLL_Walker_Dropdown();
@@ -185,7 +189,12 @@ class PLL_Admin_Filters_Columns {
 					</div>
 				</fieldset>',
 				esc_html__( 'Language', 'polylang' ),
-				$dropdown->walk( $elements, array( 'name' => 'inline_lang_choice', 'id' => '' ) )
+				$dropdown->walk(
+					$elements, [
+						'name' => 'inline_lang_choice',
+						'id' => '',
+					]
+				)
 			);
 		}
 		return $column;
@@ -219,13 +228,13 @@ class PLL_Admin_Filters_Columns {
 		}
 
 		$post_type = isset( $GLOBALS['post_type'] ) ? $GLOBALS['post_type'] : $_REQUEST['post_type']; // 2nd case for quick edit
-		$taxonomy = isset( $GLOBALS['taxonomy'] ) ? $GLOBALS['taxonomy'] : $_REQUEST['taxonomy'];
+		$taxonomy  = isset( $GLOBALS['taxonomy'] ) ? $GLOBALS['taxonomy'] : $_REQUEST['taxonomy'];
 
 		if ( ! post_type_exists( $post_type ) || ! taxonomy_exists( $taxonomy ) ) {
 			return $out;
 		}
 
-		$term_id = (int) $term_id;
+		$term_id  = (int) $term_id;
 		$language = $this->model->get_language( substr( $column, 9 ) );
 
 		if ( $column == $this->get_first_language_column() ) {
@@ -260,9 +269,7 @@ class PLL_Admin_Filters_Columns {
 					esc_html( sprintf( __( 'This item is in %s', 'polylang' ), $language->name ) )
 				);
 			}
-		}
-
-		// link to add a new translation
+		} // link to add a new translation
 		else {
 			$out .= $this->links->new_term_translation_link( $term_id, $taxonomy, $post_type, $language );
 		}
@@ -284,11 +291,11 @@ class PLL_Admin_Filters_Columns {
 
 		check_ajax_referer( 'inlineeditnonce', '_pll_nonce' );
 
-		$x = new WP_Ajax_Response();
-		$wp_list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => $_POST['screen'] ) );
+		$x             = new WP_Ajax_Response();
+		$wp_list_table = _get_list_table( 'WP_Posts_List_Table', [ 'screen' => $_POST['screen'] ] );
 
-		$translations = empty( $_POST['translations'] ) ? array() : explode( ',', $_POST['translations'] ); // collect old translations
-		$translations = array_merge( $translations, array( $_POST['post_id'] ) ); // add current post
+		$translations = empty( $_POST['translations'] ) ? [] : explode( ',', $_POST['translations'] ); // collect old translations
+		$translations = array_merge( $translations, [ $_POST['post_id'] ] ); // add current post
 		$translations = array_map( 'intval', $translations );
 
 		foreach ( $translations as $post_id ) {
@@ -297,7 +304,13 @@ class PLL_Admin_Filters_Columns {
 				ob_start();
 				$wp_list_table->single_row( $post, $level );
 				$data = ob_get_clean();
-				$x->add( array( 'what' => 'row', 'data' => $data, 'supplemental' => array( 'post_id' => $post_id ) ) );
+				$x->add(
+					[
+						'what' => 'row',
+						'data' => $data,
+						'supplemental' => [ 'post_id' => $post_id ],
+					]
+				);
 			}
 		}
 
@@ -318,10 +331,10 @@ class PLL_Admin_Filters_Columns {
 
 		check_ajax_referer( 'pll_language', '_pll_nonce' );
 
-		$x = new WP_Ajax_Response();
-		$wp_list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => $_POST['screen'] ) );
+		$x             = new WP_Ajax_Response();
+		$wp_list_table = _get_list_table( 'WP_Terms_List_Table', [ 'screen' => $_POST['screen'] ] );
 
-		$translations = empty( $_POST['translations'] ) ? array() : explode( ',', $_POST['translations'] ); // collect old translations
+		$translations = empty( $_POST['translations'] ) ? [] : explode( ',', $_POST['translations'] ); // collect old translations
 		$translations = array_merge( $translations, $this->model->term->get_translations( (int) $_POST['term_id'] ) ); // add current translations
 		$translations = array_unique( $translations ); // remove duplicates
 		$translations = array_map( 'intval', $translations );
@@ -332,7 +345,13 @@ class PLL_Admin_Filters_Columns {
 				ob_start();
 				$wp_list_table->single_row( $tag, $level );
 				$data = ob_get_clean();
-				$x->add( array( 'what' => 'row', 'data' => $data, 'supplemental' => array( 'term_id' => $term_id ) ) );
+				$x->add(
+					[
+						'what' => 'row',
+						'data' => $data,
+						'supplemental' => [ 'term_id' => $term_id ],
+					]
+				);
 			}
 		}
 

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -25,8 +25,8 @@ class PLL_Admin_Filters_Columns {
 		foreach ( $this->model->get_translated_post_types() as $type ) {
 			// use the latest filter late as some plugins purely overwrite what's done by others :(
 			// specific case for media
-			add_filter( 'manage_' . ( 'attachment' == $type ? 'upload' : 'edit-' . $type ) . '_columns', [ $this, 'add_post_column' ], 100 );
-			add_action( 'manage_' . ( 'attachment' == $type ? 'media' : $type . '_posts' ) . '_custom_column', [ $this, 'post_column' ], 10, 2 );
+			add_filter( 'manage_' . ( 'attachment' === $type ? 'upload' : 'edit-' . $type ) . '_columns', [ $this, 'add_post_column' ], 100 );
+			add_action( 'manage_' . ( 'attachment' === $type ? 'media' : $type . '_posts' ) . '_custom_column', [ $this, 'post_column' ], 10, 2 );
 		}
 
 		// quick edit and bulk edit
@@ -61,7 +61,7 @@ class PLL_Admin_Filters_Columns {
 
 		foreach ( $this->model->get_languages_list() as $language ) {
 			// don't add the column for the filtered language
-			if ( empty( $this->filter_lang ) || $language->slug != $this->filter_lang->slug ) {
+			if ( empty( $this->filter_lang ) || $language->slug !== $this->filter_lang->slug ) {
 				$columns[ 'language_' . $language->slug ] = $language->flag ? $language->flag . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>' : esc_html( $language->slug );
 			}
 		}
@@ -78,7 +78,7 @@ class PLL_Admin_Filters_Columns {
 	 */
 	protected function get_first_language_column() {
 		foreach ( $this->model->get_languages_list() as $language ) {
-			if ( empty( $this->filter_lang ) || $language->slug != $this->filter_lang->slug ) {
+			if ( empty( $this->filter_lang ) || $language->slug !== $this->filter_lang->slug ) {
 				$columns[] = 'language_' . $language->slug;
 			}
 		}
@@ -118,7 +118,7 @@ class PLL_Admin_Filters_Columns {
 		$language = $this->model->get_language( substr( $column, 9 ) );
 
 		// hidden field containing the post language for quick edit
-		if ( $column == $this->get_first_language_column() ) {
+		if ( $column === $this->get_first_language_column() ) {
 			printf( '<div class="hidden" id="lang_%d">%s</div>', intval( $post_id ), esc_html( $lang->slug ) );
 		}
 
@@ -165,10 +165,10 @@ class PLL_Admin_Filters_Columns {
 	 * @return string unmodified $column
 	 */
 	public function quick_edit_custom_box( $column, $type ) {
-		if ( $column == $this->get_first_language_column() ) {
+		if ( $column === $this->get_first_language_column() ) {
 
 			$elements = $this->model->get_languages_list();
-			if ( current_filter() == 'bulk_edit_custom_box' ) {
+			if ( current_filter() === 'bulk_edit_custom_box' ) {
 				array_unshift(
 					$elements, (object) [
 						'slug' => -1,
@@ -237,11 +237,11 @@ class PLL_Admin_Filters_Columns {
 		$term_id  = (int) $term_id;
 		$language = $this->model->get_language( substr( $column, 9 ) );
 
-		if ( $column == $this->get_first_language_column() ) {
+		if ( $column === $this->get_first_language_column() ) {
 			$out = sprintf( '<div class="hidden" id="lang_%d">%s</div>', intval( $term_id ), esc_html( $lang->slug ) );
 
 			// identify the default categories to disable the language dropdown in js
-			if ( in_array( get_option( 'default_category' ), $this->model->term->get_translations( $term_id ) ) ) {
+			if ( in_array( (int) get_option( 'default_category' ), $this->model->term->get_translations( $term_id ), true ) ) {
 				$out .= sprintf( '<div class="hidden" id="default_cat_%1$d">%1$d</div>', intval( $term_id ) );
 			}
 		}

--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -42,7 +42,7 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 	 * @return array modified list of form fields
 	 */
 	public function attachment_fields_to_edit( $fields, $post ) {
-		if ( 'post.php' == $GLOBALS['pagenow'] ) {
+		if ( 'post.php' === $GLOBALS['pagenow'] ) {
 			return $fields; // Don't add anything on edit media panel for WP 3.5+ since we have the metabox
 		}
 

--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -18,16 +18,16 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 		parent::__construct( $polylang );
 
 		// Adds the language field and translations tables in the 'Edit Media' panel
-		add_filter( 'attachment_fields_to_edit', array( $this, 'attachment_fields_to_edit' ), 10, 2 );
+		add_filter( 'attachment_fields_to_edit', [ $this, 'attachment_fields_to_edit' ], 10, 2 );
 
 		// Adds actions related to languages when creating, saving or deleting media
-		add_action( 'add_attachment', array( $this, 'set_default_language' ) );
-		add_filter( 'attachment_fields_to_save', array( $this, 'save_media' ), 10, 2 );
-		add_filter( 'wp_delete_file', array( $this, 'wp_delete_file' ) );
+		add_action( 'add_attachment', [ $this, 'set_default_language' ] );
+		add_filter( 'attachment_fields_to_save', [ $this, 'save_media' ], 10, 2 );
+		add_filter( 'wp_delete_file', [ $this, 'wp_delete_file' ] );
 
 		// Creates a media translation
 		if ( isset( $_GET['action'], $_GET['new_lang'], $_GET['from_media'] ) && 'translate_media' === $_GET['action'] ) {
-			add_action( 'admin_init', array( $this, 'translate_media' ) );
+			add_action( 'admin_init', [ $this, 'translate_media' ] );
 		}
 	}
 
@@ -47,18 +47,20 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 		}
 
 		$post_id = $post->ID;
-		$lang = $this->model->post->get_language( $post_id );
+		$lang    = $this->model->post->get_language( $post_id );
 
-		$dropdown = new PLL_Walker_Dropdown();
-		$fields['language'] = array(
+		$dropdown           = new PLL_Walker_Dropdown();
+		$fields['language'] = [
 			'label' => __( 'Language', 'polylang' ),
 			'input' => 'html',
-			'html'  => $dropdown->walk( $this->model->get_languages_list(), array(
-				'name'     => sprintf( 'attachments[%d][language]', $post_id ),
-				'class'    => 'media_lang_choice',
-				'selected' => $lang ? $lang->slug : '',
-			) ),
-		);
+			'html'  => $dropdown->walk(
+				$this->model->get_languages_list(), [
+					'name'     => sprintf( 'attachments[%d][language]', $post_id ),
+					'class'    => 'media_lang_choice',
+					'selected' => $lang ? $lang->slug : '',
+				]
+			),
+		];
 
 		return $fields;
 	}
@@ -82,13 +84,13 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 		$lang = $this->model->get_language( $lang ); // Make sure we get a valid language slug
 
 		// Create a new attachment ( translate attachment parent if exists )
-		$post->ID = null; // Will force the creation
+		$post->ID          = null; // Will force the creation
 		$post->post_parent = ( $post->post_parent && $tr_parent = $this->model->post->get_translation( $post->post_parent, $lang->slug ) ) ? $tr_parent : 0;
-		$post->tax_input = array( 'language' => array( $lang->slug ) ); // Assigns the language
-		$tr_id = wp_insert_attachment( $post );
+		$post->tax_input   = [ 'language' => [ $lang->slug ] ]; // Assigns the language
+		$tr_id             = wp_insert_attachment( $post );
 
 		// Copy metadata, attached file and alternative text
-		foreach ( array( '_wp_attachment_metadata', '_wp_attached_file', '_wp_attachment_image_alt' ) as $key ) {
+		foreach ( [ '_wp_attachment_metadata', '_wp_attached_file', '_wp_attachment_image_alt' ] as $key ) {
 			if ( $meta = get_post_meta( $post_id, $key, true ) ) {
 				add_post_meta( $tr_id, $key, $meta );
 			}
@@ -178,11 +180,14 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 
 		$uploadpath = wp_upload_dir();
 
-		$ids = $wpdb->get_col( $wpdb->prepare( "
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"
 			SELECT post_id FROM $wpdb->postmeta
 			WHERE meta_key = '_wp_attached_file' AND meta_value = %s",
-			substr_replace( $file, '', 0, strlen( trailingslashit( $uploadpath['basedir'] ) ) )
-		) );
+				substr_replace( $file, '', 0, strlen( trailingslashit( $uploadpath['basedir'] ) ) )
+			)
+		);
 
 		if ( ! empty( $ids ) ) {
 			// Regenerate intermediate sizes if it's an image ( since we could not prevent WP deleting them before )

--- a/admin/admin-filters-post-base.php
+++ b/admin/admin-filters-post-base.php
@@ -16,8 +16,8 @@ abstract class PLL_Admin_Filters_Post_Base {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
-		$this->links = &$polylang->links;
-		$this->model = &$polylang->model;
+		$this->links     = &$polylang->links;
+		$this->model     = &$polylang->model;
 		$this->pref_lang = &$polylang->pref_lang;
 	}
 
@@ -32,13 +32,9 @@ abstract class PLL_Admin_Filters_Post_Base {
 		if ( ! $this->model->post->get_language( $post_id ) ) {
 			if ( isset( $_GET['new_lang'] ) && $lang = $this->model->get_language( $_GET['new_lang'] ) ) {
 				$this->model->post->set_language( $post_id, $lang );
-			}
-
-			elseif ( ( $parent_id = wp_get_post_parent_id( $post_id ) ) && $parent_lang = $this->model->post->get_language( $parent_id ) ) {
+			} elseif ( ( $parent_id = wp_get_post_parent_id( $post_id ) ) && $parent_lang = $this->model->post->get_language( $parent_id ) ) {
 				$this->model->post->set_language( $post_id, $parent_lang );
-			}
-
-			else {
+			} else {
 				$this->model->post->set_language( $post_id, $this->pref_lang );
 			}
 		}

--- a/admin/admin-filters-post-base.php
+++ b/admin/admin-filters-post-base.php
@@ -56,7 +56,7 @@ abstract class PLL_Admin_Filters_Post_Base {
 
 		// save translations after checking the translated post is in the right language
 		foreach ( $arr as $lang => $tr_id ) {
-			$translations[ $lang ] = ( $tr_id && $this->model->post->get_language( (int) $tr_id )->slug == $lang ) ? (int) $tr_id : 0;
+			$translations[ $lang ] = ( $tr_id && $this->model->post->get_language( (int) $tr_id )->slug === $lang ) ? (int) $tr_id : 0;
 		}
 
 		$this->model->post->save_translations( $post_id, $translations );

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -63,7 +63,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		$screen = get_current_screen();
 
 		// Hierarchical taxonomies
-		if ( 'edit' == $screen->base && $taxonomies = get_object_taxonomies( $screen->post_type, 'object' ) ) {
+		if ( 'edit' === $screen->base && $taxonomies = get_object_taxonomies( $screen->post_type, 'object' ) ) {
 			// Get translated hierarchical taxonomies
 			foreach ( $taxonomies as $taxonomy ) {
 				if ( $taxonomy->hierarchical && $taxonomy->show_in_quick_edit && $this->model->is_translated_taxonomy( $taxonomy->name ) ) {
@@ -88,7 +88,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		}
 
 		// Hierarchical post types
-		if ( 'edit' == $screen->base && is_post_type_hierarchical( $screen->post_type ) ) {
+		if ( 'edit' === $screen->base && is_post_type_hierarchical( $screen->post_type ) ) {
 			$pages = get_pages();
 
 			foreach ( $pages as $page ) {
@@ -176,7 +176,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 
 		echo '<div id="post-translations" class="translations">';
 		if ( $lang ) {
-			include PLL_ADMIN_INC . '/view-translations-' . ( 'attachment' == $post_type ? 'media' : 'post' ) . '.php';
+			include PLL_ADMIN_INC . '/view-translations-' . ( 'attachment' === $post_type ? 'media' : 'post' ) . '.php';
 		}
 		echo '</div>' . "\n";
 	}
@@ -203,7 +203,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 
 		ob_start();
 		if ( $lang ) {
-			include PLL_ADMIN_INC . '/view-translations-' . ( 'attachment' == $post_type ? 'media' : 'post' ) . '.php';
+			include PLL_ADMIN_INC . '/view-translations-' . ( 'attachment' === $post_type ? 'media' : 'post' ) . '.php';
 		}
 		$x = new WP_Ajax_Response(
 			[
@@ -258,7 +258,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		}
 
 		// Parent dropdown list ( only for hierarchical post types )
-		if ( in_array( $post_type, get_post_types( [ 'hierarchical' => true ] ) ) ) {
+		if ( in_array( $post_type, get_post_types( [ 'hierarchical' => true ] ), true ) ) {
 			$post = get_post( $post_ID );
 
 			// Args and filter from 'page_attributes_meta_box' in wp-admin/includes/meta-boxes.php of WP 4.2.1
@@ -414,7 +414,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			$this->model->post->set_language( $post_id, $lang ); // set new language
 
 			// Checks if the new language already exists in the translation group
-			if ( $old_lang && $old_lang->slug != $lang->slug ) {
+			if ( $old_lang && $old_lang->slug !== $lang->slug ) {
 				$translations = $this->model->post->get_translations( $post_id );
 
 				// If yes, separate this post from the translation group
@@ -544,7 +544,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 						$newterms = [];
 
 						foreach ( $terms as $term ) {
-							if ( in_array( $term->term_id, $wrong_term_ids ) ) {
+							if ( in_array( $term->term_id, $wrong_term_ids, true ) ) {
 								// Check if the term is in the correct language or if a translation exist ( mainly for default category )
 								if ( $newterm = $this->model->term->get( $term->term_id, $lang ) ) {
 									$newterms[] = (int) $newterm;
@@ -581,7 +581,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	public function wp_insert_post_parent( $post_parent, $post_id, $new_postarr, $postarr ) {
 		if ( isset( $postarr['bulk_edit'] ) ) {
 			check_admin_referer( 'bulk-posts' );
-			$lang        = -1 == $postarr['inline_lang_choice'] ?
+			$lang        = -1 === $postarr['inline_lang_choice'] ?
 				$this->model->post->get_language( $post_id ) :
 				$this->model->get_language( $postarr['inline_lang_choice'] );
 			$post_parent = $this->model->post->get_translation( $post_parent, $lang );

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -20,35 +20,35 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		$this->options = &$polylang->options;
 		$this->curlang = &$polylang->curlang;
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 
 		// Filters posts, pages and media by language
-		add_action( 'parse_query', array( $this, 'parse_query' ) );
+		add_action( 'parse_query', [ $this, 'parse_query' ] );
 
 		// Adds the Languages box in the 'Edit Post' and 'Edit Page' panels
-		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 10, 2 );
+		add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ], 10, 2 );
 
 		// Ajax response for changing the language in the post metabox
-		add_action( 'wp_ajax_post_lang_choice', array( $this, 'post_lang_choice' ) );
-		add_action( 'wp_ajax_pll_posts_not_translated', array( $this, 'ajax_posts_not_translated' ) );
+		add_action( 'wp_ajax_post_lang_choice', [ $this, 'post_lang_choice' ] );
+		add_action( 'wp_ajax_pll_posts_not_translated', [ $this, 'ajax_posts_not_translated' ] );
 
 		// Adds actions and filters related to languages when creating, saving or deleting posts and pages
-		add_action( 'load-post.php', array( $this, 'edit_post' ) );
-		add_action( 'load-edit.php', array( $this, 'bulk_edit_posts' ) );
-		add_action( 'wp_ajax_inline-save', array( $this, 'inline_edit_post' ), 0 ); // Before WordPress
-		add_action( 'save_post', array( $this, 'save_post' ), 21, 3 ); // Priority 21 to come after advanced custom fields ( 20 ) and before the event calendar which breaks everything after 25
-		add_action( 'set_object_terms', array( $this, 'set_object_terms' ), 10, 4 );
-		add_filter( 'wp_insert_post_parent', array( $this, 'wp_insert_post_parent' ), 10, 4 );
-		add_action( 'before_delete_post', array( $this, 'delete_post' ) );
+		add_action( 'load-post.php', [ $this, 'edit_post' ] );
+		add_action( 'load-edit.php', [ $this, 'bulk_edit_posts' ] );
+		add_action( 'wp_ajax_inline-save', [ $this, 'inline_edit_post' ], 0 ); // Before WordPress
+		add_action( 'save_post', [ $this, 'save_post' ], 21, 3 ); // Priority 21 to come after advanced custom fields ( 20 ) and before the event calendar which breaks everything after 25
+		add_action( 'set_object_terms', [ $this, 'set_object_terms' ], 10, 4 );
+		add_filter( 'wp_insert_post_parent', [ $this, 'wp_insert_post_parent' ], 10, 4 );
+		add_action( 'before_delete_post', [ $this, 'delete_post' ] );
 		if ( $this->options['media_support'] ) {
-			add_action( 'delete_attachment', array( $this, 'delete_post' ) ); // Action shared with media
+			add_action( 'delete_attachment', [ $this, 'delete_post' ] ); // Action shared with media
 		}
 
 		// Filters the pages by language in the parent dropdown list in the page attributes metabox
-		add_filter( 'page_attributes_dropdown_pages_args', array( $this, 'page_attributes_dropdown_pages_args' ), 10, 2 );
+		add_filter( 'page_attributes_dropdown_pages_args', [ $this, 'page_attributes_dropdown_pages_args' ], 10, 2 );
 
 		// Sets the language in Tiny MCE
-		add_filter( 'tiny_mce_before_init', array( $this, 'tiny_mce_before_init' ) );
+		add_filter( 'tiny_mce_before_init', [ $this, 'tiny_mce_before_init' ] );
 	}
 
 	/**
@@ -72,7 +72,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			}
 
 			if ( ! empty( $hierarchical_taxonomies ) ) {
-				$terms = get_terms( $hierarchical_taxonomies, array( 'get' => 'all' ) );
+				$terms = get_terms( $hierarchical_taxonomies, [ 'get' => 'all' ] );
 
 				foreach ( $terms as $term ) {
 					if ( $lang = $this->model->term->get_language( $term->term_id ) ) {
@@ -126,7 +126,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	 */
 	public function add_meta_boxes( $post_type, $post ) {
 		if ( $this->model->is_translated_post_type( $post_type ) ) {
-			add_meta_box( 'ml_box', __( 'Languages', 'polylang' ), array( $this, 'post_language' ), $post_type, 'side', 'high' );
+			add_meta_box( 'ml_box', __( 'Languages', 'polylang' ), [ $this, 'post_language' ], $post_type, 'side', 'high' );
 		}
 	}
 
@@ -137,7 +137,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	 */
 	public function post_language() {
 		global $post_ID;
-		$post_id = $post_ID;
+		$post_id   = $post_ID;
 		$post_type = get_post_type( $post_ID );
 
 		$lang = ( $lg = $this->model->post->get_language( $post_ID ) ) ? $lg :
@@ -149,19 +149,22 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		wp_nonce_field( 'pll_language', '_pll_nonce' );
 
 		// NOTE: the class "tags-input" allows to include the field in the autosave $_POST ( see autosave.js )
-		printf( '
+		printf(
+			'
 			<p><strong>%1$s</strong></p>
 			<label class="screen-reader-text" for="%2$s">%1$s</label>
 			<div id="select-%3$s-language">%4$s</div>',
 			esc_html__( 'Language', 'polylang' ),
 			$id = ( 'attachment' === $post_type ) ? sprintf( 'attachments[%d][language]', $post_ID ) : 'post_lang_choice',
 			'attachment' === $post_type ? 'media' : 'post',
-			$dropdown->walk( $this->model->get_languages_list(), array(
-				'name'     => $id,
-				'class'    => 'post_lang_choice tags-input',
-				'selected' => $lang ? $lang->slug : '',
-				'flag'     => true,
-			) )
+			$dropdown->walk(
+				$this->model->get_languages_list(), [
+					'name'     => $id,
+					'class'    => 'post_lang_choice tags-input',
+					'selected' => $lang ? $lang->slug : '',
+					'flag'     => true,
+				]
+			)
 		);
 
 		/**
@@ -188,9 +191,9 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 
 		global $post_ID; // Obliged to use the global variable for wp_popular_terms_checklist
 		$post_id = $post_ID = (int) $_POST['post_id'];
-		$lang = $this->model->get_language( $_POST['lang'] );
+		$lang    = $this->model->get_language( $_POST['lang'] );
 
-		$post_type = $_POST['post_type'];
+		$post_type        = $_POST['post_type'];
 		$post_type_object = get_post_type_object( $post_type );
 		if ( ! current_user_can( $post_type_object->cap->edit_post, $post_ID ) ) {
 			wp_die( -1 );
@@ -202,7 +205,12 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		if ( $lang ) {
 			include PLL_ADMIN_INC . '/view-translations-' . ( 'attachment' == $post_type ? 'media' : 'post' ) . '.php';
 		}
-		$x = new WP_Ajax_Response( array( 'what' => 'translations', 'data' => ob_get_contents() ) );
+		$x = new WP_Ajax_Response(
+			[
+				'what' => 'translations',
+				'data' => ob_get_contents(),
+			]
+		);
 		ob_end_clean();
 
 		// Categories
@@ -212,36 +220,49 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 				$taxonomy = get_taxonomy( $taxname );
 
 				ob_start();
-				$popular_ids = wp_popular_terms_checklist( $taxonomy->name );
+				$popular_ids              = wp_popular_terms_checklist( $taxonomy->name );
 				$supplemental['populars'] = ob_get_contents();
 				ob_end_clean();
 
 				ob_start();
 				// Use $post_ID to remember checked terms in case we come back to the original language
-				wp_terms_checklist( $post_ID, array( 'taxonomy' => $taxonomy->name, 'popular_cats' => $popular_ids ) );
+				wp_terms_checklist(
+					$post_ID, [
+						'taxonomy' => $taxonomy->name,
+						'popular_cats' => $popular_ids,
+					]
+				);
 				$supplemental['all'] = ob_get_contents();
 				ob_end_clean();
 
-				$supplemental['dropdown'] = wp_dropdown_categories( array(
-					'taxonomy'         => $taxonomy->name,
-					'hide_empty'       => 0,
-					'name'             => 'new' . $taxonomy->name . '_parent',
-					'orderby'          => 'name',
-					'hierarchical'     => 1,
-					'show_option_none' => '&mdash; ' . $taxonomy->labels->parent_item . ' &mdash;',
-					'echo'             => 0,
-				) );
+				$supplemental['dropdown'] = wp_dropdown_categories(
+					[
+						'taxonomy'         => $taxonomy->name,
+						'hide_empty'       => 0,
+						'name'             => 'new' . $taxonomy->name . '_parent',
+						'orderby'          => 'name',
+						'hierarchical'     => 1,
+						'show_option_none' => '&mdash; ' . $taxonomy->labels->parent_item . ' &mdash;',
+						'echo'             => 0,
+					]
+				);
 
-				$x->Add( array( 'what' => 'taxonomy', 'data' => $taxonomy->name, 'supplemental' => $supplemental ) );
+				$x->Add(
+					[
+						'what' => 'taxonomy',
+						'data' => $taxonomy->name,
+						'supplemental' => $supplemental,
+					]
+				);
 			}
 		}
 
 		// Parent dropdown list ( only for hierarchical post types )
-		if ( in_array( $post_type, get_post_types( array( 'hierarchical' => true ) ) ) ) {
+		if ( in_array( $post_type, get_post_types( [ 'hierarchical' => true ] ) ) ) {
 			$post = get_post( $post_ID );
 
 			// Args and filter from 'page_attributes_meta_box' in wp-admin/includes/meta-boxes.php of WP 4.2.1
-			$dropdown_args = array(
+			$dropdown_args = [
 				'post_type'        => $post->post_type,
 				'exclude_tree'     => $post->ID,
 				'selected'         => $post->post_parent,
@@ -249,19 +270,34 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 				'show_option_none' => __( '(no parent)' ),
 				'sort_column'      => 'menu_order, post_title',
 				'echo'             => 0,
-			);
+			];
 
 			/** This filter is documented in wp-admin/includes/meta-boxes.php */
 			$dropdown_args = apply_filters( 'page_attributes_dropdown_pages_args', $dropdown_args, $post ); // Since WP 3.3
 
-			$x->Add( array( 'what' => 'pages', 'data' => wp_dropdown_pages( $dropdown_args ) ) );
+			$x->Add(
+				[
+					'what' => 'pages',
+					'data' => wp_dropdown_pages( $dropdown_args ),
+				]
+			);
 		}
 
 		// Flag
-		$x->Add( array( 'what' => 'flag', 'data' => empty( $lang->flag ) ? esc_html( $lang->slug ) : $lang->flag ) );
+		$x->Add(
+			[
+				'what' => 'flag',
+				'data' => empty( $lang->flag ) ? esc_html( $lang->slug ) : $lang->flag,
+			]
+		);
 
 		// Sample permalink
-		$x->Add( array( 'what' => 'permalink', 'data' => get_sample_permalink_html( $post_ID ) ) );
+		$x->Add(
+			[
+				'what' => 'permalink',
+				'data' => get_sample_permalink_html( $post_ID ),
+			]
+		);
 
 		$x->send();
 	}
@@ -278,25 +314,25 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			die( 0 );
 		}
 
-		$post_language = $this->model->get_language( $_GET['post_language'] );
+		$post_language        = $this->model->get_language( $_GET['post_language'] );
 		$translation_language = $this->model->get_language( $_GET['translation_language'] );
 
 		// Don't order by title: see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough
-		$args = array(
+		$args = [
 			's'                => wp_unslash( $_GET['term'] ),
 			'suppress_filters' => 0, // To make the post_fields filter work
 			'lang'             => 0, // Avoid admin language filter
 			'numberposts'      => 20, // Limit to 20 posts
 			'post_status'      => 'any',
 			'post_type'        => $_GET['post_type'],
-			'tax_query'        => array(
-				array(
+			'tax_query'        => [
+				[
 					'taxonomy' => 'language',
 					'field'    => 'term_taxonomy_id', // WP 3.5+
 					'terms'    => $translation_language->term_taxonomy_id,
-				),
-			),
-		);
+				],
+			],
+		];
 
 		/**
 		 * Filter the query args when auto suggesting untranslated posts in the Languages metabox
@@ -308,29 +344,31 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		 *
 		 * @param array $args WP_Query arguments
 		 */
-		$args = apply_filters( 'pll_ajax_posts_not_translated_args', $args );
+		$args  = apply_filters( 'pll_ajax_posts_not_translated_args', $args );
 		$posts = get_posts( $args );
 
-		$return = array();
+		$return = [];
 
 		foreach ( $posts as $key => $post ) {
 			if ( ! $this->model->post->get_translation( $post->ID, $post_language ) ) {
-				$return[] = array(
+				$return[] = [
 					'id' => $post->ID,
 					'value' => $post->post_title,
 					'link' => $this->links->edit_post_translation_link( $post->ID ),
-				);
+				];
 			}
 		}
 
 		// Add current translation in list
 		if ( $post_id = $this->model->post->get_translation( (int) $_GET['pll_post_id'], $translation_language ) ) {
 			$post = get_post( $post_id );
-			array_unshift( $return, array(
-				'id' => $post_id,
-				'value' => $post->post_title,
-				'link' => $this->links->edit_post_translation_link( $post_id ),
-			) );
+			array_unshift(
+				$return, [
+					'id' => $post_id,
+					'value' => $post->post_title,
+					'link' => $this->links->edit_post_translation_link( $post_id ),
+				]
+			);
 		}
 
 		wp_die( json_encode( $return ) );
@@ -345,7 +383,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		if ( isset( $_POST['post_lang_choice'], $_POST['post_ID'] ) && $post_id = (int) $_POST['post_ID'] ) {
 			check_admin_referer( 'pll_language', '_pll_nonce' );
 
-			$post = get_post( $post_id );
+			$post             = get_post( $post_id );
 			$post_type_object = get_post_type_object( $post->post_type );
 
 			if ( current_user_can( $post_type_object->cap->edit_post, $post_id ) ) {
@@ -368,7 +406,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	 * @param object $lang    Language
 	 */
 	protected function inline_save_language( $post_id, $lang ) {
-		$post = get_post( $post_id );
+		$post             = get_post( $post_id );
 		$post_type_object = get_post_type_object( $post->post_type );
 
 		if ( current_user_can( $post_type_object->cap->edit_post, $post_id ) ) {
@@ -382,9 +420,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 				// If yes, separate this post from the translation group
 				if ( array_key_exists( $lang->slug, $translations ) ) {
 					$this->model->post->delete_translation( $post_id );
-				}
-
-				elseif ( array_key_exists( $old_lang->slug, $translations ) ) {
+				} elseif ( array_key_exists( $old_lang->slug, $translations ) ) {
 					unset( $translations[ $old_lang->slug ] );
 					$this->model->post->save_translations( $post_id, $translations );
 				}
@@ -420,7 +456,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 
 		if ( isset( $_POST['post_ID'], $_POST['inline_lang_choice'] ) ) {
 			$post_id = (int) $_POST['post_ID'];
-			$lang = $this->model->get_language( $_POST['inline_lang_choice'] );
+			$lang    = $this->model->get_language( $_POST['inline_lang_choice'] );
 			if ( $post_id && $lang ) {
 				$this->inline_save_language( $post_id, $lang );
 			}
@@ -483,37 +519,39 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 				// Convert to term ids if we got tag names
 				$strings = array_filter( $terms, 'is_string' );
 				if ( ! empty( $strings ) ) {
-					$_terms = get_terms( $taxonomy, array( 'name' => $strings, 'object_ids' => $object_id, 'fields' => 'ids' ) );
-					$terms = array_merge( array_diff( $terms, $strings ), $_terms );
+					$_terms = get_terms(
+						$taxonomy, [
+							'name' => $strings,
+							'object_ids' => $object_id,
+							'fields' => 'ids',
+						]
+					);
+					$terms  = array_merge( array_diff( $terms, $strings ), $_terms );
 				}
 
-				$term_ids = array_combine( $terms, $terms );
-				$languages = array_map( array( $this->model->term, 'get_language' ), $term_ids );
-				$languages = wp_list_pluck( $languages, 'slug' );
-				$wrong_terms = array_diff( $languages, array( $lang->slug ) );
+				$term_ids    = array_combine( $terms, $terms );
+				$languages   = array_map( [ $this->model->term, 'get_language' ], $term_ids );
+				$languages   = wp_list_pluck( $languages, 'slug' );
+				$wrong_terms = array_diff( $languages, [ $lang->slug ] );
 
 				if ( ! empty( $wrong_terms ) ) {
 					// We got terms in a wrong language
 					$wrong_term_ids = array_keys( $wrong_terms );
-					$terms = get_the_terms( $object_id, $taxonomy );
+					$terms          = get_the_terms( $object_id, $taxonomy );
 					wp_remove_object_terms( $object_id, $wrong_term_ids, $taxonomy );
 
 					if ( is_array( $terms ) ) {
-						$newterms = array();
+						$newterms = [];
 
 						foreach ( $terms as $term ) {
 							if ( in_array( $term->term_id, $wrong_term_ids ) ) {
 								// Check if the term is in the correct language or if a translation exist ( mainly for default category )
 								if ( $newterm = $this->model->term->get( $term->term_id, $lang ) ) {
 									$newterms[] = (int) $newterm;
-								}
-
-								// Or choose the correct language for tags ( initially defined by name )
+								} // Or choose the correct language for tags ( initially defined by name )
 								elseif ( $newterm = $this->model->term_exists( $term->name, $taxonomy, $term->parent, $lang ) ) {
 									$newterms[] = (int) $newterm; // Cast is important otherwise we get 'numeric' tags
-								}
-
-								// Or create the term in the correct language
+								} // Or create the term in the correct language
 								elseif ( ! is_wp_error( $term_info = wp_insert_term( $term->name, $taxonomy ) ) ) {
 									$newterms[] = (int) $term_info['term_id'];
 								}
@@ -543,7 +581,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	public function wp_insert_post_parent( $post_parent, $post_id, $new_postarr, $postarr ) {
 		if ( isset( $postarr['bulk_edit'] ) ) {
 			check_admin_referer( 'bulk-posts' );
-			$lang = -1 == $postarr['inline_lang_choice'] ?
+			$lang        = -1 == $postarr['inline_lang_choice'] ?
 				$this->model->post->get_language( $post_id ) :
 				$this->model->get_language( $postarr['inline_lang_choice'] );
 			$post_parent = $this->model->post->get_translation( $post_parent, $lang );
@@ -594,7 +632,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	 */
 	public function tiny_mce_before_init( $mce_init ) {
 		if ( ! empty( $this->curlang ) ) {
-			$mce_init['wp_lang_attr'] = $this->curlang->get_locale( 'display' );
+			$mce_init['wp_lang_attr']   = $this->curlang->get_locale( 'display' );
 			$mce_init['directionality'] = $this->curlang->is_rtl ? 'rtl' : 'ltr';
 		}
 		return $mce_init;

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -681,7 +681,7 @@ class PLL_Admin_Filters_Term {
 
 		// FIXME backward compatibility with WP < 4.7
 		if ( version_compare( $GLOBALS['wp_version'], '4.7alpha', '<' ) ) {
-			$traces = debug_backtrace();
+			$traces = debug_backtrace( 1, 4 );
 			$n      = version_compare( PHP_VERSION, '7', '>=' ) ? 3 : 4; // PHP 7 does not include call_user_func_array
 
 			if ( isset( $traces[ $n ] ) ) {

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -135,7 +135,7 @@ class PLL_Admin_Filters_Term {
 		$dropdown = new PLL_Walker_Dropdown();
 
 		// Disable the language dropdown and the translations input fields for default categories to prevent removal
-		$disabled = in_array( get_option( 'default_category' ), $this->model->term->get_translations( $term_id ) );
+		$disabled = in_array( (int) get_option( 'default_category' ), $this->model->term->get_translations( $term_id ), true );
 
 		printf(
 			'
@@ -238,7 +238,7 @@ class PLL_Admin_Filters_Term {
 
 		// Edit tags
 		if ( isset( $_POST['term_lang_choice'] ) ) {
-			if ( 'add-' . $taxonomy == $_POST['action'] ) {
+			if ( 'add-' . $taxonomy === $_POST['action'] ) {
 				check_ajax_referer( $_POST['action'], '_ajax_nonce-add-' . $taxonomy ); // category metabox
 			} else {
 				check_admin_referer( 'pll_language', '_pll_nonce' ); // edit tags or tags metabox
@@ -251,7 +251,7 @@ class PLL_Admin_Filters_Term {
 
 			// Bulk edit does not modify the language
 			// So we possibly create a tag in several languages
-			if ( -1 == $_GET['inline_lang_choice'] ) {
+			if ( -1 === $_GET['inline_lang_choice'] ) {
 				// The language of the current term is set a according to the language of the current post
 				$this->model->term->set_language( $term_id, $this->model->post->get_language( $this->post_id ) );
 				$term = get_term( $term_id, $taxonomy );
@@ -285,7 +285,7 @@ class PLL_Admin_Filters_Term {
 		} // Quick edit
 		elseif ( isset( $_POST['inline_lang_choice'] ) ) {
 			check_ajax_referer(
-				isset( $_POST['action'] ) && 'inline-save' == $_POST['action'] ? 'inlineeditnonce' : 'taxinlineeditnonce', // Post quick edit or tag quick edit ?
+				isset( $_POST['action'] ) && 'inline-save' === $_POST['action'] ? 'inlineeditnonce' : 'taxinlineeditnonce', // Post quick edit or tag quick edit ?
 				'_inline_edit'
 			);
 
@@ -294,7 +294,7 @@ class PLL_Admin_Filters_Term {
 			$translations = $this->model->term->get_translations( $term_id );
 
 			// Checks if the new language already exists in the translation group
-			if ( $old_lang && $old_lang->slug != $lang->slug ) {
+			if ( $old_lang && $old_lang->slug !== $lang->slug ) {
 				if ( array_key_exists( $lang->slug, $translations ) ) {
 					$this->model->term->delete_translation( $term_id );
 				} elseif ( array_key_exists( $old_lang->slug, $translations ) ) {
@@ -328,7 +328,7 @@ class PLL_Admin_Filters_Term {
 		// Save translations after checking the translated term is in the right language ( as well as cast id to int )
 		foreach ( $_POST['term_tr_lang'] as $lang => $tr_id ) {
 			$tr_lang               = $this->model->term->get_language( (int) $tr_id );
-			$translations[ $lang ] = $tr_lang && $tr_lang->slug == $lang ? (int) $tr_id : 0;
+			$translations[ $lang ] = $tr_lang && $tr_lang->slug === $lang ? (int) $tr_id : 0;
 		}
 
 		$this->model->term->save_translations( $term_id, $translations );
@@ -412,7 +412,7 @@ class PLL_Admin_Filters_Term {
 			} // *Post* bulk edit, in case a new term is created
 			elseif ( isset( $_GET['bulk_edit'], $_GET['inline_lang_choice'] ) ) {
 				// Bulk edit does not modify the language
-				if ( -1 == $_GET['inline_lang_choice'] ) {
+				if ( -1 === $_GET['inline_lang_choice'] ) {
 					$slug = $name . '-' . $this->model->post->get_language( $this->post_id )->slug;
 				} else {
 					$slug = $name . '-' . $this->model->get_language( $_GET['inline_lang_choice'] )->slug;
@@ -545,7 +545,7 @@ class PLL_Admin_Filters_Term {
 		foreach ( get_terms( $taxonomy, 'hide_empty=0&lang=0&name__like=' . $s ) as $term ) {
 			$lang = $this->model->term->get_language( $term->term_id );
 
-			if ( $lang && $lang->slug == $translation_language->slug && ! $this->model->term->get_translation( $term->term_id, $term_language ) ) {
+			if ( $lang && $lang->slug === $translation_language->slug && ! $this->model->term->get_translation( $term->term_id, $term_language ) ) {
 				$return[] = [
 					'id' => $term->term_id,
 					'value' => $term->name,
@@ -686,11 +686,11 @@ class PLL_Admin_Filters_Term {
 
 			if ( isset( $traces[ $n ] ) ) {
 				// FIXME 'column_name' for backward compatibility with WP < 4.3
-				if ( in_array( $traces[ $n ]['function'], [ 'column_cb', 'column_name', 'handle_row_actions' ] ) && in_array( $traces[ $n ]['args'][0]->term_id, $this->model->term->get_translations( $value ) ) ) {
+				if ( in_array( $traces[ $n ]['function'], [ 'column_cb', 'column_name', 'handle_row_actions' ], true ) && in_array( $traces[ $n ]['args'][0]->term_id, $this->model->term->get_translations( $value ) ) ) {
 					return $traces[ $n ]['args'][0]->term_id;
 				}
 
-				if ( 'wp_delete_term' == $traces[ $n ]['function'] ) {
+				if ( 'wp_delete_term' === $traces[ $n ]['function'] ) {
 					return $this->model->term->get( $value, $this->model->term->get_language( $traces[ $n ]['args'][0] ) );
 				}
 			}
@@ -718,7 +718,7 @@ class PLL_Admin_Filters_Term {
 		}
 
 		foreach ( $this->model->get_languages_list() as $language ) {
-			if ( $language->slug != $default_cat_lang->slug && ! $this->model->term->get_translation( $value, $language ) ) {
+			if ( $language->slug !== $default_cat_lang->slug && ! $this->model->term->get_translation( $value, $language ) ) {
 				$this->model->create_default_category( $language );
 			}
 		}
@@ -750,14 +750,14 @@ class PLL_Admin_Filters_Term {
 		$lang            = $this->model->term->get_language( $term_id );
 
 		foreach ( $this->model->term->get_translations( $term_id ) as $key => $tr_id ) {
-			if ( $lang->slug == $key ) {
+			if ( $lang->slug === $key ) {
 				$translations[ $key ] = $new_term_id;
 			} else {
 				$tr_term              = get_term( $tr_id, $taxonomy );
 				$translations[ $key ] = _split_shared_term( $tr_id, $tr_term->term_taxonomy_id );
 
 				// Hack translation ids sent by the form to avoid overwrite in PLL_Admin_Filters_Term::save_translations
-				if ( isset( $_POST['term_tr_lang'][ $key ] ) && $_POST['term_tr_lang'][ $key ] == $tr_id ) {
+				if ( isset( $_POST['term_tr_lang'][ $key ] ) && (int) $_POST['term_tr_lang'][ $key ] === (int) $tr_id ) {
 					$_POST['term_tr_lang'][ $key ] = $translations[ $key ];
 				}
 			}

--- a/admin/admin-filters.php
+++ b/admin/admin-filters.php
@@ -97,7 +97,7 @@ class PLL_Admin_Filters extends PLL_Filters {
 	 * @return array Widget options
 	 */
 	public function widget_update_callback( $instance, $new_instance, $old_instance, $widget ) {
-		if ( ! empty( $_POST[ $key = $widget->id . '_lang_choice' ] ) && in_array( $_POST[ $key ], $this->model->get_languages_list( [ 'fields' => 'slug' ] ) ) ) {
+		if ( ! empty( $_POST[ $key = $widget->id . '_lang_choice' ] ) && in_array( $_POST[ $key ], $this->model->get_languages_list( [ 'fields' => 'slug' ] ), true ) ) {
 			$instance['pll_lang'] = $_POST[ $key ];
 		} else {
 			unset( $instance['pll_lang'] );
@@ -117,13 +117,13 @@ class PLL_Admin_Filters extends PLL_Filters {
 		// Admin language
 		// FIXME Backward compatibility with WP < 4.7
 		if ( version_compare( $GLOBALS['wp_version'], '4.7alpha', '<' ) ) {
-			$user_lang = in_array( $_POST['user_lang'], $this->model->get_languages_list( [ 'fields' => 'locale' ] ) ) ? $_POST['user_lang'] : 0;
+			$user_lang = in_array( $_POST['user_lang'], $this->model->get_languages_list( [ 'fields' => 'locale' ] ), true ) ? $_POST['user_lang'] : 0;
 			update_user_meta( $user_id, 'locale', $user_lang );
 		}
 
 		// Biography translations
 		foreach ( $this->model->get_languages_list() as $lang ) {
-			$meta        = $lang->slug == $this->options['default_lang'] ? 'description' : 'description_' . $lang->slug;
+			$meta        = $lang->slug === $this->options['default_lang'] ? 'description' : 'description_' . $lang->slug;
 			$description = empty( $_POST[ 'description_' . $lang->slug ] ) ? '' : trim( $_POST[ 'description_' . $lang->slug ] );
 
 			/** This filter is documented in wp-includes/user.php */
@@ -171,7 +171,7 @@ class PLL_Admin_Filters extends PLL_Filters {
 
 		// Hidden information to modify the biography form with js
 		foreach ( $this->model->get_languages_list() as $lang ) {
-			$meta = $lang->slug == $this->options['default_lang'] ? 'description' : 'description_' . $lang->slug;
+			$meta = $lang->slug === $this->options['default_lang'] ? 'description' : 'description_' . $lang->slug;
 
 			/** This filter is documented in wp-includes/user.php */
 			$description = apply_filters( 'user_description', get_user_meta( $profileuser->ID, $meta, true ) ); // Applies WP default filter wp_kses_data
@@ -244,7 +244,7 @@ class PLL_Admin_Filters extends PLL_Filters {
 	public function sanitize_title( $title, $raw_title, $context ) {
 		static $once = false;
 
-		if ( ! $once && 'save' == $context && ! empty( $this->curlang ) && ! empty( $title ) ) {
+		if ( ! $once && 'save' === $context && ! empty( $this->curlang ) && ! empty( $title ) ) {
 			$once = true;
 			add_filter( 'locale', [ $this, 'get_locale' ], 20 ); // After the filter for the admin interface
 			$title = sanitize_title( $raw_title, '', $context );

--- a/admin/admin-links.php
+++ b/admin/admin-links.php
@@ -17,27 +17,27 @@ class PLL_Admin_Links extends PLL_Links {
 	 * @return string
 	 */
 	public function get_new_post_translation_link( $post_id, $language ) {
-		$post_type = get_post_type( $post_id );
+		$post_type        = get_post_type( $post_id );
 		$post_type_object = get_post_type_object( get_post_type( $post_id ) );
 		if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
 			return '';
 		}
 
 		if ( 'attachment' == $post_type ) {
-			$args = array(
+			$args = [
 				'action'     => 'translate_media',
 				'from_media' => $post_id,
 				'new_lang'   => $language->slug,
-			);
+			];
 
 			// add nonce for media as we will directly publish a new attachment from a click on this link
 			$link = wp_nonce_url( add_query_arg( $args, admin_url( 'admin.php' ) ), 'translate_media' );
 		} else {
-			$args = array(
+			$args = [
 				'post_type' => $post_type,
 				'from_post' => $post_id,
 				'new_lang'  => $language->slug,
-			);
+			];
 
 			$link = add_query_arg( $args, admin_url( 'post-new.php' ) );
 		}
@@ -82,7 +82,7 @@ class PLL_Admin_Links extends PLL_Links {
 	 * @return string
 	 */
 	public function edit_post_translation_link( $post_id ) {
-		$link = get_edit_post_link( $post_id );
+		$link     = get_edit_post_link( $post_id );
 		$language = $this->model->post->get_language( $post_id );
 		return $link ? sprintf(
 			'<a href="%1$s" class="pll_icon_edit"><span class="screen-reader-text">%2$s</span></a>',
@@ -109,12 +109,12 @@ class PLL_Admin_Links extends PLL_Links {
 			return '';
 		}
 
-		$args = array(
+		$args = [
 			'taxonomy'  => $taxonomy,
 			'post_type' => $post_type,
 			'from_tag'  => $term_id,
 			'new_lang'  => $language->slug,
-		);
+		];
 
 		$link = add_query_arg( $args, admin_url( 'edit-tags.php' ) );
 
@@ -164,7 +164,7 @@ class PLL_Admin_Links extends PLL_Links {
 	 * @return string
 	 */
 	public function edit_term_translation_link( $term_id, $taxonomy, $post_type ) {
-		$link = get_edit_term_link( $term_id, $taxonomy, $post_type );
+		$link     = get_edit_term_link( $term_id, $taxonomy, $post_type );
 		$language = $this->model->term->get_language( $term_id );
 		return $link ? sprintf(
 			'<a href="%1$s" class="pll_icon_edit"><span class="screen-reader-text">%2$s</span></a>',

--- a/admin/admin-links.php
+++ b/admin/admin-links.php
@@ -23,7 +23,7 @@ class PLL_Admin_Links extends PLL_Links {
 			return '';
 		}
 
-		if ( 'attachment' == $post_type ) {
+		if ( 'attachment' === $post_type ) {
 			$args = [
 				'action'     => 'translate_media',
 				'from_media' => $post_id,

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -106,7 +106,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Oops ! we are deleting the default language...
 		// Need to do this before loosing the information for default category translations
-		if ( $this->options['default_lang'] == $lang->slug ) {
+		if ( $this->options['default_lang'] === $lang->slug ) {
 			$slugs = $this->get_languages_list( [ 'fields' => 'slug' ] );
 			$slugs = array_diff( $slugs, [ $lang->slug ] );
 
@@ -127,7 +127,7 @@ class PLL_Admin_Model extends PLL_Model {
 				$number = $widget['params'][0]['number'];
 				if ( is_object( $obj ) && method_exists( $obj, 'get_settings' ) && method_exists( $obj, 'save_settings' ) ) {
 					$settings = $obj->get_settings();
-					if ( isset( $settings[ $number ]['pll_lang'] ) && $settings[ $number ]['pll_lang'] == $lang->slug ) {
+					if ( isset( $settings[ $number ]['pll_lang'] ) && $settings[ $number ]['pll_lang'] === $lang->slug ) {
 						unset( $settings[ $number ]['pll_lang'] );
 						$obj->save_settings( $settings );
 					}
@@ -200,7 +200,7 @@ class PLL_Admin_Model extends PLL_Model {
 		$slug     = $args['slug'];
 		$old_slug = $lang->slug;
 
-		if ( $old_slug != $slug ) {
+		if ( $old_slug !== $slug ) {
 			// Update the language slug in translations
 			$this->update_translations( $old_slug, $slug );
 
@@ -211,7 +211,7 @@ class PLL_Admin_Model extends PLL_Model {
 					$number = $widget['params'][0]['number'];
 					if ( is_object( $obj ) && method_exists( $obj, 'get_settings' ) && method_exists( $obj, 'save_settings' ) ) {
 						$settings = $obj->get_settings();
-						if ( isset( $settings[ $number ]['pll_lang'] ) && $settings[ $number ]['pll_lang'] == $old_slug ) {
+						if ( isset( $settings[ $number ]['pll_lang'] ) && $settings[ $number ]['pll_lang'] === $old_slug ) {
 							$settings[ $number ]['pll_lang'] = $slug;
 							$obj->save_settings( $settings );
 						}
@@ -238,7 +238,7 @@ class PLL_Admin_Model extends PLL_Model {
 			}
 
 			// Update the default language option if necessary
-			if ( $this->options['default_lang'] == $old_slug ) {
+			if ( $this->options['default_lang'] === $old_slug ) {
 				$this->options['default_lang'] = $slug;
 			}
 		}
@@ -306,7 +306,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Validate slug is unique
 		foreach ( $this->get_languages_list() as $language ) {
-			if ( $language->slug === $args['slug'] && ( null === $lang || ( isset( $lang ) && $lang->term_id != $language->term_id ) ) ) {
+			if ( $language->slug === $args['slug'] && ( null === $lang || ( isset( $lang ) && $lang->term_id !== $language->term_id ) ) ) {
 				add_settings_error( 'general', 'pll_non_unique_slug', __( 'The language code must be unique', 'polylang' ) );
 			}
 		}
@@ -414,7 +414,7 @@ class PLL_Admin_Model extends PLL_Model {
 		// Prepare objects relationships
 		foreach ( $terms as $term ) {
 			$t = unserialize( $term->description );
-			if ( in_array( $t, $translations ) ) {
+			if ( in_array( $t, $translations, true ) ) {
 				foreach ( $t as $object_id ) {
 					if ( ! empty( $object_id ) ) {
 						$trs[] = $wpdb->prepare( '( %d, %d )', $object_id, $term->term_taxonomy_id );
@@ -527,7 +527,7 @@ class PLL_Admin_Model extends PLL_Model {
 				}
 				unset( $tr[ $old_slug ] );
 
-				if ( empty( $tr ) || 1 == count( $tr ) ) {
+				if ( empty( $tr ) || 1 === count( $tr ) ) {
 					$dt['t'][]  = (int) $term->term_id;
 					$dt['tt'][] = (int) $term->term_taxonomy_id;
 				} else {

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -337,6 +337,8 @@ class PLL_Admin_Model extends PLL_Model {
 	public function set_language_in_mass( $type, $ids, $lang ) {
 		global $wpdb;
 
+		set_time_limit( 0 );
+
 		$ids   = array_map( 'intval', $ids );
 		$lang  = $this->get_language( $lang );
 		$tt_id = 'term' === $type ? $lang->tl_term_taxonomy_id : $lang->term_taxonomy_id;
@@ -347,6 +349,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		if ( ! empty( $values ) ) {
 			$values = array_unique( $values );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $values ) );
 			$lang->update_count(); // Updating term count is mandatory ( thanks to AndyDeGroo )
 		}
@@ -377,6 +380,8 @@ class PLL_Admin_Model extends PLL_Model {
 	public function set_translation_in_mass( $type, $translations ) {
 		global $wpdb;
 
+		set_time_limit( 0 );
+
 		$taxonomy = $type . '_translations';
 
 		foreach ( $translations as $t ) {
@@ -390,10 +395,12 @@ class PLL_Admin_Model extends PLL_Model {
 		// Insert terms
 		if ( ! empty( $terms ) ) {
 			$terms = array_unique( $terms );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->terms ( slug, name ) VALUES " . implode( ',', $terms ) );
 		}
 
 		// Get all terms with their term_id
+		// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 		$terms = $wpdb->get_results( "SELECT term_id, slug FROM $wpdb->terms WHERE slug IN ( " . implode( ',', $slugs ) . ' )' );
 
 		// Prepare terms taxonomy relationship
@@ -405,6 +412,7 @@ class PLL_Admin_Model extends PLL_Model {
 		// Insert term_taxonomy
 		if ( ! empty( $tts ) ) {
 			$tts = array_unique( $tts );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->term_taxonomy ( term_id, taxonomy, description, count ) VALUES " . implode( ',', $tts ) );
 		}
 
@@ -425,6 +433,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Insert term_relationships
 		if ( ! empty( $trs ) ) {
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $trs ) );
 			$trs = array_unique( $trs );
 		}
@@ -441,8 +450,12 @@ class PLL_Admin_Model extends PLL_Model {
 	 * @param in $limit Max number of posts or terms to return. Defaults to -1 (no limit).
 	 * @return array Array made of an array of post ids and an array of term ids
 	 */
-	public function get_objects_with_no_lang( $limit = -1 ) {
+	public function get_objects_with_no_lang( $limit = 300 ) {
 		global $wpdb;
+
+		if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+			$limit = -1;
+		}
 
 		/**
 		 * Filters the max number of posts or terms to return when searching objects with no language
@@ -472,6 +485,7 @@ class PLL_Admin_Model extends PLL_Model {
 			]
 		);
 
+		// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 		$terms = $wpdb->get_col(
 			sprintf(
 				"
@@ -486,6 +500,7 @@ class PLL_Admin_Model extends PLL_Model {
 				$limit > 0 ? "LIMIT {$limit}" : ''
 			)
 		);
+		// phpcs:enable
 
 		/**
 		 * Filter the list of untranslated posts ids and terms ids
@@ -527,7 +542,7 @@ class PLL_Admin_Model extends PLL_Model {
 				}
 				unset( $tr[ $old_slug ] );
 
-				if ( empty( $tr ) || 1 == count( $tr ) ) {
+				if ( empty( $tr ) || 1 === count( $tr ) ) {
 					$dt['t'][]  = (int) $term->term_id;
 					$dt['tt'][] = (int) $term->term_taxonomy_id;
 				} else {
@@ -539,6 +554,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Delete relationships
 		if ( ! empty( $dr ) ) {
+			// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query(
 				"
 				DELETE FROM $wpdb->term_relationships
@@ -546,16 +562,20 @@ class PLL_Admin_Model extends PLL_Model {
 				AND term_taxonomy_id IN ( ' . implode( ',', $dr['tt'] ) . ' )
 			'
 			);
+			// phpcs:enable
 		}
 
 		// Delete terms
 		if ( ! empty( $dt ) ) {
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->terms WHERE term_id IN ( " . implode( ',', $dt['t'] ) . ' )' );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->term_taxonomy WHERE term_taxonomy_id IN ( " . implode( ',', $dt['tt'] ) . ' )' );
 		}
 
 		// Update terms
 		if ( ! empty( $ut ) ) {
+			// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query(
 				"
 				UPDATE $wpdb->term_taxonomy
@@ -563,6 +583,7 @@ class PLL_Admin_Model extends PLL_Model {
 				WHERE term_id IN ( ' . implode( ',', $ut['in'] ) . ' )
 			'
 			);
+			// phpcs:enable
 		}
 
 		if ( ! empty( $term_ids ) ) {

--- a/admin/admin-nav-menu.php
+++ b/admin/admin-nav-menu.php
@@ -93,7 +93,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 	 */
 	public function admin_enqueue_scripts() {
 		$screen = get_current_screen();
-		if ( 'nav-menus' != $screen->base ) {
+		if ( 'nav-menus' !== $screen->base ) {
 			return;
 		}
 
@@ -133,7 +133,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 	 * @param int $menu_item_db_id
 	 */
 	public function wp_update_nav_menu_item( $menu_id = 0, $menu_item_db_id = 0 ) {
-		if ( empty( $_POST['menu-item-url'][ $menu_item_db_id ] ) || '#pll_switcher' != $_POST['menu-item-url'][ $menu_item_db_id ] ) {
+		if ( empty( $_POST['menu-item-url'][ $menu_item_db_id ] ) || '#pll_switcher' !== $_POST['menu-item-url'][ $menu_item_db_id ] ) {
 			return;
 		}
 
@@ -173,7 +173,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 	 */
 	public function translate_switcher_title( $items ) {
 		foreach ( $items as $item ) {
-			if ( '#pll_switcher' == $item->url ) {
+			if ( '#pll_switcher' === $item->url ) {
 				$item->post_title = __( 'Language switcher', 'polylang' );
 			}
 		}
@@ -195,7 +195,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		foreach ( $locations as $loc => $menu ) {
 			$infos = $this->explode_location( $loc );
 			$this->options['nav_menus'][ $this->theme ][ $infos['location'] ][ $infos['lang'] ] = $menu;
-			if ( $this->options['default_lang'] != $infos['lang'] ) {
+			if ( $this->options['default_lang'] !== $infos['lang'] ) {
 				unset( $locations[ $loc ] ); // Remove temporary locations before database update
 			}
 		}
@@ -216,18 +216,18 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		if ( current_user_can( 'edit_theme_options' ) && isset( $mods['nav_menu_locations'] ) ) {
 
 			// Manage Locations tab in Appearance -> Menus
-			if ( isset( $_GET['action'] ) && 'locations' == $_GET['action'] ) {
+			if ( isset( $_GET['action'] ) && 'locations' === $_GET['action'] ) {
 				check_admin_referer( 'save-menu-locations' );
 				$this->options['nav_menus'][ $this->theme ] = [];
 			} // Edit Menus tab in Appearance -> Menus
 			// Add the test of $_POST['update-nav-menu-nonce'] to avoid conflict with Vantage theme
-			elseif ( isset( $_POST['action'], $_POST['update-nav-menu-nonce'] ) && 'update' == $_POST['action'] ) {
+			elseif ( isset( $_POST['action'], $_POST['update-nav-menu-nonce'] ) && 'update' === $_POST['action'] ) {
 				check_admin_referer( 'update-nav_menu', 'update-nav-menu-nonce' );
 				$this->options['nav_menus'][ $this->theme ] = [];
 			} // Customizer
 			// Don't reset locations in this case.
 			// see http://wordpress.org/support/topic/menus-doesnt-show-and-not-saved-in-theme-settings-multilingual-site
-			elseif ( isset( $_POST['action'] ) && 'customize_save' == $_POST['action'] ) {
+			elseif ( isset( $_POST['action'] ) && 'customize_save' === $_POST['action'] ) {
 				check_ajax_referer( 'save-customize_' . $GLOBALS['wp_customize']->get_stylesheet(), 'nonce' );
 			} else {
 				return $mods; // No modification for nav menu locations
@@ -313,7 +313,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 	 * @param object $post Post data.
 	 */
 	public function auto_add_pages_to_menu( $new_status, $old_status, $post ) {
-		if ( 'publish' != $new_status || 'publish' == $old_status || 'page' != $post->post_type || ! empty( $post->post_parent ) ) {
+		if ( 'publish' !== $new_status || 'publish' === $old_status || 'page' !== $post->post_type || ! empty( $post->post_parent ) ) {
 			return;
 		}
 

--- a/admin/admin-nav-menu.php
+++ b/admin/admin-nav-menu.php
@@ -21,10 +21,10 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 
 		// Populates nav menus locations
 		// Since WP 4.4, must be done before customize_register is fired
-		add_filter( 'theme_mod_nav_menu_locations', array( $this, 'theme_mod_nav_menu_locations' ), 20 );
+		add_filter( 'theme_mod_nav_menu_locations', [ $this, 'theme_mod_nav_menu_locations' ], 20 );
 
 		// Integration in the WP menu interface
-		add_action( 'admin_init', array( $this, 'admin_init' ) ); // after Polylang upgrade
+		add_action( 'admin_init', [ $this, 'admin_init' ] ); // after Polylang upgrade
 	}
 
 	/**
@@ -34,20 +34,20 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 	 * @since 1.1
 	 */
 	public function admin_init() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-		add_action( 'wp_update_nav_menu_item', array( $this, 'wp_update_nav_menu_item' ), 10, 2 );
-		add_filter( 'wp_get_nav_menu_items', array( $this, 'translate_switcher_title' ) );
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
+		add_action( 'wp_update_nav_menu_item', [ $this, 'wp_update_nav_menu_item' ], 10, 2 );
+		add_filter( 'wp_get_nav_menu_items', [ $this, 'translate_switcher_title' ] );
 
 		// Translation of menus based on chosen locations
-		add_filter( 'pre_update_option_theme_mods_' . $this->theme, array( $this, 'pre_update_option_theme_mods' ) );
-		add_action( 'delete_nav_menu', array( $this, 'delete_nav_menu' ) );
+		add_filter( 'pre_update_option_theme_mods_' . $this->theme, [ $this, 'pre_update_option_theme_mods' ] );
+		add_action( 'delete_nav_menu', [ $this, 'delete_nav_menu' ] );
 
 		// Filter _wp_auto_add_pages_to_menu by language
-		add_action( 'transition_post_status', array( $this, 'auto_add_pages_to_menu' ), 5, 3 ); // before _wp_auto_add_pages_to_menu
+		add_action( 'transition_post_status', [ $this, 'auto_add_pages_to_menu' ], 5, 3 ); // before _wp_auto_add_pages_to_menu
 
 		// FIXME is it possible to choose the order ( after theme locations in WP3.5 and older ) ?
 		// FIXME not displayed if Polylang is activated before the first time the user goes to nav menus http://core.trac.wordpress.org/ticket/16828
-		add_meta_box( 'pll_lang_switch_box', __( 'Language switcher', 'polylang' ), array( $this, 'lang_switch' ), 'nav-menus', 'side', 'high' );
+		add_meta_box( 'pll_lang_switch_box', __( 'Language switcher', 'polylang' ), [ $this, 'lang_switch' ], 'nav-menus', 'side', 'high' );
 
 		$this->create_nav_menu_locations();
 	}
@@ -98,22 +98,24 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		}
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-		wp_enqueue_script( 'pll_nav_menu', plugins_url( '/js/nav-menu' . $suffix . '.js', POLYLANG_FILE ), array( 'jquery' ), POLYLANG_VERSION );
+		wp_enqueue_script( 'pll_nav_menu', plugins_url( '/js/nav-menu' . $suffix . '.js', POLYLANG_FILE ), [ 'jquery' ], POLYLANG_VERSION );
 
 		$data['strings'] = PLL_Switcher::get_switcher_options( 'menu', 'string' ); // The strings for the options
-		$data['title'] = __( 'Language switcher', 'polylang' ); // The title
+		$data['title']   = __( 'Language switcher', 'polylang' ); // The title
 
 		// Get all language switcher menu items
-		$items = get_posts( array(
-			'numberposts' => -1,
-			'nopaging'    => true,
-			'post_type'   => 'nav_menu_item',
-			'fields'      => 'ids',
-			'meta_key'    => '_pll_menu_item',
-		) );
+		$items = get_posts(
+			[
+				'numberposts' => -1,
+				'nopaging'    => true,
+				'post_type'   => 'nav_menu_item',
+				'fields'      => 'ids',
+				'meta_key'    => '_pll_menu_item',
+			]
+		);
 
 		// The options values for the language switcher
-		$data['val'] = array();
+		$data['val'] = [];
 		foreach ( $items as $item ) {
 			$data['val'][ $item ] = get_post_meta( $item, '_pll_menu_item', true );
 		}
@@ -139,14 +141,20 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		if ( current_user_can( 'edit_theme_options' ) ) {
 			check_admin_referer( 'update-nav_menu', 'update-nav-menu-nonce' );
 
-			$options = array( 'hide_if_no_translation' => 0, 'hide_current' => 0, 'force_home' => 0, 'show_flags' => 0, 'show_names' => 1, 'dropdown' => 0 ); // Default values
+			$options = [
+				'hide_if_no_translation' => 0,
+				'hide_current' => 0,
+				'force_home' => 0,
+				'show_flags' => 0,
+				'show_names' => 1,
+				'dropdown' => 0,
+			]; // Default values
 			// Our jQuery form has not been displayed
 			if ( empty( $_POST['menu-item-pll-detect'][ $menu_item_db_id ] ) ) {
 				if ( ! get_post_meta( $menu_item_db_id, '_pll_menu_item', true ) ) { // Our options were never saved
 					update_post_meta( $menu_item_db_id, '_pll_menu_item', $options );
 				}
-			}
-			else {
+			} else {
 				foreach ( $options as $opt => $v ) {
 					$options[ $opt ] = empty( $_POST[ 'menu-item-' . $opt ][ $menu_item_db_id ] ) ? 0 : 1;
 				}
@@ -210,24 +218,18 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 			// Manage Locations tab in Appearance -> Menus
 			if ( isset( $_GET['action'] ) && 'locations' == $_GET['action'] ) {
 				check_admin_referer( 'save-menu-locations' );
-				$this->options['nav_menus'][ $this->theme ] = array();
-			}
-
-			// Edit Menus tab in Appearance -> Menus
+				$this->options['nav_menus'][ $this->theme ] = [];
+			} // Edit Menus tab in Appearance -> Menus
 			// Add the test of $_POST['update-nav-menu-nonce'] to avoid conflict with Vantage theme
 			elseif ( isset( $_POST['action'], $_POST['update-nav-menu-nonce'] ) && 'update' == $_POST['action'] ) {
 				check_admin_referer( 'update-nav_menu', 'update-nav-menu-nonce' );
-				$this->options['nav_menus'][ $this->theme ] = array();
-			}
-
-			// Customizer
+				$this->options['nav_menus'][ $this->theme ] = [];
+			} // Customizer
 			// Don't reset locations in this case.
 			// see http://wordpress.org/support/topic/menus-doesnt-show-and-not-saved-in-theme-settings-multilingual-site
 			elseif ( isset( $_POST['action'] ) && 'customize_save' == $_POST['action'] ) {
 				check_ajax_referer( 'save-customize_' . $GLOBALS['wp_customize']->get_stylesheet(), 'nonce' );
-			}
-
-			else {
+			} else {
 				return $mods; // No modification for nav menu locations
 			}
 
@@ -249,7 +251,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		$locations = get_registered_nav_menus();
 		if ( is_array( $locations ) ) {
 			$locations = array_fill_keys( array_keys( $locations ), 0 );
-			$menus = is_array( $menus ) ? array_merge( $locations, $menus ) : $locations;
+			$menus     = is_array( $menus ) ? array_merge( $locations, $menus ) : $locations;
 		}
 
 		if ( is_array( $menus ) ) {
@@ -316,7 +318,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		}
 
 		if ( ! empty( $this->options['nav_menus'][ $this->theme ] ) ) {
-			$this->auto_add_menus = array();
+			$this->auto_add_menus = [];
 
 			$lang = $this->model->post->get_language( $post->ID );
 			$lang = empty( $lang ) ? $this->options['default_lang'] : $lang->slug; // If the page has no language yet, the default language will be assigned
@@ -328,7 +330,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 				}
 			}
 
-			add_filter( 'option_nav_menu_options', array( $this, 'nav_menu_options' ) );
+			add_filter( 'option_nav_menu_options', [ $this, 'nav_menu_options' ] );
 		}
 	}
 }

--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -18,20 +18,20 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 		parent::__construct( $polylang );
 
 		// Removes the editor and the template select dropdown for pages for posts
-		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 10, 2 );
+		add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ], 10, 2 );
 
 		// Add post state for translations of the front page and posts page
-		add_filter( 'display_post_states', array( $this, 'display_post_states' ), 10, 2 );
+		add_filter( 'display_post_states', [ $this, 'display_post_states' ], 10, 2 );
 
 		// Refresh language cache when a static front page has been translated
-		add_action( 'pll_save_post', array( $this, 'pll_save_post' ), 10, 3 );
+		add_action( 'pll_save_post', [ $this, 'pll_save_post' ], 10, 3 );
 
 		// Checks if chosen page on front is translated
-		add_filter( 'pre_update_option_page_on_front', array( $this, 'update_page_on_front' ), 10, 2 );
-		add_filter( 'customize_validate_page_on_front', array( $this, 'customize_validate_page_on_front' ), 10, 2 );
+		add_filter( 'pre_update_option_page_on_front', [ $this, 'update_page_on_front' ], 10, 2 );
+		add_filter( 'customize_validate_page_on_front', [ $this, 'customize_validate_page_on_front' ], 10, 2 );
 
 		// Prevents WP resetting the option
-		add_filter( 'pre_update_option_show_on_front', array( $this, 'update_show_on_front' ), 10, 2 );
+		add_filter( 'pre_update_option_show_on_front', [ $this, 'update_show_on_front' ], 10, 2 );
 	}
 
 	/**
@@ -45,7 +45,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 */
 	function add_meta_boxes( $post_type, $post ) {
 		if ( 'page' === $post_type ) {
-			add_filter( 'option_page_for_posts', array( $this, 'translate_page_for_posts' ) );
+			add_filter( 'option_page_for_posts', [ $this, 'translate_page_for_posts' ] );
 
 			if ( ( get_option( 'page_for_posts' ) == $post->ID ) && empty( $post->post_content ) ) {
 				add_action( 'edit_form_after_title', '_wp_posts_page_notice' );
@@ -64,11 +64,11 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 * @return array
 	 */
 	public function display_post_states( $post_states, $post ) {
-		if ( in_array( $post->ID, $this->model->get_languages_list( array( 'fields' => 'page_on_front' ) ) ) ) {
+		if ( in_array( $post->ID, $this->model->get_languages_list( [ 'fields' => 'page_on_front' ] ) ) ) {
 			$post_states['page_on_front'] = __( 'Front Page' );
 		}
 
-		if ( in_array( $post->ID, $this->model->get_languages_list( array( 'fields' => 'page_for_posts' ) ) ) ) {
+		if ( in_array( $post->ID, $this->model->get_languages_list( [ 'fields' => 'page_for_posts' ] ) ) ) {
 			$post_states['page_for_posts'] = __( 'Posts Page' );
 		}
 
@@ -101,7 +101,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	protected function is_page_translated( $page_id ) {
 		if ( $page_id ) {
 			$translations = count( $this->model->post->get_translations( $page_id ) );
-			$languages = count( $this->model->get_languages_list() );
+			$languages    = count( $this->model->get_languages_list() );
 
 			if ( $languages > 1 && $translations != $languages ) {
 				return false;
@@ -157,7 +157,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 * @return string
 	 */
 	public function update_show_on_front( $value, $old_value ) {
-		if ( ! empty( $GLOBALS['pagenow'] ) && 'options-reading.php' === $GLOBALS['pagenow'] && 'posts' === $value && ! get_pages() && get_pages( array( 'lang' => '' ) ) ) {
+		if ( ! empty( $GLOBALS['pagenow'] ) && 'options-reading.php' === $GLOBALS['pagenow'] && 'posts' === $value && ! get_pages() && get_pages( [ 'lang' => '' ] ) ) {
 			$value = $old_value;
 		}
 		return $value;

--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -47,7 +47,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 		if ( 'page' === $post_type ) {
 			add_filter( 'option_page_for_posts', [ $this, 'translate_page_for_posts' ] );
 
-			if ( ( get_option( 'page_for_posts' ) == $post->ID ) && empty( $post->post_content ) ) {
+			if ( ( get_option( 'page_for_posts' ) === $post->ID ) && empty( $post->post_content ) ) {
 				add_action( 'edit_form_after_title', '_wp_posts_page_notice' );
 				remove_post_type_support( $post_type, 'editor' );
 			}
@@ -64,11 +64,11 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 * @return array
 	 */
 	public function display_post_states( $post_states, $post ) {
-		if ( in_array( $post->ID, $this->model->get_languages_list( [ 'fields' => 'page_on_front' ] ) ) ) {
+		if ( in_array( $post->ID, $this->model->get_languages_list( [ 'fields' => 'page_on_front' ] ), true ) ) {
 			$post_states['page_on_front'] = __( 'Front Page' );
 		}
 
-		if ( in_array( $post->ID, $this->model->get_languages_list( [ 'fields' => 'page_for_posts' ] ) ) ) {
+		if ( in_array( $post->ID, $this->model->get_languages_list( [ 'fields' => 'page_for_posts' ] ), true ) ) {
 			$post_states['page_for_posts'] = __( 'Posts Page' );
 		}
 
@@ -85,7 +85,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 * @param array  $translations
 	 */
 	public function pll_save_post( $post_id, $post, $translations ) {
-		if ( in_array( $this->page_on_front, $translations ) ) {
+		if ( in_array( $this->page_on_front, $translations, true ) ) {
 			$this->model->clean_languages_cache();
 		}
 	}
@@ -103,7 +103,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 			$translations = count( $this->model->post->get_translations( $page_id ) );
 			$languages    = count( $this->model->get_languages_list() );
 
-			if ( $languages > 1 && $translations != $languages ) {
+			if ( $languages > 1 && $translations !== $languages ) {
 				return false;
 			}
 		}

--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -69,7 +69,7 @@ class PLL_Admin_Strings {
 		global $wp_registered_widgets;
 		$sidebars = wp_get_sidebars_widgets();
 		foreach ( $sidebars as $sidebar => $widgets ) {
-			if ( 'wp_inactive_widgets' == $sidebar || empty( $widgets ) ) {
+			if ( 'wp_inactive_widgets' === $sidebar || empty( $widgets ) ) {
 				continue;
 			}
 
@@ -124,11 +124,11 @@ class PLL_Admin_Strings {
 			$translation = sanitize_option( $option, $translation );
 		}
 
-		if ( $name == self::$default_strings['widget_title'] ) {
+		if ( $name === self::$default_strings['widget_title'] ) {
 			$translation = strip_tags( $translation );
 		}
 
-		if ( $name == self::$default_strings['widget_text'] && ! current_user_can( 'unfiltered_html' ) ) {
+		if ( $name === self::$default_strings['widget_text'] && ! current_user_can( 'unfiltered_html' ) ) {
 			$translation = wp_unslash( wp_filter_post_kses( addslashes( $translation ) ) ); // wp_filter_post_kses() expects slashed
 		}
 

--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -6,7 +6,7 @@
  * @since 1.6
  */
 class PLL_Admin_Strings {
-	static protected $strings = array(); // strings to translate
+	static protected $strings = []; // strings to translate
 	static protected $default_strings; // default strings to register
 
 	/**
@@ -16,7 +16,7 @@ class PLL_Admin_Strings {
 	 */
 	static public function init() {
 		// default strings translations sanitization
-		add_filter( 'pll_sanitize_string_translation', array( __CLASS__, 'sanitize_string_translation' ), 10, 2 );
+		add_filter( 'pll_sanitize_string_translation', [ __CLASS__, 'sanitize_string_translation' ], 10, 2 );
 	}
 
 	/**
@@ -33,7 +33,7 @@ class PLL_Admin_Strings {
 		// backward compatibility with Polylang older than 1.1
 		if ( is_bool( $context ) ) {
 			$multiline = $context;
-			$context = 'Polylang';
+			$context   = 'Polylang';
 		}
 
 		if ( $string && is_scalar( $string ) ) {
@@ -49,16 +49,16 @@ class PLL_Admin_Strings {
 	 * @return array list of all registered strings
 	 */
 	static public function &get_strings() {
-		self::$default_strings = array(
-			'options' => array(
+		self::$default_strings = [
+			'options' => [
 				'blogname'        => __( 'Site Title' ),
 				'blogdescription' => __( 'Tagline' ),
 				'date_format'     => __( 'Date Format' ),
 				'time_format'     => __( 'Time Format' ),
-			),
+			],
 			'widget_title' => __( 'Widget title', 'polylang' ),
 			'widget_text'  => __( 'Widget text', 'polylang' ),
-		);
+		];
 
 		// WP strings
 		foreach ( self::$default_strings['options'] as $option => $string ) {
@@ -81,7 +81,7 @@ class PLL_Admin_Strings {
 				}
 
 				$widget_settings = $wp_registered_widgets[ $widget ]['callback'][0]->get_settings();
-				$number = $wp_registered_widgets[ $widget ]['params'][0]['number'];
+				$number          = $wp_registered_widgets[ $widget ]['params'][0]['number'];
 
 				// don't enable widget translation if the widget is visible in only one language or if there is no title
 				if ( empty( $widget_settings[ $number ]['pll_lang'] ) ) {

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -38,8 +38,8 @@ class PLL_Admin extends PLL_Admin_Base {
 		parent::__construct( $links_model );
 
 		// adds a 'settings' link in the plugins table
-		add_filter( 'plugin_action_links_' . POLYLANG_BASENAME, array( $this, 'plugin_action_links' ) );
-		add_action( 'in_plugin_update_message-' . POLYLANG_BASENAME, array( $this, 'plugin_update_message' ), 10, 2 );
+		add_filter( 'plugin_action_links_' . POLYLANG_BASENAME, [ $this, 'plugin_action_links' ] );
+		add_action( 'in_plugin_update_message-' . POLYLANG_BASENAME, [ $this, 'plugin_update_message' ], 10, 2 );
 	}
 
 	/**
@@ -54,7 +54,7 @@ class PLL_Admin extends PLL_Admin_Base {
 		// setup filters for admin pages
 		// priority 5 to make sure filters are there before customize_register is fired
 		if ( $this->model->get_languages_list() ) {
-			add_action( 'wp_loaded', array( $this, 'add_filters' ), 5 );
+			add_action( 'wp_loaded', [ $this, 'add_filters' ], 5 );
 		}
 	}
 
@@ -92,7 +92,7 @@ class PLL_Admin extends PLL_Admin_Base {
 	 */
 	public function add_filters() {
 		// all these are separated just for convenience and maintainability
-		$classes = array( 'Filters', 'Filters_Columns', 'Filters_Post', 'Filters_Term', 'Nav_Menu', 'Sync' );
+		$classes = [ 'Filters', 'Filters_Columns', 'Filters_Post', 'Filters_Term', 'Nav_Menu', 'Sync' ];
 
 		// don't load media filters if option is disabled or if user has no right
 		if ( $this->options['media_support'] && ( $obj = get_post_type_object( 'attachment' ) ) && ( current_user_can( $obj->cap->edit_posts ) || current_user_can( $obj->cap->create_posts ) ) ) {
@@ -109,7 +109,7 @@ class PLL_Admin extends PLL_Admin_Base {
 			 *
 			 * @param string $class class name
 			 */
-			$class = apply_filters( 'pll_' . $obj, 'PLL_Admin_' . $class );
+			$class      = apply_filters( 'pll_' . $obj, 'PLL_Admin_' . $class );
 			$this->$obj = new $class( $this );
 		}
 	}

--- a/admin/view-translations-media.php
+++ b/admin/view-translations-media.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <table>
 	<?php
 	foreach ( $this->model->get_languages_list() as $language ) {
-		if ( $language->term_id == $lang->term_id ) {
+		if ( $language->term_id === $lang->term_id ) {
 			continue;
 		}
 		?>

--- a/admin/view-translations-media.php
+++ b/admin/view-translations-media.php
@@ -29,9 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						esc_attr( $translation_id ),
 						$this->links->edit_post_translation_link( $translation_id )
 					);
-				}
-
-				// No translation
+				} // No translation
 				else {
 					echo $this->links->new_post_translation_link( $post_id, $language );
 				}

--- a/admin/view-translations-post.php
+++ b/admin/view-translations-post.php
@@ -12,12 +12,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 <table>
 	<?php
 	foreach ( $this->model->get_languages_list() as $language ) {
-		if ( $language->term_id == $lang->term_id ) {
+		if ( $language->term_id === $lang->term_id ) {
 			continue;
 		}
 
 		$value = $this->model->post->get_translation( $post_ID, $language );
-		if ( ! $value || $value == $post_ID ) { // $value == $post_ID happens if the post has been ( auto )saved before changing the language
+		if ( ! $value || (int) $value === (int) $post_ID ) { // $value === $post_ID happens if the post has been ( auto )saved before changing the language
 			$value = '';
 		}
 

--- a/admin/view-translations-post.php
+++ b/admin/view-translations-post.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		if ( $value ) {
 			$selected = get_post( $value );
-			$link = $this->links->edit_post_translation_link( $value );
+			$link     = $this->links->edit_post_translation_link( $value );
 		}
 		?>
 		<tr>
@@ -48,7 +48,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			?>
 			<td class = "pll-translation-column">
 				<?php
-				printf( '
+				printf(
+					'
 					<label class="screen-reader-text" for="tr_lang_%1$s">%2$s</label>
 					<input type="hidden" name="post_tr_lang[%1$s]" id="htr_lang_%1$s" value="%3$s" />
 					<span lang="%6$s" dir="%7$s"><input type="text" class="tr_lang" id="tr_lang_%1$s" value="%4$s"%5$s /></span>',

--- a/admin/view-translations-term.php
+++ b/admin/view-translations-term.php
@@ -23,14 +23,14 @@ if ( isset( $term_id ) ) {
 <table class="widefat term-translations"  id="<?php echo isset( $term_id ) ? 'edit' : 'add'; ?>-term-translations">
 	<?php
 	foreach ( $this->model->get_languages_list() as $language ) {
-		if ( $language->term_id == $lang->term_id ) {
+		if ( $language->term_id === $lang->term_id ) {
 			continue;
 		}
 
 		// Look for any existing translation in this language
 		// Take care not to propose a self link
 		$translation = 0;
-		if ( isset( $term_id ) && ( $translation_id = $this->model->term->get_translation( $term_id, $language ) ) && $translation_id != $term_id ) {
+		if ( isset( $term_id ) && ( $translation_id = $this->model->term->get_translation( $term_id, $language ) ) && $translation_id !== $term_id ) {
 			$translation = get_term( $translation_id, $taxonomy );
 		}
 		if ( isset( $_GET['from_tag'] ) && ( $translation_id = $this->model->term->get( (int) $_GET['from_tag'], $language ) ) && ! $this->model->term->get_translation( $translation_id, $lang ) ) {

--- a/admin/view-translations-term.php
+++ b/admin/view-translations-term.php
@@ -13,8 +13,7 @@ if ( isset( $term_id ) ) {
 	<th scope="row"><?php esc_html_e( 'Translations', 'polylang' ); ?></th>
 	<td>
 	<?php
-}
-else {
+} else {
 	// Add term form
 	?>
 	<p><?php esc_html_e( 'Translations', 'polylang' ); ?></p>
@@ -67,7 +66,8 @@ else {
 			?>
 			<td class = "pll-translation-column">
 				<?php
-				printf( '
+				printf(
+					'
 					<label class="screen-reader-text" for="tr_lang_%1$s">%2$s</label>
 					<input type="hidden" class="htr_lang" name="term_tr_lang[%1$s]" id="htr_lang_%1$s" value="%3$s" />
 					<span lang="%6$s" dir="%7$s"><input type="text" class="tr_lang" id="tr_lang_%1$s" value="%4$s"%5$s /></span>',

--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -97,7 +97,7 @@ class PLL_Choose_Lang_Content extends PLL_Choose_lang {
 
 		parent::parse_main_query( $query );
 
-		$is_archive = ( count( $query->query ) == 1 && ! empty( $qv['paged'] ) ) ||
+		$is_archive = ( count( $query->query ) === 1 && ! empty( $qv['paged'] ) ) ||
 			$query->is_date ||
 			$query->is_author ||
 			( ! empty( $qv['post_type'] ) && $query->is_post_type_archive && $this->model->is_translated_post_type( $qv['post_type'] ) );
@@ -105,7 +105,7 @@ class PLL_Choose_Lang_Content extends PLL_Choose_lang {
 		// sets the language in case we hide the default language
 		// use $query->query['s'] as is_search is not set when search is empty
 		// http://wordpress.org/support/topic/search-for-empty-string-in-default-language
-		if ( $this->options['hide_default'] && ! isset( $qv['lang'] ) && ( $is_archive || isset( $query->query['s'] ) || ( count( $query->query ) == 1 && ! empty( $qv['feed'] ) ) ) ) {
+		if ( $this->options['hide_default'] && ! isset( $qv['lang'] ) && ( $is_archive || isset( $query->query['s'] ) || ( count( $query->query ) === 1 && ! empty( $qv['feed'] ) ) ) ) {
 			$this->set_language( $this->model->get_language( $this->options['default_lang'] ) );
 			$this->set_curlang_in_query( $query );
 		}

--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -18,10 +18,10 @@ class PLL_Choose_Lang_Content extends PLL_Choose_lang {
 
 		if ( ! did_action( 'pll_language_defined' ) ) {
 			// set the languages from content
-			add_action( 'wp', array( $this, 'wp' ), 5 ); // priority 5 for post types and taxonomies registered in wp hook with default priority
+			add_action( 'wp', [ $this, 'wp' ], 5 ); // priority 5 for post types and taxonomies registered in wp hook with default priority
 
 			// if no language found, choose the preferred one
-			add_filter( 'pll_get_current_language', array( $this, 'pll_get_current_language' ) );
+			add_filter( 'pll_get_current_language', [ $this, 'pll_get_current_language' ] );
 		}
 	}
 
@@ -34,7 +34,7 @@ class PLL_Choose_Lang_Content extends PLL_Choose_lang {
 	 */
 	protected function set_language( $curlang ) {
 		parent::set_language( $curlang );
-		remove_action( 'wp', array( $this, 'wp' ), 5 ); // won't attempt to set the language a 2nd time
+		remove_action( 'wp', [ $this, 'wp' ], 5 ); // won't attempt to set the language a 2nd time
 	}
 
 	/**
@@ -53,13 +53,9 @@ class PLL_Choose_Lang_Content extends PLL_Choose_lang {
 		if ( $var = get_query_var( 'lang' ) ) {
 			$lang = explode( ',', $var );
 			$lang = $this->model->get_language( reset( $lang ) ); // choose the first queried language
-		}
-
-		elseif ( ( is_single() || is_page() || ( is_attachment() && $this->options['media_support'] ) ) && ( ( $var = get_queried_object_id() ) || ( $var = get_query_var( 'p' ) ) || ( $var = get_query_var( 'page_id' ) ) || ( $var = get_query_var( 'attachment_id' ) ) ) ) {
+		} elseif ( ( is_single() || is_page() || ( is_attachment() && $this->options['media_support'] ) ) && ( ( $var = get_queried_object_id() ) || ( $var = get_query_var( 'p' ) ) || ( $var = get_query_var( 'page_id' ) ) || ( $var = get_query_var( 'attachment_id' ) ) ) ) {
 			$lang = $this->model->post->get_language( $var );
-		}
-
-		else {
+		} else {
 			foreach ( $this->model->get_translated_taxonomies() as $taxonomy ) {
 				if ( $var = get_query_var( get_taxonomy( $taxonomy )->query_var ) ) {
 					$lang = $this->model->term->get_language( $var, $taxonomy );

--- a/frontend/choose-lang-url.php
+++ b/frontend/choose-lang-url.php
@@ -38,7 +38,7 @@ class PLL_Choose_Lang_Url extends PLL_Choose_lang {
 		$requested_uri  = rtrim( str_replace( $this->index, '', $_SERVER['REQUEST_URI'] ), '/' ); // some PHP setups turn requests for / into /index.php in REQUEST_URI
 
 		// home is requested
-		if ( $requested_host == $host && $requested_uri == $home_path && empty( $_SERVER['QUERY_STRING'] ) ) {
+		if ( $requested_host === $host && $requested_uri === $home_path && empty( $_SERVER['QUERY_STRING'] ) ) {
 			$this->home_language();
 			add_action( 'setup_theme', [ $this, 'home_requested' ] );
 		} // take care to post & page preview http://wordpress.org/support/topic/static-frontpage-url-parameter-url-language-information

--- a/frontend/choose-lang-url.php
+++ b/frontend/choose-lang-url.php
@@ -22,7 +22,7 @@ class PLL_Choose_Lang_Url extends PLL_Choose_lang {
 			$this->set_language_from_url();
 		}
 
-		add_action( 'request', array( $this, 'request' ) );
+		add_action( 'request', [ $this, 'request' ] );
 	}
 
 	/**
@@ -31,33 +31,25 @@ class PLL_Choose_Lang_Url extends PLL_Choose_lang {
 	 * @since 1.2
 	 */
 	public function set_language_from_url() {
-		$host = str_replace( 'www.', '', parse_url( $this->links_model->home, PHP_URL_HOST ) );
+		$host      = str_replace( 'www.', '', parse_url( $this->links_model->home, PHP_URL_HOST ) );
 		$home_path = parse_url( $this->links_model->home, PHP_URL_PATH );
 
 		$requested_host = str_replace( 'www.', '', $_SERVER['HTTP_HOST'] );
-		$requested_uri = rtrim( str_replace( $this->index, '', $_SERVER['REQUEST_URI'] ), '/' ); // some PHP setups turn requests for / into /index.php in REQUEST_URI
+		$requested_uri  = rtrim( str_replace( $this->index, '', $_SERVER['REQUEST_URI'] ), '/' ); // some PHP setups turn requests for / into /index.php in REQUEST_URI
 
 		// home is requested
 		if ( $requested_host == $host && $requested_uri == $home_path && empty( $_SERVER['QUERY_STRING'] ) ) {
 			$this->home_language();
-			add_action( 'setup_theme', array( $this, 'home_requested' ) );
-		}
-
-		// take care to post & page preview http://wordpress.org/support/topic/static-frontpage-url-parameter-url-language-information
+			add_action( 'setup_theme', [ $this, 'home_requested' ] );
+		} // take care to post & page preview http://wordpress.org/support/topic/static-frontpage-url-parameter-url-language-information
 		elseif ( isset( $_GET['preview'] ) && ( ( isset( $_GET['p'] ) && $id = (int) $_GET['p'] ) || ( isset( $_GET['page_id'] ) && $id = (int) $_GET['page_id'] ) ) ) {
 			$curlang = ( $lg = $this->model->post->get_language( $id ) ) ? $lg : $this->model->get_language( $this->options['default_lang'] );
-		}
-
-		// take care to ( unattached ) attachments
+		} // take care to ( unattached ) attachments
 		elseif ( isset( $_GET['attachment_id'] ) && $id = (int) $_GET['attachment_id'] ) {
 			$curlang = ( $lg = $this->model->post->get_language( $id ) ) ? $lg : $this->get_preferred_language();
-		}
-
-		elseif ( $slug = $this->links_model->get_language_from_url() ) {
+		} elseif ( $slug = $this->links_model->get_language_from_url() ) {
 			$curlang = $this->model->get_language( $slug );
-		}
-
-		elseif ( $this->options['hide_default'] ) {
+		} elseif ( $this->options['hide_default'] ) {
 			$curlang = $this->model->get_language( $this->options['default_lang'] );
 		}
 
@@ -86,7 +78,7 @@ class PLL_Choose_Lang_Url extends PLL_Choose_lang {
 		}
 
 		// untranslated taxonomies
-		$tax_qv = array_filter( wp_list_pluck( get_taxonomies( array(), 'objects' ), 'query_var' ) ); // get all taxonomies query vars
+		$tax_qv = array_filter( wp_list_pluck( get_taxonomies( [], 'objects' ), 'query_var' ) ); // get all taxonomies query vars
 		$tax_qv = array_intersect( $tax_qv, array_keys( $qv ) ); // get all queried taxonomies query vars
 
 		if ( ! $this->model->is_translated_taxonomy( array_keys( $tax_qv ) ) ) {

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -82,7 +82,7 @@ abstract class PLL_Choose_Lang {
 	public function maybe_setcookie() {
 		// check headers have not been sent to avoid ugly error
 		// cookie domain must be set to false for localhost ( default value for COOKIE_DOMAIN ) thanks to Stephen Harris.
-		if ( ! headers_sent() && PLL_COOKIE !== false && ! empty( $this->curlang ) && ( ! isset( $_COOKIE[ PLL_COOKIE ] ) || $_COOKIE[ PLL_COOKIE ] != $this->curlang->slug ) && ! is_404() ) {
+		if ( ! headers_sent() && PLL_COOKIE !== false && ! empty( $this->curlang ) && ( ! isset( $_COOKIE[ PLL_COOKIE ] ) || $_COOKIE[ PLL_COOKIE ] !== $this->curlang->slug ) && ! is_404() ) {
 
 			/**
 			 * Filter the Polylang cookie duration
@@ -98,7 +98,7 @@ abstract class PLL_Choose_Lang {
 				$this->curlang->slug,
 				time() + $expiration,
 				COOKIEPATH,
-				2 == $this->options['force_lang'] ? parse_url( $this->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN,
+				2 === $this->options['force_lang'] ? parse_url( $this->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN,
 				is_ssl()
 			);
 		}
@@ -218,7 +218,7 @@ abstract class PLL_Choose_Lang {
 	protected function home_language() {
 		// test referer in case PLL_COOKIE is set to false
 		// thanks to Ov3rfly http://wordpress.org/support/topic/enhance-feature-when-front-page-is-visited-set-language-according-to-browser
-		$language = $this->options['hide_default'] && ( ( isset( $_SERVER['HTTP_REFERER'] ) && in_array( parse_url( $_SERVER['HTTP_REFERER'], PHP_URL_HOST ), $this->links_model->get_hosts() ) ) || ! $this->options['browser'] ) ?
+		$language = $this->options['hide_default'] && ( ( isset( $_SERVER['HTTP_REFERER'] ) && in_array( wp_parse_url( $_SERVER['HTTP_REFERER'], PHP_URL_HOST ), $this->links_model->get_hosts(), true ) ) || ! $this->options['browser'] ) ?
 			$this->model->get_language( $this->options['default_lang'] ) :
 			$this->get_preferred_language(); // sets the language according to browser preference or default language
 		$this->set_language( $language );
@@ -233,7 +233,7 @@ abstract class PLL_Choose_Lang {
 	 */
 	public function home_requested() {
 		// we are already on the right page
-		if ( $this->options['default_lang'] == $this->curlang->slug && $this->options['hide_default'] ) {
+		if ( $this->options['default_lang'] === $this->curlang->slug && $this->options['hide_default'] ) {
 			$this->set_curlang_in_query( $GLOBALS['wp_query'] );
 
 			/**
@@ -303,7 +303,7 @@ abstract class PLL_Choose_Lang {
 		} // sets is_home on translated home page when it displays posts
 		// is_home must be true on page 2, 3... too
 		// as well as when searching an empty string: http://wordpress.org/support/topic/plugin-polylang-polylang-breaks-search-in-spun-theme
-		elseif ( ( count( $query->query ) == 1 || ( is_paged() && count( $query->query ) == 2 ) || ( isset( $query->query['s'] ) && ! $query->query['s'] ) ) && $lang = get_query_var( 'lang' ) ) {
+		elseif ( ( count( $query->query ) === 1 || ( is_paged() && count( $query->query ) === 2 ) || ( isset( $query->query['s'] ) && ! $query->query['s'] ) ) && $lang = get_query_var( 'lang' ) ) {
 			$lang = $this->model->get_language( $lang );
 			$this->set_language( $lang ); // sets the language now otherwise it will be too late to filter sticky posts !
 			$query->is_home    = true;

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -18,8 +18,8 @@ abstract class PLL_Choose_Lang {
 	 */
 	public function __construct( &$polylang ) {
 		$this->links_model = &$polylang->links_model;
-		$this->model = &$polylang->model;
-		$this->options = &$polylang->options;
+		$this->model       = &$polylang->model;
+		$this->options     = &$polylang->options;
 
 		$this->curlang = &$polylang->curlang;
 	}
@@ -36,9 +36,9 @@ abstract class PLL_Choose_Lang {
 			$this->set_language( empty( $_REQUEST['lang'] ) ? $this->get_preferred_language() : $this->model->get_language( $_REQUEST['lang'] ) );
 		}
 
-		add_action( 'pre_comment_on_post', array( $this, 'pre_comment_on_post' ) ); // sets the language of comment
-		add_action( 'parse_query', array( $this, 'parse_main_query' ), 2 ); // sets the language in special cases
-		add_action( 'wp', array( $this, 'maybe_setcookie' ), 7 );
+		add_action( 'pre_comment_on_post', [ $this, 'pre_comment_on_post' ] ); // sets the language of comment
+		add_action( 'parse_query', [ $this, 'parse_main_query' ], 2 ); // sets the language in special cases
+		add_action( 'wp', [ $this, 'maybe_setcookie' ], 7 );
 	}
 
 	/**
@@ -113,7 +113,7 @@ abstract class PLL_Choose_Lang {
 	 * @return string|bool the preferred language slug or false
 	 */
 	public function get_preferred_browser_language() {
-		$accept_langs = array();
+		$accept_langs = [];
 
 		if ( isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
 			// break up string into pieces ( languages and q factors )
@@ -136,12 +136,12 @@ abstract class PLL_Choose_Lang {
 						for ( $j = 0; $j <= $n - 2; $j++ ) {
 							if ( $v[ $j ] < $v[ $j + 1 ] ) {
 								// swap values
-								$temp = $v[ $j ];
-								$v[ $j ] = $v[ $j + 1 ];
+								$temp        = $v[ $j ];
+								$v[ $j ]     = $v[ $j + 1 ];
 								$v[ $j + 1 ] = $temp;
 								// Swap keys
-								$temp = $k[ $j ];
-								$k[ $j ] = $k[ $j + 1 ];
+								$temp        = $k[ $j ];
+								$k[ $j ]     = $k[ $j + 1 ];
 								$k[ $j + 1 ] = $temp;
 							}
 						}
@@ -151,7 +151,7 @@ abstract class PLL_Choose_Lang {
 			}
 		}
 
-		$languages = $this->model->get_languages_list( array( 'hide_empty' => true ) ); // hides languages with no post
+		$languages = $this->model->get_languages_list( [ 'hide_empty' => true ] ); // hides languages with no post
 
 		/**
 		 * Filter the list of languages to use to match the browser preferences
@@ -242,8 +242,7 @@ abstract class PLL_Choose_Lang {
 			 * @since 1.8
 			 */
 			do_action( 'pll_home_requested' );
-		}
-		// redirect to the home page in the right language
+		} // redirect to the home page in the right language
 		// test to avoid crash if get_home_url returns something wrong
 		// FIXME why this happens? http://wordpress.org/support/topic/polylang-crashes-1
 		// don't redirect if $_POST is not empty as it could break other plugins
@@ -301,15 +300,13 @@ abstract class PLL_Choose_Lang {
 		if ( $lang = apply_filters( 'pll_set_language_from_query', false, $query ) ) {
 			$this->set_language( $lang );
 			$this->set_curlang_in_query( $query );
-		}
-
-		// sets is_home on translated home page when it displays posts
+		} // sets is_home on translated home page when it displays posts
 		// is_home must be true on page 2, 3... too
 		// as well as when searching an empty string: http://wordpress.org/support/topic/plugin-polylang-polylang-breaks-search-in-spun-theme
 		elseif ( ( count( $query->query ) == 1 || ( is_paged() && count( $query->query ) == 2 ) || ( isset( $query->query['s'] ) && ! $query->query['s'] ) ) && $lang = get_query_var( 'lang' ) ) {
 			$lang = $this->model->get_language( $lang );
 			$this->set_language( $lang ); // sets the language now otherwise it will be too late to filter sticky posts !
-			$query->is_home = true;
+			$query->is_home    = true;
 			$query->is_archive = $query->is_tax = false;
 		}
 	}

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -192,7 +192,7 @@ class PLL_Frontend_Auto_Translate {
 				// post__in used by the 2 functions below
 				// Useless to filter them as output is already in the right language and would result in performance loss
 				foreach ( debug_backtrace() as $trace ) {
-					if ( in_array( $trace['function'], [ 'wp_nav_menu', 'gallery_shortcode' ] ) ) {
+					if ( in_array( $trace['function'], [ 'wp_nav_menu', 'gallery_shortcode' ], true ) ) {
 						return;
 					}
 				}
@@ -239,7 +239,7 @@ class PLL_Frontend_Auto_Translate {
 		foreach ( $tax_queries as $key => $q ) {
 			if ( isset( $q['taxonomy'], $q['terms'] ) && $this->model->is_translated_taxonomy( $q['taxonomy'] ) ) {
 				$arr   = [];
-				$field = isset( $q['field'] ) && in_array( $q['field'], [ 'slug', 'name' ] ) ? $q['field'] : 'term_id';
+				$field = isset( $q['field'] ) && in_array( $q['field'], [ 'slug', 'name' ], true ) ? $q['field'] : 'term_id';
 				foreach ( (array) $q['terms'] as $t ) {
 					$arr[] = $this->get_translated_term_by( $field, $t, $q['taxonomy'] );
 				}

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -21,32 +21,32 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		parent::__construct( $polylang );
 
 		$this->curlang = &$polylang->curlang;
-		$this->cache = new PLL_Cache();
+		$this->cache   = new PLL_Cache();
 
 		// Rewrites author and date links to filter them by language
-		foreach ( array( 'feed_link', 'author_link', 'search_link', 'year_link', 'month_link', 'day_link' ) as $filter ) {
-			add_filter( $filter, array( $this, 'archive_link' ), 20 );
+		foreach ( [ 'feed_link', 'author_link', 'search_link', 'year_link', 'month_link', 'day_link' ] as $filter ) {
+			add_filter( $filter, [ $this, 'archive_link' ], 20 );
 		}
 
 		// Meta in the html head section
-		add_action( 'wp_head', array( $this, 'wp_head' ) );
+		add_action( 'wp_head', [ $this, 'wp_head' ] );
 
 		// Modifies the home url
 		if ( ! defined( 'PLL_FILTER_HOME_URL' ) || PLL_FILTER_HOME_URL ) {
-			add_filter( 'home_url', array( $this, 'home_url' ), 10, 2 );
+			add_filter( 'home_url', [ $this, 'home_url' ], 10, 2 );
 		}
 
 		if ( $this->options['force_lang'] > 1 ) {
 			// Rewrites next and previous post links when not automatically done by WordPress
-			add_filter( 'get_pagenum_link', array( $this, 'archive_link' ), 20 );
+			add_filter( 'get_pagenum_link', [ $this, 'archive_link' ], 20 );
 
 			// Rewrites ajax url
-			add_filter( 'admin_url', array( $this, 'admin_url' ), 10, 2 );
+			add_filter( 'admin_url', [ $this, 'admin_url' ], 10, 2 );
 		}
 
 		// Redirects to canonical url before WordPress redirect_canonical
 		// but after Nextgen Gallery which hacks $_SERVER['REQUEST_URI'] !!! and restores it in 'template_redirect' with priority 1
-		add_action( 'template_redirect', array( $this, 'check_canonical_url' ), 4 );
+		add_action( 'template_redirect', [ $this, 'check_canonical_url' ], 4 );
 	}
 
 	/**
@@ -137,9 +137,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 				/** This filter is documented in include/filters-links.php */
 				$_link = apply_filters( 'pll_term_link', $_link, $this->curlang, $term );
-			}
-
-			else {
+			} else {
 				$_link = parent::term_link( $link, $term, $tax );
 			}
 			$this->cache->set( $cache_key, $_link );
@@ -171,14 +169,14 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 			// Prepare the list of languages to remove the country code
 			foreach ( array_keys( $urls ) as $locale ) {
-				$split = explode( '-', $locale );
+				$split                = explode( '-', $locale );
 				$languages[ $locale ] = reset( $split );
 			}
 
 			$count = array_count_values( $languages );
 
 			foreach ( $urls as $locale => $url ) {
-				$lang = $count[ $languages[ $locale ] ] > 1 ? $locale : $languages[ $locale ]; // Output the country code only when necessary
+				$lang               = $count[ $languages[ $locale ] ] > 1 ? $locale : $languages[ $locale ]; // Output the country code only when necessary
 				$hreflangs[ $lang ] = $url;
 			}
 
@@ -236,12 +234,14 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			 *
 			 * @param array $args
 			 */
-			$white_list = apply_filters( 'pll_home_url_white_list', array(
-				array( 'file' => $theme_root ),
-				array( 'function' => 'wp_nav_menu' ),
-				array( 'function' => 'login_footer' ),
-				array( 'function' => 'get_custom_logo' ),
-			) );
+			$white_list = apply_filters(
+				'pll_home_url_white_list', [
+					[ 'file' => $theme_root ],
+					[ 'function' => 'wp_nav_menu' ],
+					[ 'function' => 'login_footer' ],
+					[ 'function' => 'get_custom_logo' ],
+				]
+			);
 		}
 
 		// We don't want to filter the home url in these cases
@@ -257,10 +257,12 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			 *
 			 * @param array $args
 			 */
-			$black_list = apply_filters( 'pll_home_url_black_list', array(
-				array( 'file' => 'searchform.php' ), // Since WP 3.6 searchform.php is passed through get_search_form
-				array( 'function' => 'get_search_form' ),
-			) );
+			$black_list = apply_filters(
+				'pll_home_url_black_list', [
+					[ 'file' => 'searchform.php' ], // Since WP 3.6 searchform.php is passed through get_search_form
+					[ 'function' => 'get_search_form' ],
+				]
+			);
 		}
 
 		$traces = version_compare( PHP_VERSION, '5.2.5', '>=' ) ? debug_backtrace( false ) : debug_backtrace();
@@ -276,7 +278,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 			foreach ( $white_list as $v ) {
 				if ( ( isset( $trace['function'], $v['function'] ) && $trace['function'] == $v['function'] ) ||
-					( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) && in_array( $trace['function'], array( 'home_url', 'get_home_url', 'bloginfo', 'get_bloginfo' ) ) ) ) {
+					( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) && in_array( $trace['function'], [ 'home_url', 'get_home_url', 'bloginfo', 'get_bloginfo' ] ) ) ) {
 					$ok = true;
 				}
 			}
@@ -335,21 +337,15 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			if ( isset( $post->ID ) && $this->model->is_translated_post_type( $post->post_type ) ) {
 				$language = $this->model->post->get_language( (int) $post->ID );
 			}
-		}
-
-		elseif ( is_category() || is_tag() || is_tax() ) {
+		} elseif ( is_category() || is_tag() || is_tax() ) {
 			$obj = $wp_query->get_queried_object();
 			if ( $this->model->is_translated_taxonomy( $obj->taxonomy ) ) {
 				$language = $this->model->term->get_language( (int) $obj->term_id );
 			}
-		}
-
-		elseif ( $wp_query->is_posts_page ) {
-			$obj = $wp_query->get_queried_object();
+		} elseif ( $wp_query->is_posts_page ) {
+			$obj      = $wp_query->get_queried_object();
 			$language = $this->model->post->get_language( (int) $obj->ID );
-		}
-
-		elseif ( is_404() && ! empty( $wp_query->query['page_id'] ) && $id = get_query_var( 'page_id' ) ) {
+		} elseif ( is_404() && ! empty( $wp_query->query['page_id'] ) && $id = get_query_var( 'page_id' ) ) {
 			// Special case for page shortlinks when using subdomains or multiple domains
 			// Needed because redirect_canonical doesn't accept to change the domain name
 			$language = $this->model->post->get_language( (int) $id );
@@ -359,20 +355,20 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			foreach ( $this->options['domains'] as $lang => $domain ) {
 				$host = parse_url( $domain, PHP_URL_HOST );
 				if ( 'www.' . $_SERVER['HTTP_HOST'] === $host || 'www.' . $host === $_SERVER['HTTP_HOST'] ) {
-					$language = $this->model->get_language( $lang );
+					$language     = $this->model->get_language( $lang );
 					$redirect_url = str_replace( '://' . $_SERVER['HTTP_HOST'], '://' . $host, $requested_url );
 				}
 			}
 		}
 
 		if ( empty( $language ) ) {
-			$language = $this->curlang;
+			$language     = $this->curlang;
 			$redirect_url = $requested_url;
 		} elseif ( empty( $redirect_url ) ) {
 			// First get the canonical url evaluated by WP
 			// Workaround a WP bug which removes the port for some urls and get it back at second call to redirect_canonical
 			$_redirect_url = ( ! $_redirect_url = redirect_canonical( $requested_url, false ) ) ? $requested_url : $_redirect_url;
-			$redirect_url = ( ! $redirect_url = redirect_canonical( $_redirect_url, false ) ) ? $_redirect_url : $redirect_url;
+			$redirect_url  = ( ! $redirect_url = redirect_canonical( $_redirect_url, false ) ) ? $_redirect_url : $redirect_url;
 
 			// Then get the right language code in url
 			$redirect_url = $this->options['force_lang'] ?

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -132,7 +132,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	public function term_link( $link, $term, $tax ) {
 		$cache_key = "term:{$term->term_id}:{$link}";
 		if ( false === $_link = $this->cache->get( $cache_key ) ) {
-			if ( in_array( $tax, $this->model->get_filtered_taxonomies() ) ) {
+			if ( in_array( $tax, $this->model->get_filtered_taxonomies(), true ) ) {
 				$_link = $this->links_model->switch_language_in_link( $link, $this->curlang );
 
 				/** This filter is documented in include/filters-links.php */
@@ -211,7 +211,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	 * @return string
 	 */
 	public function home_url( $url, $path ) {
-		if ( ! ( did_action( 'template_redirect' ) || did_action( 'login_init' ) ) || rtrim( $url, '/' ) != $this->links_model->home ) {
+		if ( ! ( did_action( 'template_redirect' ) || did_action( 'login_init' ) ) || rtrim( $url, '/' ) !== $this->links_model->home ) {
 			return $url;
 		}
 
@@ -271,14 +271,14 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		foreach ( $traces as $trace ) {
 			// Black list first
 			foreach ( $black_list as $v ) {
-				if ( ( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) ) || ( isset( $trace['function'], $v['function'] ) && $trace['function'] == $v['function'] ) ) {
+				if ( ( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) ) || ( isset( $trace['function'], $v['function'] ) && $trace['function'] === $v['function'] ) ) {
 					return $url;
 				}
 			}
 
 			foreach ( $white_list as $v ) {
-				if ( ( isset( $trace['function'], $v['function'] ) && $trace['function'] == $v['function'] ) ||
-					( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) && in_array( $trace['function'], [ 'home_url', 'get_home_url', 'bloginfo', 'get_bloginfo' ] ) ) ) {
+				if ( ( isset( $trace['function'], $v['function'] ) && $trace['function'] === $v['function'] ) ||
+					( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) && in_array( $trace['function'], [ 'home_url', 'get_home_url', 'bloginfo', 'get_bloginfo' ], true ) ) ) {
 					$ok = true;
 				}
 			}
@@ -319,7 +319,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		}
 
 		// Don't redirect mysite.com/?attachment_id= to mysite.com/en/?attachment_id=
-		if ( 1 == $this->options['force_lang'] && is_attachment() && isset( $_GET['attachment_id'] ) ) {
+		if ( 1 === $this->options['force_lang'] && is_attachment() && isset( $_GET['attachment_id'] ) ) {
 			return;
 		}
 
@@ -387,7 +387,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		$redirect_url = apply_filters( 'pll_check_canonical_url', $redirect_url, $language );
 
 		// The language is not correctly set so let's redirect to the correct url for this object
-		if ( $do_redirect && $redirect_url && $requested_url != $redirect_url ) {
+		if ( $do_redirect && $redirect_url && $requested_url !== $redirect_url ) {
 			wp_redirect( $redirect_url, 301 );
 			exit;
 		}

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -110,15 +110,15 @@ class PLL_Frontend_Filters_Search {
 		$js   = "//<![CDATA[
 		e = document.getElementsByName( 's' );
 		for ( i = 0; i < e.length; i++ ) {
-			if ( e[i].tagName.toUpperCase() == 'INPUT' ) {
+			if ( e[i].tagName.toUpperCase() === 'INPUT' ) {
 				s = e[i].parentNode.parentNode.children;
 				l = 0;
 				for ( j = 0; j < s.length; j++ ) {
-					if ( s[j].name == 'lang' ) {
+					if ( s[j].name === 'lang' ) {
 						l = 1;
 					}
 				}
-				if ( l == 0 ) {
+				if ( l === 0 ) {
 					var ih = document.createElement( 'input' );
 					ih.type = 'hidden';
 					ih.name = 'lang';

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -17,19 +17,19 @@ class PLL_Frontend_Filters_Search {
 	 */
 	public function __construct( &$polylang ) {
 		$this->links_model = &$polylang->links_model;
-		$this->curlang = &$polylang->curlang;
+		$this->curlang     = &$polylang->curlang;
 
 		// adds the language information in the search form
 		// low priority in case the search form is created using the same filter as described in http://codex.wordpress.org/Function_Reference/get_search_form
-		add_filter( 'get_search_form', array( $this, 'get_search_form' ), 99 );
+		add_filter( 'get_search_form', [ $this, 'get_search_form' ], 99 );
 
 		// adds the language information in admin bar search form
-		add_action( 'add_admin_bar_menus', array( $this, 'add_admin_bar_menus' ) );
+		add_action( 'add_admin_bar_menus', [ $this, 'add_admin_bar_menus' ] );
 
 		// adds javascript at the end of the document
 		// was used for WP < 3.6. kept just in case
 		if ( defined( 'PLL_SEARCH_FORM_JS' ) && PLL_SEARCH_FORM_JS ) {
-			add_action( 'wp_footer', array( $this, 'wp_print_footer_scripts' ) );
+			add_action( 'wp_footer', [ $this, 'wp_print_footer_scripts' ] );
 		}
 	}
 
@@ -47,11 +47,10 @@ class PLL_Frontend_Filters_Search {
 			if ( $this->links_model->using_permalinks ) {
 				// take care to modify only the url in the <form> tag
 				preg_match( '#<form.+>#', $form, $matches );
-				$old = reset( $matches );
-				$new = preg_replace( '#' . esc_url( $this->links_model->home ) . '\/?#', esc_url( $this->curlang->search_url ), $old );
+				$old  = reset( $matches );
+				$new  = preg_replace( '#' . esc_url( $this->links_model->home ) . '\/?#', esc_url( $this->curlang->search_url ), $old );
 				$form = str_replace( $old, $new, $form );
-			}
-			else {
+			} else {
 				$form = str_replace( '</form>', '<input type="hidden" name="lang" value="' . esc_attr( $this->curlang->slug ) . '" /></form>', $form );
 			}
 		}
@@ -66,7 +65,7 @@ class PLL_Frontend_Filters_Search {
 	 */
 	function add_admin_bar_menus() {
 		remove_action( 'admin_bar_menu', 'wp_admin_bar_search_menu', 4 );
-		add_action( 'admin_bar_menu', array( $this, 'admin_bar_search_menu' ), 4 );
+		add_action( 'admin_bar_menu', [ $this, 'admin_bar_search_menu' ], 4 );
 	}
 
 	/**
@@ -84,12 +83,17 @@ class PLL_Frontend_Filters_Search {
 		$form .= '<input type="submit" class="adminbar-button" value="' . esc_attr__( 'Search' ) . '"/>';
 		$form .= '</form>';
 
-		$wp_admin_bar->add_menu( array(
-			'parent' => 'top-secondary',
-			'id'     => 'search',
-			'title'  => $this->get_search_form( $form ), // pass the get_search_form filter
-			'meta'   => array( 'class' => 'admin-bar-search', 'tabindex' => -1 ),
-		) );
+		$wp_admin_bar->add_menu(
+			[
+				'parent' => 'top-secondary',
+				'id'     => 'search',
+				'title'  => $this->get_search_form( $form ), // pass the get_search_form filter
+				'meta'   => [
+					'class' => 'admin-bar-search',
+					'tabindex' => -1,
+				],
+			]
+		);
 	}
 
 	/**
@@ -103,7 +107,7 @@ class PLL_Frontend_Filters_Search {
 		// thanks to AndyDeGroo for improving the code for compatibility with old browsers
 		// http://wordpress.org/support/topic/development-of-polylang-version-08?replies=6#post-2645559
 		$lang = esc_js( $this->curlang->slug );
-		$js = "//<![CDATA[
+		$js   = "//<![CDATA[
 		e = document.getElementsByName( 's' );
 		for ( i = 0; i < e.length; i++ ) {
 			if ( e[i].tagName.toUpperCase() == 'INPUT' ) {

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -19,46 +19,46 @@ class PLL_Frontend_Filters extends PLL_Filters {
 		parent::__construct( $polylang );
 
 		// Filters the WordPress locale
-		add_filter( 'locale', array( $this, 'get_locale' ) );
+		add_filter( 'locale', [ $this, 'get_locale' ] );
 
 		// Filter sticky posts by current language
-		add_filter( 'option_sticky_posts', array( $this, 'option_sticky_posts' ) );
+		add_filter( 'option_sticky_posts', [ $this, 'option_sticky_posts' ] );
 
 		// Adds cache domain when querying terms
-		add_filter( 'get_terms_args', array( $this, 'get_terms_args' ) );
+		add_filter( 'get_terms_args', [ $this, 'get_terms_args' ] );
 
 		// Filters categories and post tags by language
-		add_filter( 'terms_clauses', array( $this, 'terms_clauses' ), 10, 3 );
-		add_action( 'pre_get_posts', array( $this, 'set_tax_query_lang' ), 999 );
-		add_action( 'posts_selection', array( $this, 'unset_tax_query_lang' ), 0 );
+		add_filter( 'terms_clauses', [ $this, 'terms_clauses' ], 10, 3 );
+		add_action( 'pre_get_posts', [ $this, 'set_tax_query_lang' ], 999 );
+		add_action( 'posts_selection', [ $this, 'unset_tax_query_lang' ], 0 );
 
 		// Rewrites archives links to filter them by language
-		add_filter( 'getarchives_join', array( $this, 'getarchives_join' ), 10, 2 );
-		add_filter( 'getarchives_where', array( $this, 'getarchives_where' ), 10, 2 );
+		add_filter( 'getarchives_join', [ $this, 'getarchives_join' ], 10, 2 );
+		add_filter( 'getarchives_where', [ $this, 'getarchives_where' ], 10, 2 );
 
 		// Filters the widgets according to the current language
-		add_filter( 'widget_display_callback', array( $this, 'widget_display_callback' ), 10, 2 );
-		add_filter( 'sidebars_widgets', array( $this, 'sidebars_widgets' ) );
+		add_filter( 'widget_display_callback', [ $this, 'widget_display_callback' ], 10, 2 );
+		add_filter( 'sidebars_widgets', [ $this, 'sidebars_widgets' ] );
 
 		if ( $this->options['media_support'] ) {
-			add_filter( 'widget_media_image_instance', array( $this, 'widget_media_instance' ), 1 ); // Since WP 4.8
+			add_filter( 'widget_media_image_instance', [ $this, 'widget_media_instance' ], 1 ); // Since WP 4.8
 		}
 
 		// Strings translation ( must be applied before WordPress applies its default formatting filters )
-		foreach ( array( 'widget_text', 'widget_title', 'option_blogname', 'option_blogdescription', 'option_date_format', 'option_time_format' ) as $filter ) {
+		foreach ( [ 'widget_text', 'widget_title', 'option_blogname', 'option_blogdescription', 'option_date_format', 'option_time_format' ] as $filter ) {
 			add_filter( $filter, 'pll__', 1 );
 		}
 
 		// Translates biography
-		add_filter( 'get_user_metadata', array( $this, 'get_user_metadata' ), 10, 4 );
+		add_filter( 'get_user_metadata', [ $this, 'get_user_metadata' ], 10, 4 );
 
 		// Set posts and terms language when created from frontend ( ex with P2 theme )
-		add_action( 'save_post', array( $this, 'save_post' ), 200, 2 );
-		add_action( 'create_term', array( $this, 'save_term' ), 10, 3 );
-		add_action( 'edit_term', array( $this, 'save_term' ), 10, 3 );
+		add_action( 'save_post', [ $this, 'save_post' ], 200, 2 );
+		add_action( 'create_term', [ $this, 'save_term' ], 10, 3 );
+		add_action( 'edit_term', [ $this, 'save_term' ], 10, 3 );
 
 		if ( $this->options['media_support'] ) {
-			add_action( 'add_attachment', array( $this, 'set_default_language' ) );
+			add_action( 'add_attachment', [ $this, 'set_default_language' ] );
 		}
 
 		// Support theme customizer
@@ -70,7 +70,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 
 		// FIXME test get_user_locale for backward compatibility with WP < 4.7
 		if ( Polylang::is_ajax_on_front() && function_exists( 'get_user_locale' ) ) {
-			add_filter( 'load_textdomain_mofile', array( $this, 'load_textdomain_mofile' ) );
+			add_filter( 'load_textdomain_mofile', [ $this, 'load_textdomain_mofile' ] );
 		}
 	}
 
@@ -104,8 +104,8 @@ class PLL_Frontend_Filters extends PLL_Filters {
 				$posts = array_map( 'intval', $posts );
 				$posts = implode( ',', $posts );
 
-				$languages = $this->model->get_languages_list( array( 'fields' => 'term_taxonomy_id' ) );
-				$_posts = array_fill_keys( $languages, array() ); // Init with empty arrays
+				$languages = $this->model->get_languages_list( [ 'fields' => 'term_taxonomy_id' ] );
+				$_posts    = array_fill_keys( $languages, [] ); // Init with empty arrays
 				$languages = implode( ',', $languages );
 
 				$relations = $wpdb->get_results( "SELECT object_id, term_taxonomy_id FROM {$wpdb->term_relationships} WHERE object_id IN ({$posts}) AND term_taxonomy_id IN ({$languages})" );
@@ -140,7 +140,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 			$lang = $this->curlang->slug;
 		}
 
-		$key = '_' . ( is_array( $lang ) ? implode( ',', $lang ) : $lang );
+		$key                  = '_' . ( is_array( $lang ) ? implode( ',', $lang ) : $lang );
 		$args['cache_domain'] = empty( $args['cache_domain'] ) ? 'pll' . $key : $args['cache_domain'] . $key;
 		return $args;
 	}
@@ -253,7 +253,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 				}
 
 				$widget_settings = $wp_registered_widgets[ $widget ]['callback'][0]->get_settings();
-				$number = $wp_registered_widgets[ $widget ]['params'][0]['number'];
+				$number          = $wp_registered_widgets[ $widget ]['params'][0]['number'];
 
 				// Remove the widget if not visible in the current language
 				if ( ! empty( $widget_settings[ $number ]['pll_lang'] ) && $widget_settings[ $number ]['pll_lang'] !== $this->curlang->slug ) {
@@ -276,7 +276,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	public function widget_media_instance( $instance ) {
 		if ( empty( $instance['pll_lang'] ) && $instance['attachment_id'] && $tr_id = pll_get_post( $instance['attachment_id'] ) ) {
 			$instance['attachment_id'] = $tr_id;
-			$attachment = get_post( $tr_id );
+			$attachment                = get_post( $tr_id );
 
 			if ( $instance['caption'] && ! empty( $attachment->post_excerpt ) ) {
 				$instance['caption'] = $attachment->post_excerpt;

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -225,7 +225,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 * @return bool|array false if we hide the widget, unmodified $instance otherwise
 	 */
 	public function widget_display_callback( $instance, $widget ) {
-		return ! empty( $instance['pll_lang'] ) && $instance['pll_lang'] != $this->curlang->slug ? false : $instance;
+		return ! empty( $instance['pll_lang'] ) && $instance['pll_lang'] !== $this->curlang->slug ? false : $instance;
 	}
 
 	/**
@@ -241,7 +241,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 		global $wp_registered_widgets;
 
 		foreach ( $sidebars_widgets as $sidebar => $widgets ) {
-			if ( 'wp_inactive_widgets' == $sidebar || empty( $widgets ) ) {
+			if ( 'wp_inactive_widgets' === $sidebar || empty( $widgets ) ) {
 				continue;
 			}
 

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -108,6 +108,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 				$_posts    = array_fill_keys( $languages, [] ); // Init with empty arrays
 				$languages = implode( ',', $languages );
 
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$relations = $wpdb->get_results( "SELECT object_id, term_taxonomy_id FROM {$wpdb->term_relationships} WHERE object_id IN ({$posts}) AND term_taxonomy_id IN ({$languages})" );
 
 				foreach ( $relations as $relation ) {

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -55,7 +55,7 @@ class PLL_Frontend_Links extends PLL_Links {
 		 */
 		if ( ! $url = apply_filters( 'pll_pre_translation_url', '', $language, $queried_object_id ) ) {
 			$qv   = $wp_query->query_vars;
-			$hide = $this->options['default_lang'] == $language->slug && $this->options['hide_default'];
+			$hide = $this->options['default_lang'] === $language->slug && $this->options['hide_default'];
 
 			// Post and attachment
 			if ( is_single() && ( $this->options['media_support'] || ! is_attachment() ) && ( $id = $this->model->post->get( $queried_object_id, $language ) ) && $this->current_user_can_read( $id ) ) {
@@ -89,7 +89,7 @@ class PLL_Frontend_Links extends PLL_Links {
 			elseif ( ( is_category() || is_tag() || is_tax() ) && ( $term = get_queried_object() ) && $this->model->is_translated_taxonomy( $term->taxonomy ) ) {
 				$lang = $this->model->term->get_language( $term->term_id );
 
-				if ( ! $lang || $language->slug == $lang->slug ) {
+				if ( ! $lang || $language->slug === $lang->slug ) {
 					$url = wpcom_vip_get_term_link( $term, $term->taxonomy ); // Self link
 				} elseif ( $tr_id = $this->model->term->get_translation( $term->term_id, $language ) ) {
 					if ( $tr_term = get_term( $tr_id, $term->taxonomy ) ) {

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -144,7 +144,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	public function get_ancestors( $item ) {
 		$ids     = [];
 		$_anc_id = (int) $item->db_id;
-		while ( ( $_anc_id = get_post_meta( $_anc_id, '_menu_item_menu_item_parent', true ) ) && ! in_array( $_anc_id, $ids ) ) {
+		while ( ( $_anc_id = get_post_meta( $_anc_id, '_menu_item_menu_item_parent', true ) ) && ! in_array( $_anc_id, $ids, true ) ) {
 			$ids[] = $_anc_id;
 		}
 		return $ids;
@@ -163,11 +163,11 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 
 		foreach ( $items as $item ) {
 			if ( ! empty( $item->classes ) && is_array( $item->classes ) ) {
-				if ( in_array( 'current-lang', $item->classes ) ) {
+				if ( in_array( 'current-lang', $item->classes, true ) ) {
 					$item->current = false;
 					$item->classes = array_diff( $item->classes, [ 'current-menu-item' ] );
 					$r_ids         = array_merge( $r_ids, $this->get_ancestors( $item ) ); // Remove the classes for these ancestors
-				} elseif ( in_array( 'current-menu-item', $item->classes ) ) {
+				} elseif ( in_array( 'current-menu-item', $item->classes, true ) ) {
 					$k_ids = array_merge( $k_ids, $this->get_ancestors( $item ) ); // Keep the classes for these ancestors
 				}
 			}
@@ -176,7 +176,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 		$r_ids = array_diff( $r_ids, $k_ids );
 
 		foreach ( $items as $item ) {
-			if ( ! empty( $item->db_id ) && in_array( $item->db_id, $r_ids ) ) {
+			if ( ! empty( $item->db_id ) && in_array( $item->db_id, $r_ids, true ) ) {
 				$item->classes = array_diff( $item->classes, [ 'current-menu-ancestor', 'current-menu-parent', 'current_page_parent', 'current_page_ancestor' ] );
 			}
 		}
@@ -229,9 +229,9 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 						if ( false !== strpos( $key, 'nav_menu_locations[' ) ) {
 							$loc   = substr( trim( $key, ']' ), 19 );
 							$infos = $this->explode_location( $loc );
-							if ( $infos['lang'] == $this->curlang->slug ) {
+							if ( $infos['lang'] === $this->curlang->slug ) {
 								$menus[ $infos['location'] ] = $c;
-							} elseif ( $this->curlang->slug == $this->options['default_lang'] ) {
+							} elseif ( $this->curlang->slug === $this->options['default_lang'] ) {
 								$menus[ $loc ] = $c;
 							}
 						}
@@ -264,7 +264,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 		// This obviously does not work if the nav menu has no associated theme location
 		if ( $menu ) {
 			foreach ( $this->options['nav_menus'][ $theme ] as $menus ) {
-				if ( in_array( $menu->term_id, $menus ) && ! empty( $menus[ $this->curlang->slug ] ) ) {
+				if ( in_array( $menu->term_id, $menus, true ) && ! empty( $menus[ $this->curlang->slug ] ) ) {
 					$args['menu'] = $menus[ $this->curlang->slug ];
 					return $args;
 				}
@@ -277,7 +277,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 			foreach ( $menus as $menu_maybe ) {
 				if ( $menu_items = wp_get_nav_menu_items( $menu_maybe->term_id, [ 'update_post_term_cache' => false ] ) ) {
 					foreach ( $this->options['nav_menus'][ $theme ] as $menus ) {
-						if ( in_array( $menu_maybe->term_id, $menus ) && ! empty( $menus[ $this->curlang->slug ] ) ) {
+						if ( in_array( $menu_maybe->term_id, $menus, true ) && ! empty( $menus[ $this->curlang->slug ] ) ) {
 							$args['menu'] = $menus[ $this->curlang->slug ];
 							return $args;
 						}

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -86,7 +86,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 */
 	public function redirect_canonical( $redirect_url, $requested_url ) {
 		global $wp_query;
-		if ( is_page() && ! is_feed() && isset( $wp_query->queried_object ) && $wp_query->queried_object->ID == $this->curlang->page_on_front ) {
+		if ( is_page() && ! is_feed() && isset( $wp_query->queried_object ) && (int) $wp_query->queried_object->ID === (int) $this->curlang->page_on_front ) {
 			$url = is_paged() ? $this->links_model->add_paged_to_link( $this->links->get_home_url(), $wp_query->query_vars['page'] ) : $this->links->get_home_url();
 
 			// Don't forget additional query vars
@@ -119,7 +119,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 			if ( $GLOBALS['wp_query']->is_posts_page && ( $id = $this->model->post->get( $queried_object_id, $language ) ) ) {
 				$url = get_permalink( $id );
 			} // Page on front
-			elseif ( is_front_page() && $language->page_on_front && ( $language->page_on_front == $this->model->post->get( $queried_object_id, $language ) ) ) {
+			elseif ( is_front_page() && $language->page_on_front && ( $language->page_on_front === $this->model->post->get( $queried_object_id, $language ) ) ) {
 				$url = $language->home_url;
 			}
 		}
@@ -149,7 +149,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 */
 	protected function is_front_page( $query ) {
 		$query = array_diff( array_keys( $query->query ), [ 'preview', 'page', 'paged', 'cpage', 'orderby' ] );
-		return 1 === count( $query ) && in_array( 'lang', $query );
+		return 1 === count( $query ) && in_array( 'lang', $query, true );
 	}
 
 	/**
@@ -216,8 +216,9 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	public function page_for_posts_query( $lang, $query ) {
 		if ( empty( $lang ) && $this->page_for_posts ) {
 			$page_id = $this->get_page_id( $query );
+			$pages   = $this->model->get_languages_list( [ 'fields' => 'page_for_posts' ] );
 
-			if ( ! empty( $page_id ) && in_array( $page_id, $pages = $this->model->get_languages_list( [ 'fields' => 'page_for_posts' ] ) ) ) {
+			if ( ! empty( $page_id ) && in_array( $page_id, $pages, true ) ) {
 				// Fill the cache with all pages for posts to avoid one query per page later
 				// The posts_per_page limit is a trick to avoid splitting the query
 				get_posts(

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -105,7 +105,7 @@ class PLL_Frontend extends PLL_Base {
 		$pll_query          = new PLL_Query( $query, $this->model );
 		$queried_taxonomies = $pll_query->get_queried_taxonomies();
 
-		if ( ! empty( $queried_taxonomies ) && 'language' == reset( $queried_taxonomies ) ) {
+		if ( ! empty( $queried_taxonomies ) && 'language' === reset( $queried_taxonomies ) ) {
 			$query->tax_query->queried_terms['language'] = array_shift( $query->tax_query->queried_terms );
 		}
 	}
@@ -128,7 +128,7 @@ class PLL_Frontend extends PLL_Base {
 		}
 
 		// Modifies query vars when the language is queried
-		if ( ! empty( $qv['lang'] ) || ( ! empty( $taxonomies ) && [ 'language' ] == array_values( $taxonomies ) ) ) {
+		if ( ! empty( $qv['lang'] ) || ( ! empty( $taxonomies ) && [ 'language' ] === array_values( $taxonomies ) ) ) {
 			// Do we query a custom taxonomy?
 			$taxonomies = array_diff( $taxonomies, [ 'language', 'category', 'post_tag' ] );
 

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -34,17 +34,17 @@ class PLL_Frontend extends PLL_Base {
 	public function __construct( &$links_model ) {
 		parent::__construct( $links_model );
 
-		add_action( 'pll_language_defined', array( $this, 'pll_language_defined' ), 1 );
+		add_action( 'pll_language_defined', [ $this, 'pll_language_defined' ], 1 );
 
 		// Avoids the language being the queried object when querying multiple taxonomies
-		add_action( 'parse_tax_query', array( $this, 'parse_tax_query' ), 1 );
+		add_action( 'parse_tax_query', [ $this, 'parse_tax_query' ], 1 );
 
 		// Filters posts by language
-		add_action( 'parse_query', array( $this, 'parse_query' ), 6 );
+		add_action( 'parse_query', [ $this, 'parse_query' ], 6 );
 
 		// Not before 'check_canonical_url'
 		if ( ! defined( 'PLL_AUTO_TRANSLATE' ) || PLL_AUTO_TRANSLATE ) {
-			add_action( 'template_redirect', array( $this, 'auto_translate' ), 7 );
+			add_action( 'template_redirect', [ $this, 'auto_translate' ], 7 );
 		}
 	}
 
@@ -67,8 +67,8 @@ class PLL_Frontend extends PLL_Base {
 			}
 
 			// Setup the language chooser
-			$c = array( 'Content', 'Url', 'Url', 'Domain' );
-			$class = 'PLL_Choose_Lang_' . $c[ $this->options['force_lang'] ];
+			$c                 = [ 'Content', 'Url', 'Url', 'Domain' ];
+			$class             = 'PLL_Choose_Lang_' . $c[ $this->options['force_lang'] ];
 			$this->choose_lang = new $class( $this );
 			$this->choose_lang->init();
 
@@ -84,8 +84,8 @@ class PLL_Frontend extends PLL_Base {
 	 */
 	public function pll_language_defined() {
 		// Filters
-		$this->filters_links = new PLL_Frontend_Filters_Links( $this );
-		$this->filters = new PLL_Frontend_Filters( $this );
+		$this->filters_links  = new PLL_Frontend_Filters_Links( $this );
+		$this->filters        = new PLL_Frontend_Filters( $this );
 		$this->filters_search = new PLL_Frontend_Filters_Search( $this );
 
 		// Auto translate for Ajax
@@ -102,7 +102,7 @@ class PLL_Frontend extends PLL_Base {
 	 * @param object $query WP_Query object
 	 */
 	public function parse_tax_query( $query ) {
-		$pll_query = new PLL_Query( $query, $this->model );
+		$pll_query          = new PLL_Query( $query, $this->model );
 		$queried_taxonomies = $pll_query->get_queried_taxonomies();
 
 		if ( ! empty( $queried_taxonomies ) && 'language' == reset( $queried_taxonomies ) ) {
@@ -118,8 +118,8 @@ class PLL_Frontend extends PLL_Base {
 	 * @param object $query WP_Query object
 	 */
 	public function parse_query( $query ) {
-		$qv = $query->query_vars;
-		$pll_query = new PLL_Query( $query, $this->model );
+		$qv         = $query->query_vars;
+		$pll_query  = new PLL_Query( $query, $this->model );
 		$taxonomies = $pll_query->get_queried_taxonomies();
 
 		// Allow filtering recent posts and secondary queries by the current language
@@ -128,9 +128,9 @@ class PLL_Frontend extends PLL_Base {
 		}
 
 		// Modifies query vars when the language is queried
-		if ( ! empty( $qv['lang'] ) || ( ! empty( $taxonomies ) && array( 'language' ) == array_values( $taxonomies ) ) ) {
+		if ( ! empty( $qv['lang'] ) || ( ! empty( $taxonomies ) && [ 'language' ] == array_values( $taxonomies ) ) ) {
 			// Do we query a custom taxonomy?
-			$taxonomies = array_diff( $taxonomies, array( 'language', 'category', 'post_tag' ) );
+			$taxonomies = array_diff( $taxonomies, [ 'language', 'category', 'post_tag' ] );
 
 			// Remove pages query when the language is set unless we do a search
 			// Take care not to break the single page, attachment and taxonomies queries!
@@ -178,7 +178,7 @@ class PLL_Frontend extends PLL_Base {
 				$restore_curlang = $this->curlang->slug; // To always remember the current language through blogs
 			}
 
-			$lang = $this->model->get_language( $restore_curlang );
+			$lang          = $this->model->get_language( $restore_curlang );
 			$this->curlang = $lang ? $lang : $this->model->get_language( $this->options['default_lang'] );
 
 			if ( isset( $this->static_pages ) ) {

--- a/include/api.php
+++ b/include/api.php
@@ -193,7 +193,7 @@ function pll_esc_attr_e( $string ) {
  * @return string the string translation in the requested language
  */
 function pll_translate_string( $string, $lang ) {
-	if ( PLL() instanceof PLL_Frontend && pll_current_language() == $lang ) {
+	if ( PLL() instanceof PLL_Frontend && pll_current_language() === $lang ) {
 		return pll__( $string );
 	}
 

--- a/include/api.php
+++ b/include/api.php
@@ -253,8 +253,8 @@ function pll_is_translated_taxonomy( $tax ) {
  * @param array $args list of parameters
  * @return array
  */
-function pll_languages_list( $args = array() ) {
-	$args = wp_parse_args( $args, array( 'fields' => 'slug' ) );
+function pll_languages_list( $args = [] ) {
+	$args = wp_parse_args( $args, [ 'fields' => 'slug' ] );
 	return PLL()->model->get_languages_list( $args );
 }
 
@@ -363,7 +363,7 @@ function pll_get_term_translations( $term_id ) {
  * @param array  $args ( accepted keys: post_type, m, year, monthnum, day, author, author_name, post_format )
  * @return int posts count
  */
-function pll_count_posts( $lang, $args = array() ) {
+function pll_count_posts( $lang, $args = [] ) {
 	return PLL()->model->count_posts( PLL()->model->get_language( $lang ), $args );
 }
 

--- a/include/base.php
+++ b/include/base.php
@@ -109,7 +109,7 @@ abstract class PLL_Base {
 		foreach ( $this as $prop => &$obj ) {
 			if ( is_object( $obj ) && method_exists( $obj, $func ) ) {
 				if ( WP_DEBUG ) {
-					$debug = debug_backtrace();
+					$debug = debug_backtrace( 1, 3 );
 					$i     = 1 + empty( $debug[1]['line'] ); // The file and line are in $debug[2] if the function was called using call_user_func
 					trigger_error(
 						sprintf(
@@ -122,7 +122,7 @@ abstract class PLL_Base {
 			}
 		}
 
-		$debug = debug_backtrace();
+		$debug = debug_backtrace( 1, 1 );
 		trigger_error( sprintf( 'Call to undefined function PLL()->%1$s() in %2$s on line %3$s' . "\nError handler", $func, $debug[0]['file'], $debug[0]['line'] ), E_USER_ERROR );
 	}
 }

--- a/include/base.php
+++ b/include/base.php
@@ -87,7 +87,7 @@ abstract class PLL_Base {
 
 		// 2nd test needed when Polylang is not networked activated
 		// 3rd test needed when Polylang is networked activated and a new site is created
-		if ( $new_blog != $old_blog && in_array( POLYLANG_BASENAME, $plugins ) && get_option( 'polylang' ) ) {
+		if ( $new_blog !== $old_blog && in_array( POLYLANG_BASENAME, $plugins, true ) && get_option( 'polylang' ) ) {
 			$this->options     = get_option( 'polylang' ); // Needed for menus
 			$this->links_model = $this->model->get_links_model();
 			return true;

--- a/include/base.php
+++ b/include/base.php
@@ -17,19 +17,19 @@ abstract class PLL_Base {
 	 */
 	public function __construct( &$links_model ) {
 		$this->links_model = &$links_model;
-		$this->model = &$links_model->model;
-		$this->options = &$this->model->options;
+		$this->model       = &$links_model->model;
+		$this->options     = &$this->model->options;
 
 		$GLOBALS['l10n_unloaded']['pll_string'] = true; // Short-circuit _load_textdomain_just_in_time() for 'pll_string' domain in WP 4.6+
 
-		add_action( 'widgets_init', array( $this, 'widgets_init' ) );
+		add_action( 'widgets_init', [ $this, 'widgets_init' ] );
 
 		// User defined strings translations
-		add_action( 'pll_language_defined', array( $this, 'load_strings_translations' ), 5 );
-		add_action( 'change_locale', array( $this, 'load_strings_translations' ) ); // Since WP 4.7
+		add_action( 'pll_language_defined', [ $this, 'load_strings_translations' ], 5 );
+		add_action( 'change_locale', [ $this, 'load_strings_translations' ] ); // Since WP 4.7
 
 		// Switch_to_blog
-		add_action( 'switch_blog', array( $this, 'switch_blog' ), 10, 2 );
+		add_action( 'switch_blog', [ $this, 'switch_blog' ], 10, 2 );
 	}
 
 	/**
@@ -82,13 +82,13 @@ abstract class PLL_Base {
 	 * @return bool not used by WP but by child class
 	 */
 	public function switch_blog( $new_blog, $old_blog ) {
-		$plugins = ( $sitewide_plugins = get_site_option( 'active_sitewide_plugins' ) ) && is_array( $sitewide_plugins ) ? array_keys( $sitewide_plugins ) : array();
-		$plugins = array_merge( $plugins, get_option( 'active_plugins', array() ) );
+		$plugins = ( $sitewide_plugins = get_site_option( 'active_sitewide_plugins' ) ) && is_array( $sitewide_plugins ) ? array_keys( $sitewide_plugins ) : [];
+		$plugins = array_merge( $plugins, get_option( 'active_plugins', [] ) );
 
 		// 2nd test needed when Polylang is not networked activated
 		// 3rd test needed when Polylang is networked activated and a new site is created
 		if ( $new_blog != $old_blog && in_array( POLYLANG_BASENAME, $plugins ) && get_option( 'polylang' ) ) {
-			$this->options = get_option( 'polylang' ); // Needed for menus
+			$this->options     = get_option( 'polylang' ); // Needed for menus
 			$this->links_model = $this->model->get_links_model();
 			return true;
 		}
@@ -110,13 +110,15 @@ abstract class PLL_Base {
 			if ( is_object( $obj ) && method_exists( $obj, $func ) ) {
 				if ( WP_DEBUG ) {
 					$debug = debug_backtrace();
-					$i = 1 + empty( $debug[1]['line'] ); // The file and line are in $debug[2] if the function was called using call_user_func
-					trigger_error( sprintf(
-						'%1$s was called incorrectly in %3$s on line %4$s: the call to $polylang->%1$s() has been deprecated in Polylang 1.2, use PLL()->%2$s->%1$s() instead.' . "\nError handler",
-						$func, $prop, $debug[ $i ]['file'], $debug[ $i ]['line']
-					) );
+					$i     = 1 + empty( $debug[1]['line'] ); // The file and line are in $debug[2] if the function was called using call_user_func
+					trigger_error(
+						sprintf(
+							'%1$s was called incorrectly in %3$s on line %4$s: the call to $polylang->%1$s() has been deprecated in Polylang 1.2, use PLL()->%2$s->%1$s() instead.' . "\nError handler",
+							$func, $prop, $debug[ $i ]['file'], $debug[ $i ]['line']
+						)
+					);
 				}
-				return call_user_func_array( array( $obj, $func ), $args );
+				return call_user_func_array( [ $obj, $func ], $args );
 			}
 		}
 

--- a/include/cache.php
+++ b/include/cache.php
@@ -16,7 +16,7 @@ class PLL_Cache {
 	 */
 	public function __construct() {
 		$this->blog_id = get_current_blog_id();
-		add_action( 'switch_blog', array( $this, 'switch_blog' ) );
+		add_action( 'switch_blog', [ $this, 'switch_blog' ] );
 	}
 
 	/**
@@ -64,8 +64,7 @@ class PLL_Cache {
 	public function clean( $key = '' ) {
 		if ( empty( $key ) ) {
 			unset( $this->cache[ $this->blog_id ] );
-		}
-		else {
+		} else {
 			unset( $this->cache[ $this->blog_id ][ $key ] );
 		}
 	}

--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -28,7 +28,7 @@ class Polylang {
 	 */
 	public function __construct() {
 		require_once PLL_INC . '/functions.php'; // VIP functions
-		spl_autoload_register( array( $this, 'autoload' ) ); // Autoload classes
+		spl_autoload_register( [ $this, 'autoload' ] ); // Autoload classes
 
 		$install = new PLL_Install( POLYLANG_BASENAME );
 
@@ -39,7 +39,7 @@ class Polylang {
 
 		// Plugin initialization
 		// Take no action before all plugins are loaded
-		add_action( 'plugins_loaded', array( $this, 'init' ), 1 );
+		add_action( 'plugins_loaded', [ $this, 'init' ], 1 );
 
 		// Override load text domain waiting for the language to be defined
 		// Here for plugins which load text domain as soon as loaded :(
@@ -67,11 +67,11 @@ class Polylang {
 			return;
 		}
 
-		$class = str_replace( '_', '-', strtolower( substr( $class, 4 ) ) );
-		$to_find = array( 'media', 'share', 'slug', 'slugs', 'sync', 'translate', 'wpml', 'xdata', 'rest' );
-		$dir = implode( '-', array_intersect( explode( '-', $class ), $to_find ) );
+		$class   = str_replace( '_', '-', strtolower( substr( $class, 4 ) ) );
+		$to_find = [ 'media', 'share', 'slug', 'slugs', 'sync', 'translate', 'wpml', 'xdata', 'rest' ];
+		$dir     = implode( '-', array_intersect( explode( '-', $class ), $to_find ) );
 
-		$dirs = array(
+		$dirs = [
 			PLL_FRONT_INC,
 			PLL_MODULES_INC,
 			PLL_MODULES_INC . "/$dir",
@@ -80,7 +80,7 @@ class Polylang {
 			PLL_ADMIN_INC,
 			PLL_SETTINGS_INC,
 			PLL_INC,
-		);
+		];
 
 		foreach ( $dirs as $dir ) {
 			if ( file_exists( $file = "$dir/$class.php" ) ) {
@@ -100,7 +100,7 @@ class Polylang {
 	static public function is_ajax_on_front() {
 		// Special test for plupload which does not use jquery ajax and thus does not pass our ajax prefilter
 		// Special test for customize_save done in frontend but for which we want to load the admin
-		$in = isset( $_REQUEST['action'] ) && in_array( $_REQUEST['action'], array( 'upload-attachment', 'customize_save' ) );
+		$in               = isset( $_REQUEST['action'] ) && in_array( $_REQUEST['action'], [ 'upload-attachment', 'customize_save' ] );
 		$is_ajax_on_front = wp_doing_ajax() && empty( $_REQUEST['pll_ajax_backend'] ) && ! $in;
 
 		/**
@@ -162,7 +162,7 @@ class Polylang {
 		}
 
 		// Make sure that this filter is *always* added before PLL_Model::get_languages_list() is called for the first time
-		add_filter( 'pll_languages_list', array( 'PLL_Static_Pages', 'pll_languages_list' ), 2, 2 ); // Before PLL_Links_Model
+		add_filter( 'pll_languages_list', [ 'PLL_Static_Pages', 'pll_languages_list' ], 2, 2 ); // Before PLL_Links_Model
 
 		/**
 		 * Filter the model class to use
@@ -172,17 +172,15 @@ class Polylang {
 		 *
 		 * @param string $class either PLL_Model or PLL_Admin_Model
 		 */
-		$class = apply_filters( 'pll_model', PLL_SETTINGS ? 'PLL_Admin_Model' : 'PLL_Model' );
-		$model = new $class( $options );
+		$class       = apply_filters( 'pll_model', PLL_SETTINGS ? 'PLL_Admin_Model' : 'PLL_Model' );
+		$model       = new $class( $options );
 		$links_model = $model->get_links_model();
 
 		if ( PLL_SETTINGS ) {
 			$polylang = new PLL_Settings( $links_model );
-		}
-		elseif ( PLL_ADMIN ) {
+		} elseif ( PLL_ADMIN ) {
 			$polylang = new PLL_Admin( $links_model );
-		}
-		// Do nothing on frontend if no language is defined
+		} // Do nothing on frontend if no language is defined
 		elseif ( $model->get_languages_list() && empty( $_GET['deactivate-polylang'] ) ) {
 			$polylang = new PLL_Frontend( $links_model );
 		}
@@ -205,7 +203,7 @@ class Polylang {
 			 *
 			 * @param object $polylang
 			 */
-			do_action_ref_array( 'pll_pre_init', array( &$polylang ) );
+			do_action_ref_array( 'pll_pre_init', [ &$polylang ] );
 
 			require_once PLL_INC . '/api.php'; // Loads the API
 
@@ -223,7 +221,7 @@ class Polylang {
 			 *
 			 * @param object $polylang
 			 */
-			do_action_ref_array( 'pll_init', array( &$polylang ) );
+			do_action_ref_array( 'pll_init', [ &$polylang ] );
 		}
 	}
 }

--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -100,7 +100,7 @@ class Polylang {
 	static public function is_ajax_on_front() {
 		// Special test for plupload which does not use jquery ajax and thus does not pass our ajax prefilter
 		// Special test for customize_save done in frontend but for which we want to load the admin
-		$in               = isset( $_REQUEST['action'] ) && in_array( $_REQUEST['action'], [ 'upload-attachment', 'customize_save' ] );
+		$in               = isset( $_REQUEST['action'] ) && in_array( $_REQUEST['action'], [ 'upload-attachment', 'customize_save' ], true );
 		$is_ajax_on_front = wp_doing_ajax() && empty( $_REQUEST['pll_ajax_backend'] ) && ! $in;
 
 		/**

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -16,31 +16,31 @@ class PLL_Filters_Links {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
-		$this->links = &$polylang->links;
+		$this->links       = &$polylang->links;
 		$this->links_model = &$polylang->links_model;
-		$this->model = &$polylang->model;
-		$this->options = &$polylang->options;
-		$this->curlang = &$polylang->curlang;
+		$this->model       = &$polylang->model;
+		$this->options     = &$polylang->options;
+		$this->curlang     = &$polylang->curlang;
 
 		// Low priority on links filters to come after any other modifications
 		if ( $this->options['force_lang'] ) {
-			add_filter( 'post_link', array( $this, 'post_type_link' ), 20, 2 );
-			add_filter( '_get_page_link', array( $this, '_get_page_link' ), 20, 2 );
+			add_filter( 'post_link', [ $this, 'post_type_link' ], 20, 2 );
+			add_filter( '_get_page_link', [ $this, '_get_page_link' ], 20, 2 );
 		}
 
-		add_filter( 'post_type_link', array( $this, 'post_type_link' ), 20, 2 );
-		add_filter( 'term_link', array( $this, 'term_link' ), 20, 3 );
+		add_filter( 'post_type_link', [ $this, 'post_type_link' ], 20, 2 );
+		add_filter( 'term_link', [ $this, 'term_link' ], 20, 3 );
 
 		if ( $this->options['force_lang'] > 0 ) {
-			add_filter( 'attachment_link', array( $this, 'attachment_link' ), 20, 2 );
+			add_filter( 'attachment_link', [ $this, 'attachment_link' ], 20, 2 );
 		}
 
 		if ( 3 === $this->options['force_lang'] ) {
-			add_filter( 'preview_post_link', array( $this, 'preview_post_link' ), 20 );
+			add_filter( 'preview_post_link', [ $this, 'preview_post_link' ], 20 );
 		}
 
 		// Rewrites post types archives links to filter them by language
-		add_filter( 'post_type_archive_link', array( $this, 'post_type_archive_link' ), 20, 2 );
+		add_filter( 'post_type_archive_link', [ $this, 'post_type_archive_link' ], 20, 2 );
 	}
 
 	/**

--- a/include/filters.php
+++ b/include/filters.php
@@ -166,7 +166,7 @@ class PLL_Filters {
 			$ids = array_intersect( $ids, $this->model->post->get_objects_in_language( $language ) );
 
 			foreach ( $pages as $key => $page ) {
-				if ( ! in_array( $page->ID, $ids ) ) {
+				if ( ! in_array( $page->ID, $ids, true ) ) {
 					unset( $pages[ $key ] );
 				}
 			}

--- a/include/language.php
+++ b/include/language.php
@@ -58,17 +58,15 @@ class PLL_Language {
 			foreach ( $language as $prop => $value ) {
 				$this->$prop = $value;
 			}
-		}
-
-		// Build the object from taxonomies
+		} // Build the object from taxonomies
 		else {
 			foreach ( $language as $prop => $value ) {
-				$this->$prop = in_array( $prop, array( 'term_id', 'term_taxonomy_id', 'count' ) ) ? (int) $language->$prop : $language->$prop;
+				$this->$prop = in_array( $prop, [ 'term_id', 'term_taxonomy_id', 'count' ] ) ? (int) $language->$prop : $language->$prop;
 			}
 
-			$this->tl_term_id = (int) $term_language->term_id;
+			$this->tl_term_id          = (int) $term_language->term_id;
 			$this->tl_term_taxonomy_id = (int) $term_language->term_taxonomy_id;
-			$this->tl_count = (int) $term_language->count;
+			$this->tl_count            = (int) $term_language->count;
 
 			// The description field can contain any property
 			// Backward compatibility for is_rtl
@@ -111,7 +109,7 @@ class PLL_Language {
 
 		// Custom flags ?
 		if ( file_exists( PLL_LOCAL_DIR . ( $file = '/' . $this->locale . '.png' ) ) || file_exists( PLL_LOCAL_DIR . ( $file = '/' . $this->locale . '.jpg' ) ) ) {
-			$url = content_url( '/polylang' . $file );
+			$url                         = content_url( '/polylang' . $file );
 			$flags['custom_flag']['url'] = esc_url_raw( $url );
 			$flags['custom_flag']['src'] = esc_url( $url );
 		}
@@ -139,7 +137,8 @@ class PLL_Language {
 			 * @param string $flag html markup of the flag or empty string
 			 * @param string $slug language code
 			 */
-			$this->{$key} = apply_filters( 'pll_get_flag', empty( $flag['src'] ) ? '' :
+			$this->{$key} = apply_filters(
+				'pll_get_flag', empty( $flag['src'] ) ? '' :
 				sprintf(
 					'<img src="%s" title="%s" alt="%s" />',
 					$flag['src'],
@@ -160,17 +159,17 @@ class PLL_Language {
 	public function set_custom_flag() {
 		// Overwrite with custom flags on frontend only
 		if ( ! empty( $this->custom_flag ) ) {
-			$this->flag = $this->custom_flag;
+			$this->flag     = $this->custom_flag;
 			$this->flag_url = $this->custom_flag_url;
 			unset( $this->custom_flag, $this->custom_flag_url ); // hide this
 		}
 
 		// Set url scheme, also for default flags
 		if ( is_ssl() ) {
-			$this->flag = str_replace( 'http://', 'https://', $this->flag );
+			$this->flag     = str_replace( 'http://', 'https://', $this->flag );
 			$this->flag_url = str_replace( 'http://', 'https://', $this->flag_url );
 		} else {
-			$this->flag = str_replace( 'https://', 'http://', $this->flag );
+			$this->flag     = str_replace( 'https://', 'http://', $this->flag );
 			$this->flag_url = str_replace( 'https://', 'http://', $this->flag_url );
 		}
 	}
@@ -195,7 +194,7 @@ class PLL_Language {
 	 */
 	public function set_home_url( $search_url, $home_url ) {
 		$this->search_url = $search_url;
-		$this->home_url = $home_url;
+		$this->home_url   = $home_url;
 	}
 
 	/**
@@ -206,12 +205,10 @@ class PLL_Language {
 	 */
 	public function set_home_url_scheme() {
 		if ( is_ssl() ) {
-			$this->home_url = str_replace( 'http://', 'https://', $this->home_url );
+			$this->home_url   = str_replace( 'http://', 'https://', $this->home_url );
 			$this->search_url = str_replace( 'http://', 'https://', $this->search_url );
-		}
-
-		else {
-			$this->home_url = str_replace( 'https://', 'http://', $this->home_url );
+		} else {
+			$this->home_url   = str_replace( 'https://', 'http://', $this->home_url );
 			$this->search_url = str_replace( 'https://', 'http://', $this->search_url );
 		}
 	}

--- a/include/language.php
+++ b/include/language.php
@@ -61,7 +61,7 @@ class PLL_Language {
 		} // Build the object from taxonomies
 		else {
 			foreach ( $language as $prop => $value ) {
-				$this->$prop = in_array( $prop, [ 'term_id', 'term_taxonomy_id', 'count' ] ) ? (int) $language->$prop : $language->$prop;
+				$this->$prop = in_array( $prop, [ 'term_id', 'term_taxonomy_id', 'count' ], true ) ? (int) $language->$prop : $language->$prop;
 			}
 
 			$this->tl_term_id          = (int) $term_language->term_id;
@@ -72,7 +72,7 @@ class PLL_Language {
 			// Backward compatibility for is_rtl
 			$description = maybe_unserialize( $language->description );
 			foreach ( $description as $prop => $value ) {
-				'rtl' == $prop ? $this->is_rtl = $value : $this->$prop = $value;
+				'rtl' === $prop ? $this->is_rtl = $value : $this->$prop = $value;
 			}
 
 			$this->description = &$this->locale; // Backward compatibility with Polylang < 1.2

--- a/include/license.php
+++ b/include/license.php
@@ -29,24 +29,24 @@ class PLL_License {
 		$this->author  = $author;
 		$this->api_url = empty( $api_url ) ? $this->api_url : $api_url;
 
-		$licenses = get_option( 'polylang_licenses' );
+		$licenses          = get_option( 'polylang_licenses' );
 		$this->license_key = empty( $licenses[ $this->id ]['key'] ) ? '' : $licenses[ $this->id ]['key'];
 		if ( ! empty( $licenses[ $this->id ]['data'] ) ) {
 			$this->license_data = $licenses[ $this->id ]['data'];
 		}
 
 		// Updater
-		add_action( 'admin_init', array( $this, 'auto_updater' ), 0 );
+		add_action( 'admin_init', [ $this, 'auto_updater' ], 0 );
 
 		// Register settings
-		add_filter( 'pll_settings_licenses', array( $this, 'settings' ) );
+		add_filter( 'pll_settings_licenses', [ $this, 'settings' ] );
 
 		// Weekly schedule
 		if ( ! wp_next_scheduled( 'polylang_check_licenses' ) ) {
 			wp_schedule_event( time(), 'weekly', 'polylang_check_licenses' );
 		}
 
-		add_action( 'polylang_check_licenses', array( $this, 'check_license' ) );
+		add_action( 'polylang_check_licenses', [ $this, 'check_license' ] );
 	}
 
 	/**
@@ -55,12 +55,12 @@ class PLL_License {
 	 * @since 1.9
 	 */
 	public function auto_updater() {
-		$args = array(
+		$args = [
 			'version'   => $this->version,
 			'license'   => $this->license_key,
 			'author'    => $this->author,
 			'item_name' => $this->name,
-		);
+		];
 
 		// Setup the updater
 		new PLL_Plugin_Updater( $this->api_url, $this->file, $args );
@@ -135,21 +135,21 @@ class PLL_License {
 
 		if ( ! empty( $this->license_key ) ) {
 			// Data to send in our API request
-			$api_params = array(
+			$api_params = [
 				'edd_action' => $request,
 				'license'    => $this->license_key,
 				'item_name'  => urlencode( $this->name ),
 				'url'        => home_url(),
-			);
+			];
 
 			// Call the API
 			$response = wp_remote_post(
 				$this->api_url,
-				array(
+				[
 					'timeout'   => 15,
 					'sslverify' => false,
 					'body'      => $api_params,
-				)
+				]
 			);
 
 			// Update the option only if we got a response
@@ -158,8 +158,8 @@ class PLL_License {
 			}
 
 			// Save new license info
-			$licenses[ $this->id ] = array( 'key' => $this->license_key );
-			$data = json_decode( wp_remote_retrieve_body( $response ) );
+			$licenses[ $this->id ] = [ 'key' => $this->license_key ];
+			$data                  = json_decode( wp_remote_retrieve_body( $response ) );
 
 			if ( 'deactivated' !== $data->license ) {
 				$licenses[ $this->id ]['data'] = $this->license_data = $data;

--- a/include/links-abstract-domain.php
+++ b/include/links-abstract-domain.php
@@ -18,10 +18,10 @@ abstract class PLL_Links_Abstract_Domain extends PLL_Links_Permalinks {
 		parent::__construct( $model );
 
 		// Avoid cross domain requests ( mainly for custom fonts )
-		add_filter( 'content_url', array( $this, 'site_url' ) );
-		add_filter( 'plugins_url', array( $this, 'site_url' ) );
-		add_filter( 'rest_url', array( $this, 'site_url' ) );
-		add_filter( 'upload_dir', array( $this, 'upload_dir' ) );
+		add_filter( 'content_url', [ $this, 'site_url' ] );
+		add_filter( 'plugins_url', [ $this, 'site_url' ] );
+		add_filter( 'rest_url', [ $this, 'site_url' ] );
+		add_filter( 'upload_dir', [ $this, 'upload_dir' ] );
 	}
 
 	/**
@@ -35,7 +35,7 @@ abstract class PLL_Links_Abstract_Domain extends PLL_Links_Permalinks {
 	 * @return string language slug
 	 */
 	public function get_language_from_url( $url = '' ) {
-		$host = empty( $url ) ? $_SERVER['HTTP_HOST'] : parse_url( $url, PHP_URL_HOST );
+		$host          = empty( $url ) ? $_SERVER['HTTP_HOST'] : parse_url( $url, PHP_URL_HOST );
 		return ( $lang = array_search( $host, $this->get_hosts() ) ) ? $lang : '';
 	}
 
@@ -74,9 +74,9 @@ abstract class PLL_Links_Abstract_Domain extends PLL_Links_Permalinks {
 	 * @return array
 	 */
 	public function upload_dir( $uploads ) {
-		$lang = $this->get_language_from_url();
-		$lang = $this->model->get_language( $lang );
-		$uploads['url'] = $this->add_language_to_link( $uploads['url'], $lang );
+		$lang               = $this->get_language_from_url();
+		$lang               = $this->model->get_language( $lang );
+		$uploads['url']     = $this->add_language_to_link( $uploads['url'], $lang );
 		$uploads['baseurl'] = $this->add_language_to_link( $uploads['baseurl'], $lang );
 		return $uploads;
 	}

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -60,7 +60,7 @@ class PLL_Links_Default extends PLL_Links_Model {
 	 * @return string modified url
 	 */
 	public function add_paged_to_link( $url, $page ) {
-		return add_query_arg( array( 'paged' => $page ), $url );
+		return add_query_arg( [ 'paged' => $page ], $url );
 	}
 
 	/**
@@ -78,7 +78,7 @@ class PLL_Links_Default extends PLL_Links_Model {
 			$url = $_SERVER['REQUEST_URI'];
 		}
 
-		$pattern = '#lang=(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')#';
+		$pattern = '#lang=(' . implode( '|', $this->model->get_languages_list( [ 'fields' => 'slug' ] ) ) . ')#';
 		return preg_match( $pattern, trailingslashit( $url ), $matches ) ? $matches[1] : ''; // $matches[1] is the slug of the requested language
 	}
 

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -21,7 +21,7 @@ class PLL_Links_Default extends PLL_Links_Model {
 	 * @return string modified url
 	 */
 	public function add_language_to_link( $url, $lang ) {
-		return empty( $lang ) || ( $this->options['hide_default'] && $this->options['default_lang'] == $lang->slug ) ? $url : add_query_arg( 'lang', $lang->slug, $url );
+		return empty( $lang ) || ( $this->options['hide_default'] && $this->options['default_lang'] === $lang->slug ) ? $url : add_query_arg( 'lang', $lang->slug, $url );
 	}
 
 	/**
@@ -91,7 +91,7 @@ class PLL_Links_Default extends PLL_Links_Model {
 	 * @return string
 	 */
 	public function front_page_url( $lang ) {
-		if ( $this->options['hide_default'] && $lang->slug == $this->options['default_lang'] ) {
+		if ( $this->options['hide_default'] && $lang->slug === $this->options['default_lang'] ) {
 			return trailingslashit( $this->home );
 		}
 		$url = home_url( '/?page_id=' . $lang->page_on_front );

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -25,7 +25,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		if ( did_action( 'pll_init' ) ) {
 			$this->init();
 		} else {
-			add_action( 'pll_init', array( $this, 'init' ) );
+			add_action( 'pll_init', [ $this, 'init' ] );
 		}
 	}
 
@@ -38,11 +38,11 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		if ( did_action( 'setup_theme' ) ) {
 			$this->add_permastruct();
 		} else {
-			add_action( 'setup_theme', array( $this, 'add_permastruct' ), 2 );
+			add_action( 'setup_theme', [ $this, 'add_permastruct' ], 2 );
 		}
 
 		// Make sure to prepare rewrite rules when flushing
-		add_action( 'pre_option_rewrite_rules', array( $this, 'prepare_rewrite_rules' ) );
+		add_action( 'pre_option_rewrite_rules', [ $this, 'prepare_rewrite_rules' ] );
 	}
 
 	/**
@@ -91,7 +91,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 
 			$pattern = str_replace( '/', '\/', $root );
 			$pattern = '#' . $pattern . ( $this->options['rewrite'] ? '' : 'language\/' ) . '(' . implode( '|', $languages ) . ')(\/|$)#';
-			$url = preg_replace( $pattern, $root, $url );
+			$url     = preg_replace( $pattern, $root, $url );
 		}
 		return $url;
 	}
@@ -117,7 +117,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 
 		$pattern = parse_url( $root . ( $this->options['rewrite'] ? '' : 'language/' ), PHP_URL_PATH );
 		$pattern = str_replace( '/', '\/', $pattern );
-		$pattern = '#' . $pattern . '(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')(\/|$)#';
+		$pattern = '#' . $pattern . '(' . implode( '|', $this->model->get_languages_list( [ 'fields' => 'slug' ] ) ) . ')(\/|$)#';
 		return preg_match( $pattern, trailingslashit( $path ), $matches ) ? $matches[1] : ''; // $matches[1] is the slug of the requested language
 	}
 
@@ -146,7 +146,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		// The 3rd parameter structure has been modified in WP 3.4
 		// Leads to error 404 for pages when there is no language created yet
 		if ( $this->model->get_languages_list() ) {
-			add_permastruct( 'language', $this->options['rewrite'] ? '%language%' : 'language/%language%', array( 'with_front' => false ) );
+			add_permastruct( 'language', $this->options['rewrite'] ? '%language%' : 'language/%language%', [ 'with_front' => false ] );
 		}
 	}
 
@@ -166,10 +166,10 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 			add_filter( 'language_rewrite_rules', '__return_empty_array' );
 
 			foreach ( $this->get_rewrite_rules_filters() as $type ) {
-				add_filter( $type . '_rewrite_rules', array( $this, 'rewrite_rules' ) );
+				add_filter( $type . '_rewrite_rules', [ $this, 'rewrite_rules' ] );
 			}
 
-			add_filter( 'rewrite_rules_array', array( $this, 'rewrite_rules' ) ); // needed for post type archives
+			add_filter( 'rewrite_rules_array', [ $this, 'rewrite_rules' ] ); // needed for post type archives
 		}
 		return $pre;
 	}
@@ -188,11 +188,11 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		$filter = str_replace( '_rewrite_rules', '', current_filter() );
 
 		global $wp_rewrite;
-		$newrules = array();
+		$newrules = [];
 
-		$languages = $this->model->get_languages_list( array( 'fields' => 'slug' ) );
+		$languages = $this->model->get_languages_list( [ 'fields' => 'slug' ] );
 		if ( $this->options['hide_default'] ) {
-			$languages = array_diff( $languages, array( $this->options['default_lang'] ) );
+			$languages = array_diff( $languages, [ $this->options['default_lang'] ] );
 		}
 
 		if ( ! empty( $languages ) ) {
@@ -200,7 +200,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		}
 
 		// For custom post type archives
-		$cpts = array_intersect( $this->model->get_translated_post_types(), get_post_types( array( '_builtin' => false ) ) );
+		$cpts = array_intersect( $this->model->get_translated_post_types(), get_post_types( [ '_builtin' => false ] ) );
 		$cpts = $cpts ? '#post_type=(' . implode( '|', $cpts ) . ')#' : '';
 
 		foreach ( $rules as $key => $rule ) {
@@ -217,26 +217,24 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 				 * @param string      $filter  current set of rules being modified
 				 * @param string|bool $archive custom post post type archive name or false if it is not a cpt archive
 				 */
-				if ( isset( $slug ) && apply_filters( 'pll_modify_rewrite_rule', true, array( $key => $rule ), $filter, false ) ) {
+				if ( isset( $slug ) && apply_filters( 'pll_modify_rewrite_rule', true, [ $key => $rule ], $filter, false ) ) {
 					$newrules[ $slug . str_replace( $wp_rewrite->root, '', ltrim( $key, '^' ) ) ] = str_replace(
-						array( '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '[1]', '?' ),
-						array( '[9]', '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '?lang=$matches[1]&' ),
+						[ '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '[1]', '?' ],
+						[ '[9]', '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '?lang=$matches[1]&' ],
 						$rule
 					); // Should be enough!
 				}
 
 				$newrules[ $key ] = $rule;
-			}
-
-			// Rewrite rules filtered by language
+			} // Rewrite rules filtered by language
 			elseif ( in_array( $filter, $this->always_rewrite ) || in_array( $filter, $this->model->get_filtered_taxonomies() ) || ( $cpts && preg_match( $cpts, $rule, $matches ) && ! strpos( $rule, 'name=' ) ) || ( 'rewrite_rules_array' != $filter && $this->options['force_lang'] ) ) {
 
 				/** This filter is documented in include/links-directory.php */
-				if ( apply_filters( 'pll_modify_rewrite_rule', true, array( $key => $rule ), $filter, empty( $matches[1] ) ? false : $matches[1] ) ) {
+				if ( apply_filters( 'pll_modify_rewrite_rule', true, [ $key => $rule ], $filter, empty( $matches[1] ) ? false : $matches[1] ) ) {
 					if ( isset( $slug ) ) {
 						$newrules[ $slug . str_replace( $wp_rewrite->root, '', ltrim( $key, '^' ) ) ] = str_replace(
-							array( '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '[1]', '?' ),
-							array( '[9]', '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '?lang=$matches[1]&' ),
+							[ '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '[1]', '?' ],
+							[ '[9]', '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '?lang=$matches[1]&' ],
 							$rule
 						); // Should be enough!
 					}
@@ -247,9 +245,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 				} else {
 					$newrules[ $key ] = $rule;
 				}
-			}
-
-			// Unmodified rules
+			} // Unmodified rules
 			else {
 				$newrules[ $key ] = $rule;
 			}

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -58,7 +58,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) ) {
 			$base = $this->options['rewrite'] ? '' : 'language/';
-			$slug = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : $base . $lang->slug . '/';
+			$slug = $this->options['default_lang'] === $lang->slug && $this->options['hide_default'] ? '' : $base . $lang->slug . '/';
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : $this->home . '/' . $this->root;
 
 			if ( false === strpos( $url, $new = $root . $slug ) ) {
@@ -81,7 +81,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	 */
 	function remove_language_from_link( $url ) {
 		foreach ( $this->model->get_languages_list() as $language ) {
-			if ( ! $this->options['hide_default'] || $this->options['default_lang'] != $language->slug ) {
+			if ( ! $this->options['hide_default'] || $this->options['default_lang'] !== $language->slug ) {
 				$languages[] = $language->slug;
 			}
 		}
@@ -132,7 +132,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	 */
 	public function home_url( $lang ) {
 		$base = $this->options['rewrite'] ? '' : 'language/';
-		$slug = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : '/' . $this->root . $base . $lang->slug;
+		$slug = $this->options['default_lang'] === $lang->slug && $this->options['hide_default'] ? '' : '/' . $this->root . $base . $lang->slug;
 		return trailingslashit( $this->home . $slug );
 	}
 
@@ -205,7 +205,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 
 		foreach ( $rules as $key => $rule ) {
 			// Special case for translated post types and taxonomies to allow canonical redirection
-			if ( $this->options['force_lang'] && in_array( $filter, array_merge( $this->model->get_translated_post_types(), $this->model->get_translated_taxonomies() ) ) ) {
+			if ( $this->options['force_lang'] && in_array( $filter, array_merge( $this->model->get_translated_post_types(), $this->model->get_translated_taxonomies() ), true ) ) {
 
 				/**
 				 * Filters the rewrite rules to modify
@@ -227,7 +227,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 
 				$newrules[ $key ] = $rule;
 			} // Rewrite rules filtered by language
-			elseif ( in_array( $filter, $this->always_rewrite ) || in_array( $filter, $this->model->get_filtered_taxonomies() ) || ( $cpts && preg_match( $cpts, $rule, $matches ) && ! strpos( $rule, 'name=' ) ) || ( 'rewrite_rules_array' != $filter && $this->options['force_lang'] ) ) {
+			elseif ( in_array( $filter, $this->always_rewrite ) || in_array( $filter, $this->model->get_filtered_taxonomies(), true ) || ( $cpts && preg_match( $cpts, $rule, $matches ) && ! strpos( $rule, 'name=' ) ) || ( 'rewrite_rules_array' !== $filter && $this->options['force_lang'] ) ) {
 
 				/** This filter is documented in include/links-directory.php */
 				if ( apply_filters( 'pll_modify_rewrite_rule', true, [ $key => $rule ], $filter, empty( $matches[1] ) ? false : $matches[1] ) ) {
@@ -252,7 +252,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		}
 
 		// The home rewrite rule
-		if ( 'root' == $filter && isset( $slug ) ) {
+		if ( 'root' === $filter && isset( $slug ) ) {
 			$newrules[ $slug . '?$' ] = $wp_rewrite->index . '?lang=$matches[1]';
 		}
 

--- a/include/links-domain.php
+++ b/include/links-domain.php
@@ -22,7 +22,7 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 		$this->hosts = $this->get_hosts();
 
 		// Filter the site url ( mainly to get the correct login form )
-		add_filter( 'site_url', array( $this, 'site_url' ) );
+		add_filter( 'site_url', [ $this, 'site_url' ] );
 	}
 
 
@@ -80,7 +80,7 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 	 * @return array list of hosts
 	 */
 	public function get_hosts() {
-		$hosts = array();
+		$hosts = [];
 		foreach ( $this->options['domains'] as $lang => $domain ) {
 			$hosts[ $lang ] = parse_url( $domain, PHP_URL_HOST );
 		}

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -18,16 +18,16 @@ abstract class PLL_Links_Model {
 	 * @param object $model PLL_Model instance
 	 */
 	public function __construct( &$model ) {
-		$this->model = &$model;
+		$this->model   = &$model;
 		$this->options = &$model->options;
 
 		$this->home = home_url();
 
-		add_filter( 'pll_languages_list', array( $this, 'pll_languages_list' ), 4 ); // after PLL_Static_Pages
-		add_filter( 'pll_after_languages_cache', array( $this, 'pll_after_languages_cache' ) );
+		add_filter( 'pll_languages_list', [ $this, 'pll_languages_list' ], 4 ); // after PLL_Static_Pages
+		add_filter( 'pll_after_languages_cache', [ $this, 'pll_after_languages_cache' ] );
 
 		// adds our domains or subdomains to allowed hosts for safe redirection
-		add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
+		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );
 	}
 
 	/**
@@ -52,7 +52,7 @@ abstract class PLL_Links_Model {
 	 * @return array list of hosts
 	 */
 	public function get_hosts() {
-		return array( parse_url( $this->home, PHP_URL_HOST ) );
+		return [ parse_url( $this->home, PHP_URL_HOST ) ];
 	}
 
 	/**
@@ -77,7 +77,7 @@ abstract class PLL_Links_Model {
 	 */
 	protected function set_home_url( $language ) {
 		$search_url = $this->home_url( $language );
-		$home_url = empty( $language->page_on_front ) || $this->options['redirect_lang'] ? $search_url : $this->front_page_url( $language );
+		$home_url   = empty( $language->page_on_front ) || $this->options['redirect_lang'] ? $search_url : $this->front_page_url( $language );
 		$language->set_home_url( $search_url, $home_url );
 	}
 

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -65,7 +65,7 @@ abstract class PLL_Links_Model {
 	 */
 	public function home_url( $lang ) {
 		$url = trailingslashit( $this->home );
-		return $this->options['hide_default'] && $lang->slug == $this->options['default_lang'] ? $url : $this->add_language_to_link( $url, $lang );
+		return $this->options['hide_default'] && $lang->slug === $this->options['default_lang'] ? $url : $this->add_language_to_link( $url, $lang );
 	}
 
 	/**

--- a/include/links-permalinks.php
+++ b/include/links-permalinks.php
@@ -24,7 +24,7 @@ abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 		// Inspired by wp-includes/rewrite.php
 		$permalink_structure        = get_option( 'permalink_structure' );
 		$this->root                 = preg_match( '#^/*' . $this->index . '#', $permalink_structure ) ? $this->index . '/' : '';
-		$this->use_trailing_slashes = ( '/' == substr( $permalink_structure, -1, 1 ) );
+		$this->use_trailing_slashes = ( '/' === substr( $permalink_structure, -1, 1 ) );
 	}
 
 	/**
@@ -90,7 +90,7 @@ abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 	 * @return string
 	 */
 	public function front_page_url( $lang ) {
-		if ( $this->options['hide_default'] && $lang->slug == $this->options['default_lang'] ) {
+		if ( $this->options['hide_default'] && $lang->slug === $this->options['default_lang'] ) {
 			return trailingslashit( $this->home );
 		}
 		$url = home_url( $this->root . get_page_uri( $lang->page_on_front ) );

--- a/include/links-permalinks.php
+++ b/include/links-permalinks.php
@@ -7,9 +7,9 @@
  */
 abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 	public $using_permalinks = true;
-	protected $index = 'index.php'; // Need this before $wp_rewrite is created, also hardcoded in wp-includes/rewrite.php
+	protected $index         = 'index.php'; // Need this before $wp_rewrite is created, also hardcoded in wp-includes/rewrite.php
 	protected $root, $use_trailing_slashes;
-	protected $always_rewrite = array( 'date', 'root', 'comments', 'search', 'author' );
+	protected $always_rewrite = [ 'date', 'root', 'comments', 'search', 'author' ];
 
 	/**
 	 * Constructor
@@ -22,8 +22,8 @@ abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 		parent::__construct( $model );
 
 		// Inspired by wp-includes/rewrite.php
-		$permalink_structure = get_option( 'permalink_structure' );
-		$this->root = preg_match( '#^/*' . $this->index . '#', $permalink_structure ) ? $this->index . '/' : '';
+		$permalink_structure        = get_option( 'permalink_structure' );
+		$this->root                 = preg_match( '#^/*' . $this->index . '#', $permalink_structure ) ? $this->index . '/' : '';
 		$this->use_trailing_slashes = ( '/' == substr( $permalink_structure, -1, 1 ) );
 	}
 

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -34,7 +34,7 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 	 */
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) && false === strpos( $url, '://' . $lang->slug . '.' ) ) {
-			$url = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? $url : str_replace( $this->www, '://' . $lang->slug . '.', $url );
+			$url = $this->options['default_lang'] === $lang->slug && $this->options['hide_default'] ? $url : str_replace( $this->www, '://' . $lang->slug . '.', $url );
 		}
 		return $url;
 	}
@@ -50,7 +50,7 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 	 */
 	public function remove_language_from_link( $url ) {
 		foreach ( $this->model->get_languages_list() as $language ) {
-			if ( ! $this->options['hide_default'] || $this->options['default_lang'] != $language->slug ) {
+			if ( ! $this->options['hide_default'] || $this->options['default_lang'] !== $language->slug ) {
 				$languages[] = $language->slug;
 			}
 		}

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -70,7 +70,7 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 	 * @return array list of hosts
 	 */
 	public function get_hosts() {
-		$hosts = array();
+		$hosts = [];
 		foreach ( $this->model->get_languages_list() as $lang ) {
 			$hosts[ $lang->slug ] = parse_url( $this->home_url( $lang ), PHP_URL_HOST );
 		}

--- a/include/links.php
+++ b/include/links.php
@@ -49,15 +49,15 @@ class PLL_Links {
 			$post = get_post( $post->post_parent );
 		}
 
-		if ( 'inherit' === $post->post_status || in_array( $post->post_status, get_post_stati( [ 'public' => true ] ) ) ) {
+		if ( 'inherit' === $post->post_status || in_array( $post->post_status, get_post_stati( [ 'public' => true ] ), true ) ) {
 			return true;
 		}
 
 		// Follow WP practices, which shows links to private posts ( when readable ), but not for draft posts ( ex: get_adjacent_post_link() )
-		if ( in_array( $post->post_status, get_post_stati( [ 'private' => true ] ) ) ) {
+		if ( in_array( $post->post_status, get_post_stati( [ 'private' => true ] ), true ) ) {
 			$post_type_object = get_post_type_object( $post->post_type );
 			$user             = wp_get_current_user();
-			return is_user_logged_in() && ( current_user_can( $post_type_object->cap->read_private_posts ) || $user->ID == $post->post_author ); // Comparison must not be strict!
+			return is_user_logged_in() && ( current_user_can( $post_type_object->cap->read_private_posts ) || (int) $user->ID === (int) $post->post_author ); // Comparison must not be strict!
 		}
 
 		return false;

--- a/include/links.php
+++ b/include/links.php
@@ -17,8 +17,8 @@ class PLL_Links {
 	 */
 	public function __construct( &$polylang ) {
 		$this->links_model = &$polylang->links_model;
-		$this->model = &$polylang->model;
-		$this->options = &$polylang->options;
+		$this->model       = &$polylang->model;
+		$this->options     = &$polylang->options;
 	}
 
 	/**
@@ -49,14 +49,14 @@ class PLL_Links {
 			$post = get_post( $post->post_parent );
 		}
 
-		if ( 'inherit' === $post->post_status || in_array( $post->post_status, get_post_stati( array( 'public' => true ) ) ) ) {
+		if ( 'inherit' === $post->post_status || in_array( $post->post_status, get_post_stati( [ 'public' => true ] ) ) ) {
 			return true;
 		}
 
 		// Follow WP practices, which shows links to private posts ( when readable ), but not for draft posts ( ex: get_adjacent_post_link() )
-		if ( in_array( $post->post_status, get_post_stati( array( 'private' => true ) ) ) ) {
+		if ( in_array( $post->post_status, get_post_stati( [ 'private' => true ] ) ) ) {
 			$post_type_object = get_post_type_object( $post->post_type );
-			$user = wp_get_current_user();
+			$user             = wp_get_current_user();
 			return is_user_logged_in() && ( current_user_can( $post_type_object->cap->read_private_posts ) || $user->ID == $post->post_author ); // Comparison must not be strict!
 		}
 

--- a/include/mo.php
+++ b/include/mo.php
@@ -15,10 +15,17 @@ class PLL_MO extends MO {
 	 */
 	public function __construct() {
 		if ( ! post_type_exists( 'polylang_mo' ) ) {
-			$labels = array( 'name' => __( 'Strings translations', 'polylang' ) );
-			register_post_type( 'polylang_mo', array( 'labels' => $labels, 'rewrite' => false, 'query_var' => false, '_pll' => true ) );
+			$labels = [ 'name' => __( 'Strings translations', 'polylang' ) ];
+			register_post_type(
+				'polylang_mo', [
+					'labels' => $labels,
+					'rewrite' => false,
+					'query_var' => false,
+					'_pll' => true,
+				]
+			);
 
-			add_action( 'pll_add_language', array( $this, 'clean_cache' ) );
+			add_action( 'pll_add_language', [ $this, 'clean_cache' ] );
 		}
 	}
 
@@ -34,19 +41,19 @@ class PLL_MO extends MO {
 
 		// Would be convenient to store the whole object but it would take a huge space in DB
 		// So let's keep only the strings in an array
-		$strings = array();
+		$strings = [];
 		foreach ( $this->entries as $entry ) {
-			$strings[] = array( $entry->singular, $this->translate( $entry->singular ) );
+			$strings[] = [ $entry->singular, $this->translate( $entry->singular ) ];
 		}
 
 		$strings = wp_slash( $strings ); // Avoid breaking slashed strings in update_post_meta. See https://codex.wordpress.org/Function_Reference/update_post_meta#Character_Escaping
 
 		if ( empty( $lang->mo_id ) ) {
-			$post = array(
+			$post  = [
 				'post_title'  => 'polylang_mo_' . $lang->term_id,
 				'post_status' => 'private', // To avoid a conflict with WP Super Cache. See https://wordpress.org/support/topic/polylang_mo-and-404s-take-2
 				'post_type'   => 'polylang_mo',
-			);
+			];
 			$mo_id = wp_insert_post( $post );
 			update_post_meta( $mo_id, '_pll_strings_translations', $strings );
 		} else {

--- a/include/model.php
+++ b/include/model.php
@@ -615,7 +615,7 @@ class PLL_Model {
 
 		if ( ! empty( $o ) && is_object( $this->$o ) && method_exists( $this->$o, $f ) ) {
 			if ( WP_DEBUG ) {
-				$debug = debug_backtrace();
+				$debug = debug_backtrace( 1, 3 );
 				$i     = 1 + empty( $debug[1]['line'] ); // the file and line are in $debug[2] if the function was called using call_user_func
 
 				trigger_error(
@@ -628,7 +628,7 @@ class PLL_Model {
 			return call_user_func_array( [ $this->$o, $f ], $args );
 		}
 
-		$debug = debug_backtrace();
+		$debug = debug_backtrace( 1, 1 );
 		trigger_error( sprintf( 'Call to undefined function PLL()->model->%1$s() in %2$s on line %3$s' . "\nError handler", $func, $debug[0]['file'], $debug[0]['line'] ), E_USER_ERROR );
 	}
 }

--- a/include/model.php
+++ b/include/model.php
@@ -144,7 +144,7 @@ class PLL_Model {
 	 * @param string $taxonomy taxonomy name
 	 */
 	public function clean_languages_cache( $term = 0, $taxonomy = null ) {
-		if ( empty( $taxonomy ) || 'language' == $taxonomy ) {
+		if ( empty( $taxonomy ) || 'language' === $taxonomy ) {
 			delete_transient( 'pll_languages_list' );
 			$this->cache->clean();
 		}
@@ -264,7 +264,7 @@ class PLL_Model {
 	 */
 	public function is_translated_post_type( $post_type ) {
 		$post_types = $this->get_translated_post_types( false );
-		return ( is_array( $post_type ) && array_intersect( $post_type, $post_types ) || in_array( $post_type, $post_types ) || 'any' === $post_type && ! empty( $post_types ) );
+		return ( is_array( $post_type ) && array_intersect( $post_type, $post_types ) || in_array( $post_type, $post_types, true ) || 'any' === $post_type && ! empty( $post_types ) );
 	}
 
 	/**
@@ -316,7 +316,7 @@ class PLL_Model {
 	 */
 	public function is_translated_taxonomy( $tax ) {
 		$taxonomies = $this->get_translated_taxonomies( false );
-		return ( is_array( $tax ) && array_intersect( $tax, $taxonomies ) || in_array( $tax, $taxonomies ) );
+		return ( is_array( $tax ) && array_intersect( $tax, $taxonomies ) || in_array( $tax, $taxonomies, true ) );
 	}
 
 	/**
@@ -362,7 +362,7 @@ class PLL_Model {
 	 */
 	public function is_filtered_taxonomy( $tax ) {
 		$taxonomies = $this->get_filtered_taxonomies( false );
-		return ( is_array( $tax ) && array_intersect( $tax, $taxonomies ) || in_array( $tax, $taxonomies ) );
+		return ( is_array( $tax ) && array_intersect( $tax, $taxonomies ) || in_array( $tax, $taxonomies, true ) );
 	}
 
 	/**
@@ -590,7 +590,7 @@ class PLL_Model {
 			case 'get_translations':
 			case 'get_translation':
 			case 'join_clause':
-				$o = ( 'post' == $args[0] || $this->is_translated_post_type( $args[0] ) ) ? 'post' : ( 'term' == $args[0] || $this->is_translated_taxonomy( $args[0] ) ? 'term' : false );
+				$o = ( 'post' === $args[0] || $this->is_translated_post_type( $args[0] ) ) ? 'post' : ( 'term' === $args[0] || $this->is_translated_taxonomy( $args[0] ) ? 'term' : false );
 				unset( $args[0] );
 				break;
 

--- a/include/nav-menu.php
+++ b/include/nav-menu.php
@@ -17,11 +17,11 @@ class PLL_Nav_Menu {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
-		$this->model = &$polylang->model;
+		$this->model   = &$polylang->model;
 		$this->options = &$polylang->options;
 
 		// integration with WP customizer
-		add_action( 'customize_register', array( $this, 'create_nav_menu_locations' ), 5 );
+		add_action( 'customize_register', [ $this, 'create_nav_menu_locations' ], 5 );
 	}
 
 	/**
@@ -42,7 +42,7 @@ class PLL_Nav_Menu {
 			}
 
 			$_wp_registered_nav_menus = $arr;
-			$once = true;
+			$once                     = true;
 		}
 	}
 
@@ -74,6 +74,6 @@ class PLL_Nav_Menu {
 		if ( 1 == count( $infos ) ) {
 			$infos[] = $this->options['default_lang'];
 		}
-		return array_combine( array( 'location', 'lang' ), $infos );
+		return array_combine( [ 'location', 'lang' ], $infos );
 	}
 }

--- a/include/nav-menu.php
+++ b/include/nav-menu.php
@@ -71,7 +71,7 @@ class PLL_Nav_Menu {
 	 */
 	public function explode_location( $loc ) {
 		$infos = explode( '___', $loc );
-		if ( 1 == count( $infos ) ) {
+		if ( 1 === count( $infos ) ) {
 			$infos[] = $this->options['default_lang'];
 		}
 		return array_combine( [ 'location', 'lang' ], $infos );

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -12,8 +12,8 @@
 class PLL_OLT_Manager {
 	static protected $instance; // For singleton
 	protected $default_locale;
-	protected $list_textdomains = array(); // All text domains
-	public $labels = array(); // Post types and taxonomies labels to translate
+	protected $list_textdomains = []; // All text domains
+	public $labels              = []; // Post types and taxonomies labels to translate
 
 	/**
 	 * Constructor: setups relevant filters
@@ -22,8 +22,8 @@ class PLL_OLT_Manager {
 	 */
 	public function __construct() {
 		// Allows Polylang to be the first plugin loaded ;-)
-		add_filter( 'pre_update_option_active_plugins', array( $this, 'make_polylang_first' ) );
-		add_filter( 'pre_update_option_active_sitewide_plugins', array( $this, 'make_polylang_first' ) );
+		add_filter( 'pre_update_option_active_plugins', [ $this, 'make_polylang_first' ] );
+		add_filter( 'pre_update_option_active_sitewide_plugins', [ $this, 'make_polylang_first' ] );
 
 		// Overriding load text domain only on front since WP 4.7
 		// FIXME test get_user_locale for backward compatibility with WP < 4.7
@@ -35,14 +35,14 @@ class PLL_OLT_Manager {
 		$this->default_locale = get_locale();
 
 		// Filters for text domain management
-		add_filter( 'load_textdomain_mofile', array( $this, 'load_textdomain_mofile' ), 10, 2 );
-		add_filter( 'gettext', array( $this, 'gettext' ), 10, 3 );
-		add_filter( 'gettext_with_context', array( $this, 'gettext_with_context' ), 10, 4 );
+		add_filter( 'load_textdomain_mofile', [ $this, 'load_textdomain_mofile' ], 10, 2 );
+		add_filter( 'gettext', [ $this, 'gettext' ], 10, 3 );
+		add_filter( 'gettext_with_context', [ $this, 'gettext_with_context' ], 10, 4 );
 
 		if ( ! Polylang::is_ajax_on_front() ) {
 			// Loads text domains
-			add_action( 'pll_language_defined', array( $this, 'load_textdomains' ), 2 ); // After PLL_Frontend::pll_language_defined
-			add_action( 'pll_no_language_defined', array( $this, 'load_textdomains' ) );
+			add_action( 'pll_language_defined', [ $this, 'load_textdomains' ], 2 ); // After PLL_Frontend::pll_language_defined
+			add_action( 'pll_no_language_defined', [ $this, 'load_textdomains' ] );
 		}
 	}
 
@@ -68,9 +68,9 @@ class PLL_OLT_Manager {
 	 */
 	public function load_textdomains() {
 		// Our load_textdomain_mofile filter has done its job. let's remove it before calling load_textdomain
-		remove_filter( 'load_textdomain_mofile', array( $this, 'load_textdomain_mofile' ), 10, 2 );
-		remove_filter( 'gettext', array( $this, 'gettext' ), 10, 3 );
-		remove_filter( 'gettext_with_context', array( $this, 'gettext_with_context' ), 10, 4 );
+		remove_filter( 'load_textdomain_mofile', [ $this, 'load_textdomain_mofile' ], 10, 2 );
+		remove_filter( 'gettext', [ $this, 'gettext' ], 10, 3 );
+		remove_filter( 'gettext_with_context', [ $this, 'gettext_with_context' ], 10, 4 );
 		$new_locale = get_locale();
 
 		// Don't try to save time for en_US as some users have theme written in another language
@@ -97,14 +97,14 @@ class PLL_OLT_Manager {
 		}
 
 		// First remove taxonomies and post_types labels that we don't need to translate
-		$taxonomies = get_taxonomies( array( '_pll' => true ) );
-		$post_types = get_post_types( array( '_pll' => true ) );
+		$taxonomies = get_taxonomies( [ '_pll' => true ] );
+		$post_types = get_post_types( [ '_pll' => true ] );
 
 		// We don't need to translate core taxonomies and post types labels when setting the language from the url
 		// As they will be translated when registered the second time
 		if ( ! did_action( 'setup_theme' ) ) {
-			$taxonomies = array_merge( get_taxonomies( array( '_builtin' => true ) ), $taxonomies );
-			$post_types = array_merge( get_post_types( array( '_builtin' => true ) ), $post_types );
+			$taxonomies = array_merge( get_taxonomies( [ '_builtin' => true ] ), $taxonomies );
+			$post_types = array_merge( get_post_types( [ '_builtin' => true ] ), $post_types );
 		}
 
 		// Translate labels of post types and taxonomies
@@ -130,7 +130,7 @@ class PLL_OLT_Manager {
 		 *
 		 * @param array $labels list of strings to trnaslate
 		 */
-		do_action_ref_array( 'pll_translate_labels', array( &$this->labels ) );
+		do_action_ref_array( 'pll_translate_labels', [ &$this->labels ] );
 
 		// Free memory
 		unset( $this->default_locale, $this->list_textdomains, $this->labels );
@@ -164,9 +164,15 @@ class PLL_OLT_Manager {
 	public function load_textdomain_mofile( $mofile, $domain ) {
 		// On multisite, 2 files are sharing the same domain so we need to distinguish them
 		if ( 'default' === $domain && false !== strpos( $mofile, '/ms-' ) ) {
-			$this->list_textdomains['ms-default'] = array( 'mo' => $mofile, 'domain' => $domain );
+			$this->list_textdomains['ms-default'] = [
+				'mo' => $mofile,
+				'domain' => $domain,
+			];
 		} else {
-			$this->list_textdomains[ $domain ] = array( 'mo' => $mofile, 'domain' => $domain );
+			$this->list_textdomains[ $domain ] = [
+				'mo' => $mofile,
+				'domain' => $domain,
+			];
 		}
 		return ''; // Hack to prevent WP loading text domains as we will load them all later
 	}
@@ -183,7 +189,7 @@ class PLL_OLT_Manager {
 	 */
 	public function gettext( $translation, $text, $domain ) {
 		if ( is_string( $text ) ) { // Avoid a warning with some buggy plugins which pass an array
-			$this->labels[ $text ] = array( 'domain' => $domain );
+			$this->labels[ $text ] = [ 'domain' => $domain ];
 		}
 		return $translation;
 	}
@@ -200,7 +206,10 @@ class PLL_OLT_Manager {
 	 * @return string unmodified $translation
 	 */
 	public function gettext_with_context( $translation, $text, $context, $domain ) {
-		$this->labels[ $text ] = array( 'domain' => $domain, 'context' => $context );
+		$this->labels[ $text ] = [
+			'domain' => $domain,
+			'context' => $context,
+		];
 		return $translation;
 	}
 
@@ -213,7 +222,7 @@ class PLL_OLT_Manager {
 	 */
 	public function translate_labels( $type ) {
 		// Use static array to avoid translating several times the same ( default ) labels
-		static $translated = array();
+		static $translated = [];
 
 		foreach ( $type->labels as $key => $label ) {
 			if ( is_string( $label ) && isset( $this->labels[ $label ] ) ) {
@@ -221,8 +230,7 @@ class PLL_OLT_Manager {
 					$type->labels->$key = $translated[ $label ] = isset( $this->labels[ $label ]['context'] ) ?
 						_x( $label, $this->labels[ $label ]['context'], $this->labels[ $label ]['domain'] ) :
 						__( $label, $this->labels[ $label ]['domain'] );
-				}
-				else {
+				} else {
 					$type->labels->$key = $translated[ $label ];
 				}
 			}

--- a/include/pointer.php
+++ b/include/pointer.php
@@ -43,7 +43,7 @@ class PLL_Pointer {
 	 */
 	public function enqueue_scripts() {
 		$dismissed = explode( ',', get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) );
-		if ( in_array( $this->args['pointer'], $dismissed ) || ! current_user_can( 'manage_options' ) ) {
+		if ( in_array( $this->args['pointer'], $dismissed, true ) || ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
 

--- a/include/pointer.php
+++ b/include/pointer.php
@@ -33,7 +33,7 @@ class PLL_Pointer {
 	 */
 	public function __construct( $args ) {
 		$this->args = $args;
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 	}
 
 	/**
@@ -48,7 +48,7 @@ class PLL_Pointer {
 		}
 
 		// Add pointer javascript
-		add_action( 'admin_print_footer_scripts', array( $this, 'print_js' ) );
+		add_action( 'admin_print_footer_scripts', [ $this, 'print_js' ] );
 
 		wp_enqueue_style( 'wp-pointer' );
 		wp_enqueue_script( 'wp-pointer' );
@@ -70,7 +70,8 @@ class PLL_Pointer {
 
 			// all the buttons use the standard WP ajax action to remember the pointer has been dismissed
 			foreach ( $this->args['buttons'] as $button ) {
-				$b .= sprintf( "
+				$b .= sprintf(
+					"
 					$( '<a>' ).addClass( '%s' ).html( '%s' ).css( 'margin-left', '10px' ).click( function() {
 						$.post( ajaxurl, {
 							pointer: '%s',
@@ -87,7 +88,8 @@ class PLL_Pointer {
 			}
 		}
 
-		$js = sprintf( "
+		$js = sprintf(
+			"
 			//<![CDATA[
 			jQuery( document ).ready( function( $ ) {
 				var pointer = $( '#%s' ).pointer( {

--- a/include/query.php
+++ b/include/query.php
@@ -7,7 +7,7 @@
  */
 class PLL_Query {
 
-	static protected $excludes = array(
+	static protected $excludes = [
 		'p',
 		'post_parent',
 		'attachment',
@@ -28,7 +28,7 @@ class PLL_Query {
 		'tag_slug__in',
 		'tag_slug__and',
 		'post_parent__in',
-	);
+	];
 
 	/**
 	 * Constructor
@@ -58,9 +58,7 @@ class PLL_Query {
 			foreach ( $tax_queries as $tax_query ) {
 				if ( isset( $tax_query['taxonomy'] ) && $this->model->is_translated_taxonomy( $tax_query['taxonomy'] ) && ! ( isset( $tax_query['operator'] ) && 'NOT IN' === $tax_query['operator'] ) ) {
 					return true;
-				}
-
-				// Nested queries
+				} // Nested queries
 				elseif ( is_array( $tax_query ) && $this->have_translated_taxonomy( $tax_query ) ) {
 					return true;
 				}
@@ -78,7 +76,7 @@ class PLL_Query {
 	 * @return array queried taxonomies
 	 */
 	public function get_queried_taxonomies() {
-		return isset( $this->query->tax_query->queried_terms ) ? array_keys( wp_list_filter( $this->query->tax_query->queried_terms, array( 'operator' => 'NOT IN' ), 'NOT' ) ) : array();
+		return isset( $this->query->tax_query->queried_terms ) ? array_keys( wp_list_filter( $this->query->tax_query->queried_terms, [ 'operator' => 'NOT IN' ], 'NOT' ) ) : [];
 	}
 
 	/**
@@ -91,21 +89,21 @@ class PLL_Query {
 	 */
 	public function set_language( $lang ) {
 		// Defining directly the tax_query ( rather than setting 'lang' avoids transforming the query by WP )
-		$lang_query = array(
+		$lang_query = [
 			'taxonomy' => 'language',
 			'field'    => 'term_taxonomy_id', // Since WP 3.5
 			'terms'    => $lang->term_taxonomy_id,
 			'operator' => 'IN',
-		);
+		];
 
 		$tax_query = &$this->query->query_vars['tax_query'];
 
 		if ( isset( $tax_query['relation'] ) && 'OR' === $tax_query['relation'] ) {
-			$tax_query = array(
+			$tax_query = [
 				$lang_query,
-				array( $tax_query ),
+				[ $tax_query ],
 				'relation' => 'AND',
-			);
+			];
 		} else {
 			$tax_query[] = $lang_query;
 		}
@@ -149,7 +147,7 @@ class PLL_Query {
 				}
 			}
 
-			$taxonomies = array_intersect( $this->model->get_translated_taxonomies(), get_taxonomies( array( '_builtin' => false ) ) );
+			$taxonomies = array_intersect( $this->model->get_translated_taxonomies(), get_taxonomies( [ '_builtin' => false ] ) );
 
 			foreach ( $taxonomies as $tax ) {
 				$tax = get_taxonomy( $tax );

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -17,19 +17,19 @@ abstract class PLL_Static_Pages {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
-		$this->model = &$polylang->model;
+		$this->model   = &$polylang->model;
 		$this->options = &$polylang->options;
 		$this->curlang = &$polylang->curlang;
 
 		$this->init();
 
 		// Modifies the page link in case the front page is not in the default language
-		add_filter( 'page_link', array( $this, 'page_link' ), 20, 2 );
+		add_filter( 'page_link', [ $this, 'page_link' ], 20, 2 );
 
 		// clean the languages cache when editing page of front, page for posts
-		add_action( 'update_option_show_on_front', array( $this->model, 'clean_languages_cache' ) );
-		add_action( 'update_option_page_on_front', array( $this->model, 'clean_languages_cache' ) );
-		add_action( 'update_option_page_for_posts', array( $this->model, 'clean_languages_cache' ) );
+		add_action( 'update_option_show_on_front', [ $this->model, 'clean_languages_cache' ] );
+		add_action( 'update_option_page_on_front', [ $this->model, 'clean_languages_cache' ] );
+		add_action( 'update_option_page_for_posts', [ $this->model, 'clean_languages_cache' ] );
 
 		// refresh rewrite rules when the page on front is modified
 		add_action( 'update_option_page_on_front', 'flush_rewrite_rules' );
@@ -42,12 +42,10 @@ abstract class PLL_Static_Pages {
 	 */
 	public function init() {
 		if ( 'page' == get_option( 'show_on_front' ) ) {
-			$this->page_on_front = get_option( 'page_on_front' );
+			$this->page_on_front  = get_option( 'page_on_front' );
 			$this->page_for_posts = get_option( 'page_for_posts' );
-		}
-
-		else {
-			$this->page_on_front = 0;
+		} else {
+			$this->page_on_front  = 0;
 			$this->page_for_posts = 0;
 		}
 	}
@@ -79,7 +77,7 @@ abstract class PLL_Static_Pages {
 	public static function pll_languages_list( $languages, $model ) {
 		if ( 'page' === get_option( 'show_on_front' ) ) {
 			foreach ( $languages as $k => $language ) {
-				$languages[ $k ]->page_on_front = $model->post->get( get_option( 'page_on_front' ), $language );
+				$languages[ $k ]->page_on_front  = $model->post->get( get_option( 'page_on_front' ), $language );
 				$languages[ $k ]->page_for_posts = $model->post->get( get_option( 'page_for_posts' ), $language );
 			}
 		}

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -41,9 +41,9 @@ abstract class PLL_Static_Pages {
 	 * @since 1.8
 	 */
 	public function init() {
-		if ( 'page' == get_option( 'show_on_front' ) ) {
-			$this->page_on_front  = get_option( 'page_on_front' );
-			$this->page_for_posts = get_option( 'page_for_posts' );
+		if ( 'page' === get_option( 'show_on_front' ) ) {
+			$this->page_on_front  = (int) get_option( 'page_on_front' );
+			$this->page_for_posts = (int) get_option( 'page_for_posts' );
 		} else {
 			$this->page_on_front  = 0;
 			$this->page_for_posts = 0;
@@ -60,7 +60,7 @@ abstract class PLL_Static_Pages {
 	 * @return string modified link
 	 */
 	public function page_link( $link, $id ) {
-		if ( ( $lang = $this->model->post->get_language( $id ) ) && $id == $lang->page_on_front ) {
+		if ( ( $lang = $this->model->post->get_language( $id ) ) && $id === (int) $lang->page_on_front ) {
 			return $lang->home_url;
 		}
 		return $link;

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -18,14 +18,32 @@ class PLL_Switcher {
 	 * @return array list of switcher options strings or default values
 	 */
 	static public function get_switcher_options( $type = 'widget', $key = 'string' ) {
-		$options = array(
-			'dropdown'               => array( 'string' => __( 'Displays as dropdown', 'polylang' ), 'default' => 0 ),
-			'show_names'             => array( 'string' => __( 'Displays language names', 'polylang' ), 'default' => 1 ),
-			'show_flags'             => array( 'string' => __( 'Displays flags', 'polylang' ), 'default' => 0 ),
-			'force_home'             => array( 'string' => __( 'Forces link to front page', 'polylang' ), 'default' => 0 ),
-			'hide_current'           => array( 'string' => __( 'Hides the current language', 'polylang' ), 'default' => 0 ),
-			'hide_if_no_translation' => array( 'string' => __( 'Hides languages with no translation', 'polylang' ), 'default' => 0 ),
-		);
+		$options = [
+			'dropdown'               => [
+				'string' => __( 'Displays as dropdown', 'polylang' ),
+				'default' => 0,
+			],
+			'show_names'             => [
+				'string' => __( 'Displays language names', 'polylang' ),
+				'default' => 1,
+			],
+			'show_flags'             => [
+				'string' => __( 'Displays flags', 'polylang' ),
+				'default' => 0,
+			],
+			'force_home'             => [
+				'string' => __( 'Forces link to front page', 'polylang' ),
+				'default' => 0,
+			],
+			'hide_current'           => [
+				'string' => __( 'Hides the current language', 'polylang' ),
+				'default' => 0,
+			],
+			'hide_if_no_translation' => [
+				'string' => __( 'Hides languages with no translation', 'polylang' ),
+				'default' => 0,
+			],
+		];
 
 		return wp_list_pluck( $options, $key );
 	}
@@ -46,24 +64,23 @@ class PLL_Switcher {
 
 		$first = true;
 
-		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
-			$id = (int) $language->term_id;
-			$order = (int) $language->term_group;
-			$slug = $language->slug;
-			$locale = $language->get_locale( 'display' );
-			$classes = array( 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) );
-			$url = null; // Avoids potential notice
+		foreach ( $links->model->get_languages_list( [ 'hide_empty' => $args['hide_if_empty'] ] ) as $language ) {
+			$id      = (int) $language->term_id;
+			$order   = (int) $language->term_group;
+			$slug    = $language->slug;
+			$locale  = $language->get_locale( 'display' );
+			$classes = [ 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) ];
+			$url     = null; // Avoids potential notice
 
 			if ( $first ) {
 				$classes[] = 'lang-item-first';
-				$first = false;
+				$first     = false;
 			}
 
 			if ( $current_lang = $links->curlang->slug == $slug ) {
 				if ( $args['hide_current'] && ! ( $args['dropdown'] && ! $args['raw'] ) ) {
 					continue; // Hide current language except for dropdown
-				}
-				else {
+				} else {
 					$classes[] = 'current-lang';
 				}
 			}
@@ -102,7 +119,7 @@ class PLL_Switcher {
 			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes' );
 		}
 
-		return empty( $out ) ? array() : $out;
+		return empty( $out ) ? [] : $out;
 	}
 
 	/**
@@ -131,7 +148,7 @@ class PLL_Switcher {
 	 * @return string|array either the html markup of the switcher or the raw elements to build a custom language switcher
 	 */
 	public function the_languages( $links, $args = '' ) {
-		$defaults = array(
+		$defaults = [
 			'dropdown'               => 0, // display as list and not as dropdown
 			'echo'                   => 1, // echoes the list
 			'hide_if_empty'          => 1, // hides languages with no posts ( or pages )
@@ -145,8 +162,8 @@ class PLL_Switcher {
 			'post_id'                => null, // if not null, link to translations of post defined by post_id
 			'raw'                    => 0, // set this to true to build your own custom language switcher
 			'item_spacing'           => 'preserve', // 'preserve' or 'discard' whitespace between list items
-		);
-		$args = wp_parse_args( $args, $defaults );
+		];
+		$args     = wp_parse_args( $args, $defaults );
 
 		/**
 		 * Filter the arguments of the 'pll_the_languages' template tag
@@ -169,11 +186,10 @@ class PLL_Switcher {
 		}
 
 		if ( $args['dropdown'] ) {
-			$args['name'] = 'lang_choice_' . $args['dropdown'];
-			$walker = new PLL_Walker_Dropdown();
+			$args['name']     = 'lang_choice_' . $args['dropdown'];
+			$walker           = new PLL_Walker_Dropdown();
 			$args['selected'] = $links->curlang->slug;
-		}
-		else {
+		} else {
 			$walker = new PLL_Walker_List();
 		}
 
@@ -190,12 +206,13 @@ class PLL_Switcher {
 		// Javascript to switch the language when using a dropdown list
 		if ( $args['dropdown'] ) {
 			foreach ( $links->model->get_languages_list() as $language ) {
-				$url = $links->get_translation_url( $language );
+				$url                     = $links->get_translation_url( $language );
 				$urls[ $language->slug ] = $args['force_home'] || empty( $url ) ? $links->get_home_url( $language ) : $url;
 			}
 
 			// Accept only few valid characters for the urls_x variable name ( as the widget id includes '-' which is invalid )
-			$out .= sprintf( '
+			$out .= sprintf(
+				'
 				<script type="text/javascript">
 					//<![CDATA[
 					var %1$s = %2$s;

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -77,7 +77,7 @@ class PLL_Switcher {
 				$first     = false;
 			}
 
-			if ( $current_lang = $links->curlang->slug == $slug ) {
+			if ( $current_lang = $links->curlang->slug === $slug ) {
 				if ( $args['hide_current'] && ! ( $args['dropdown'] && ! $args['raw'] ) ) {
 					continue; // Hide current language except for dropdown
 				} else {
@@ -113,7 +113,7 @@ class PLL_Switcher {
 
 			$url = empty( $url ) || $args['force_home'] ? $links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
 
-			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' == $args['display_names_as'] ? $slug : $language->name ) : '';
+			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' === $args['display_names_as'] ? $slug : $language->name ) : '';
 			$flag = $args['raw'] && ! $args['show_flags'] ? $language->flag_url : ( $args['show_flags'] ? $language->flag : '' );
 
 			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes' );

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -58,7 +58,7 @@ abstract class PLL_Translated_Object {
 			// query terms
 			foreach ( wp_get_object_terms( $object_id, $taxonomies, [ 'update_term_meta_cache' => false ] ) as $t ) {
 				$terms[ $t->taxonomy ] = $t;
-				if ( $t->taxonomy == $taxonomy ) {
+				if ( $t->taxonomy === $taxonomy ) {
 					$term = $t;
 				}
 			}
@@ -229,7 +229,7 @@ abstract class PLL_Translated_Object {
 		}
 
 		$lang = $this->model->get_language( $lang );
-		return $obj_lang->term_id == $lang->term_id ? $id : $this->get_translation( $id, $lang );
+		return $obj_lang->term_id === $lang->term_id ? $id : $this->get_translation( $id, $lang );
 	}
 
 	/**

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -16,21 +16,21 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	 */
 	public function __construct( &$model ) {
 		// init properties
-		$this->object_type = null;
-		$this->tax_language = 'language';
+		$this->object_type      = null;
+		$this->tax_language     = 'language';
 		$this->tax_translations = 'post_translations';
-		$this->tax_tt = 'term_taxonomy_id';
+		$this->tax_tt           = 'term_taxonomy_id';
 
 		parent::__construct( $model );
 
 		// registers completely the language taxonomy
-		add_action( 'setup_theme', array( $this, 'register_taxonomy' ), 1 );
+		add_action( 'setup_theme', [ $this, 'register_taxonomy' ], 1 );
 
 		// setups post types to translate
-		add_action( 'registered_post_type', array( $this, 'registered_post_type' ) );
+		add_action( 'registered_post_type', [ $this, 'registered_post_type' ] );
 
 		// forces updating posts cache
-		add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
+		add_action( 'pre_get_posts', [ $this, 'pre_get_posts' ] );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	public function set_language( $post_id, $lang ) {
 		$old_lang = $this->get_language( $post_id );
 		$old_lang = $old_lang ? $old_lang->slug : '';
-		$lang = $lang ? $this->model->get_language( $lang )->slug : '';
+		$lang     = $lang ? $this->model->get_language( $lang )->slug : '';
 
 		if ( $old_lang !== $lang ) {
 			wp_set_post_terms( (int) $post_id, $lang, 'language' );
@@ -98,21 +98,23 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	 * @since 1.2
 	 */
 	public function register_taxonomy() {
-		register_taxonomy( 'language', $this->model->get_translated_post_types(), array(
-			'labels' => array(
-				'name'          => __( 'Languages', 'polylang' ),
-				'singular_name' => __( 'Language', 'polylang' ),
-				'all_items'     => __( 'All languages', 'polylang' ),
-			),
-			// FIXME backward compatibility with WP 4.4.x: we must keep public to true for WP to accept our query var
-			'public'             => version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) && version_compare( $GLOBALS['wp_version'], '4.5', '<' ),
-			'show_ui'            => false, // hide the taxonomy on admin side, needed for WP 4.4.x
-			'show_in_nav_menus'  => false, // no metabox for nav menus, needed for WP 4.4.x
-			'publicly_queryable' => true, // since WP 4.5
-			'query_var'          => 'lang',
-			'rewrite'            => $this->model->options['force_lang'] < 2, // no rewrite for domains and sub-domains
-			'_pll'               => true, // polylang taxonomy
-		) );
+		register_taxonomy(
+			'language', $this->model->get_translated_post_types(), [
+				'labels' => [
+					'name'          => __( 'Languages', 'polylang' ),
+					'singular_name' => __( 'Language', 'polylang' ),
+					'all_items'     => __( 'All languages', 'polylang' ),
+				],
+				// FIXME backward compatibility with WP 4.4.x: we must keep public to true for WP to accept our query var
+				'public'             => version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) && version_compare( $GLOBALS['wp_version'], '4.5', '<' ),
+				'show_ui'            => false, // hide the taxonomy on admin side, needed for WP 4.4.x
+				'show_in_nav_menus'  => false, // no metabox for nav menus, needed for WP 4.4.x
+				'publicly_queryable' => true, // since WP 4.5
+				'query_var'          => 'lang',
+				'rewrite'            => $this->model->options['force_lang'] < 2, // no rewrite for domains and sub-domains
+				'_pll'               => true, // polylang taxonomy
+			]
+		);
 	}
 
 	/**

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -15,18 +15,18 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 	 * @param object $model
 	 */
 	public function __construct( &$model ) {
-		$this->object_type = 'term';
-		$this->tax_language = 'term_language';
+		$this->object_type      = 'term';
+		$this->tax_language     = 'term_language';
 		$this->tax_translations = 'term_translations';
-		$this->tax_tt = 'tl_term_taxonomy_id';
+		$this->tax_tt           = 'tl_term_taxonomy_id';
 
 		parent::__construct( $model );
 
 		// Filters to prime terms cache
-		add_filter( 'get_terms', array( $this, '_prime_terms_cache' ), 10, 2 );
-		add_filter( 'wp_get_object_terms', array( $this, 'wp_get_object_terms' ), 10, 3 );
+		add_filter( 'get_terms', [ $this, '_prime_terms_cache' ], 10, 2 );
+		add_filter( 'wp_get_object_terms', [ $this, 'wp_get_object_terms' ], 10, 3 );
 
-		add_action( 'clean_term_cache', array( $this, 'clean_term_cache' ) );
+		add_action( 'clean_term_cache', [ $this, 'clean_term_cache' ] );
 	}
 
 	/**
@@ -42,7 +42,7 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 
 		$old_lang = $this->get_language( $term_id );
 		$old_lang = $old_lang ? $old_lang->tl_term_id : '';
-		$lang = $lang ? $this->model->get_language( $lang )->tl_term_id : '';
+		$lang     = $lang ? $this->model->get_language( $lang )->tl_term_id : '';
 
 		if ( $old_lang !== $lang ) {
 			wp_set_object_terms( $term_id, $lang, 'term_language' );
@@ -80,9 +80,7 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 	public function get_language( $value, $taxonomy = '' ) {
 		if ( is_numeric( $value ) ) {
 			$term_id = $value;
-		}
-
-		// get_term_by still not cached in WP 3.5.1 but internally, the function is always called by term_id
+		} // get_term_by still not cached in WP 3.5.1 but internally, the function is always called by term_id
 		elseif ( is_string( $value ) && $taxonomy ) {
 			$term_id = wpcom_vip_get_term_by( 'slug', $value, $taxonomy )->term_id;
 		}
@@ -128,7 +126,7 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 		if ( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( * ) FROM $wpdb->terms WHERE term_id = %d;", $id ) ) ) {
 			// Always keep a group for terms to allow relationships remap when importing from a WXR file
 			$translations[ $slug ] = $id;
-			wp_insert_term( $group = uniqid( 'pll_' ), 'term_translations', array( 'description' => serialize( $translations ) ) );
+			wp_insert_term( $group = uniqid( 'pll_' ), 'term_translations', [ 'description' => serialize( $translations ) ] );
 			wp_set_object_terms( $id, $group, 'term_translations' );
 		}
 	}

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -177,7 +177,7 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 	 */
 	public function wp_get_object_terms( $terms, $object_ids, $taxonomies ) {
 		$taxonomies = explode( "', '", trim( $taxonomies, "'" ) );
-		if ( ! in_array( 'term_translations', $taxonomies ) ) {
+		if ( ! in_array( 'term_translations', $taxonomies, true ) ) {
 			$this->_prime_terms_cache( $terms, $taxonomies );
 		}
 		return $terms;

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -6,7 +6,10 @@
  * @since 1.2
  */
 class PLL_Walker_Dropdown extends Walker {
-	var $db_fields = array( 'parent' => 'parent', 'id' => 'id' );
+	var $db_fields = [
+		'parent' => 'parent',
+		'id' => 'id',
+	];
 
 	/**
 	 * Outputs one element
@@ -19,8 +22,8 @@ class PLL_Walker_Dropdown extends Walker {
 	 * @param array  $args              An array of additional arguments.
 	 * @param int    $current_object_id ID of the current item.
 	 */
-	function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) {
-		$value = $args['value'];
+	function start_el( &$output, $element, $depth = 0, $args = [], $current_object_id = 0 ) {
+		$value   = $args['value'];
 		$output .= sprintf(
 			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",
 			esc_attr( $element->$value ),
@@ -43,7 +46,7 @@ class PLL_Walker_Dropdown extends Walker {
 	 * @param string $output            Passed by reference. Used to append additional content.
 	 */
 	function display_element( $element, &$children_elements, $max_depth, $depth = 0, $args, &$output ) {
-		$element = (object) $element; // Make sure we have an object
+		$element         = (object) $element; // Make sure we have an object
 		$element->parent = $element->id = 0; // Don't care about this
 		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
 	}
@@ -67,20 +70,25 @@ class PLL_Walker_Dropdown extends Walker {
 	 * @param array $args
 	 * @return string
 	 */
-	function walk( $elements, $args = array() ) {
+	function walk( $elements, $args = [] ) {
 		$output = '';
-		$args = wp_parse_args( $args, array( 'value' => 'slug', 'name' => 'lang_choice' ) );
+		$args   = wp_parse_args(
+			$args, [
+				'value' => 'slug',
+				'name' => 'lang_choice',
+			]
+		);
 
 		if ( ! empty( $args['flag'] ) ) {
-			$current = wp_list_filter( $elements, array( $args['value'] => $args['selected'] ) );
-			$lang = reset( $current );
-			$output = sprintf(
+			$current = wp_list_filter( $elements, [ $args['value'] => $args['selected'] ] );
+			$lang    = reset( $current );
+			$output  = sprintf(
 				'<span class="pll-select-flag">%s</span>',
 				empty( $lang->flag ) ? esc_html( $lang->slug ) : $lang->flag
 			);
 		}
 
-		$output .= sprintf(
+		$output  .= sprintf(
 			'<select name="%1$s"%2$s%3$s%4$s>' . "\n" . '%5$s' . "\n" . '</select>' . "\n",
 			$name = esc_attr( $args['name'] ),
 			isset( $args['id'] ) && ! $args['id'] ? '' : ' id="' . ( empty( $args['id'] ) ? $name : esc_attr( $args['id'] ) ) . '"',

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -6,7 +6,10 @@
  * @since 1.2
  */
 class PLL_Walker_List extends Walker {
-	var $db_fields = array( 'parent' => 'parent', 'id' => 'id' );
+	var $db_fields = [
+		'parent' => 'parent',
+		'id' => 'id',
+	];
 
 	/**
 	 * Outputs one element
@@ -19,7 +22,7 @@ class PLL_Walker_List extends Walker {
 	 * @param array  $args              An array of additional arguments.
 	 * @param int    $current_object_id ID of the current item.
 	 */
-	function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) {
+	function start_el( &$output, $element, $depth = 0, $args = [], $current_object_id = 0 ) {
 		$output .= sprintf(
 			'%6$s<li class="%1$s"><a lang="%2$s" hreflang="%2$s" href="%3$s">%4$s%5$s</a></li>%7$s',
 			esc_attr( implode( ' ', $element->classes ) ),
@@ -45,7 +48,7 @@ class PLL_Walker_List extends Walker {
 	 * @param string $output            Passed by reference. Used to append additional content.
 	 */
 	function display_element( $element, &$children_elements, $max_depth, $depth = 0, $args, &$output ) {
-		$element = (object) $element; // Make sure we have an object
+		$element         = (object) $element; // Make sure we have an object
 		$element->parent = $element->id = 0; // Don't care about this
 		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
 	}
@@ -59,7 +62,7 @@ class PLL_Walker_List extends Walker {
 	 * @param array $args
 	 * @return string
 	 */
-	function walk( $elements, $args = array() ) {
+	function walk( $elements, $args = [] ) {
 		return parent::walk( $elements, -1, $args );
 	}
 }

--- a/include/widget-calendar.php
+++ b/include/widget-calendar.php
@@ -204,7 +204,7 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 
 		// See how much we should pad in the beginning
 		$pad = calendar_week_mod( date( 'w', $unixmonth ) - $week_begins );
-		if ( 0 != $pad ) {
+		if ( 0 !== $pad ) {
 			$calendar_output .= "\n\t\t" . '<td colspan="' . esc_attr( $pad ) . '" class="pad">&nbsp;</td>';
 		}
 
@@ -217,15 +217,15 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 			}
 			$newrow = false;
 
-			if ( $day == gmdate( 'j', $ts ) &&
-				$thismonth == gmdate( 'm', $ts ) &&
-				$thisyear == gmdate( 'Y', $ts ) ) {
+			if ( $day === (int) gmdate( 'j', $ts ) &&
+				(int) $thismonth === (int) gmdate( 'm', $ts ) &&
+				(int) $thisyear === (int) gmdate( 'Y', $ts ) ) {
 				$calendar_output .= '<td id="today">';
 			} else {
 				$calendar_output .= '<td>';
 			}
 
-			if ( in_array( $day, $daywithpost ) ) {
+			if ( in_array( $day, $daywithpost, true ) ) {
 				// any posts today?
 				$date_format      = date( _x( 'F j, Y', 'daily archives date format' ), strtotime( "{$thisyear}-{$thismonth}-{$day}" ) );
 				$label            = sprintf( __( 'Posts published on %s' ), $date_format );
@@ -240,13 +240,13 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 			}
 			$calendar_output .= '</td>';
 
-			if ( 6 == calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
+			if ( 6 === calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
 				$newrow = true;
 			}
 		}
 
 		$pad = 7 - calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
-		if ( $pad != 0 && $pad != 7 ) {
+		if ( $pad !== 0 && $pad !== 7 ) {
 			$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr( $pad ) . '">&nbsp;</td>';
 		}
 		$calendar_output .= "\n\t</tr>\n\t</tbody>\n\t</table>";

--- a/include/widget-calendar.php
+++ b/include/widget-calendar.php
@@ -45,14 +45,14 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 	 * @param bool $initial Optional, default is true. Use initial calendar names.
 	 * @param bool $echo Optional, default is true. Set to false for return.
 	 * @return string|null String when retrieving, null when displaying.
- 	 */
+	 */
 	static function get_calendar( $initial = true, $echo = true ) {
 		global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
 
-		$join_clause = PLL()->model->post->join_clause(); #added#
+		$join_clause  = PLL()->model->post->join_clause(); #added#
 		$where_clause = PLL()->model->post->where_clause( PLL()->curlang ); #added#
 
-		$key = md5( PLL()->curlang->slug . $m . $monthnum . $year ); #modified#
+		$key   = md5( PLL()->curlang->slug . $m . $monthnum . $year ); #modified#
 		$cache = wp_cache_get( 'get_calendar', 'calendar' );
 
 		if ( $cache && is_array( $cache ) && isset( $cache[ $key ] ) ) {
@@ -68,12 +68,12 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		}
 
 		if ( ! is_array( $cache ) ) {
-			$cache = array();
+			$cache = [];
 		}
 
 		// Quick check. If we have no posts at all, abort!
 		if ( ! $posts ) {
-			$gotsome = $wpdb->get_var("SELECT 1 as test FROM $wpdb->posts WHERE post_type = 'post' AND post_status = 'publish' LIMIT 1");
+			$gotsome = $wpdb->get_var( "SELECT 1 as test FROM $wpdb->posts WHERE post_type = 'post' AND post_status = 'publish' LIMIT 1" );
 			if ( ! $gotsome ) {
 				$cache[ $key ] = '';
 				wp_cache_set( 'get_calendar', $cache, 'calendar' );
@@ -86,18 +86,18 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		}
 		// week_begins = 0 stands for Sunday
 		$week_begins = (int) get_option( 'start_of_week' );
-		$ts = current_time( 'timestamp' );
+		$ts          = current_time( 'timestamp' );
 
 		// Let's figure out when we are
 		if ( ! empty( $monthnum ) && ! empty( $year ) ) {
 			$thismonth = zeroise( intval( $monthnum ), 2 );
-			$thisyear = (int) $year;
+			$thisyear  = (int) $year;
 		} elseif ( ! empty( $w ) ) {
 			// We need to get the month from MySQL
 			$thisyear = (int) substr( $m, 0, 4 );
 			//it seems MySQL's weeks disagree with PHP's
-			$d = ( ( $w - 1 ) * 7 ) + 6;
-			$thismonth = $wpdb->get_var("SELECT DATE_FORMAT((DATE_ADD('{$thisyear}0101', INTERVAL $d DAY) ), '%m')");
+			$d         = ( ( $w - 1 ) * 7 ) + 6;
+			$thismonth = $wpdb->get_var( "SELECT DATE_FORMAT((DATE_ADD('{$thisyear}0101', INTERVAL $d DAY) ), '%m')" );
 		} elseif ( ! empty( $m ) ) {
 			$thisyear = (int) substr( $m, 0, 4 );
 			if ( strlen( $m ) < 6 ) {
@@ -106,30 +106,34 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 				$thismonth = zeroise( (int) substr( $m, 4, 2 ), 2 );
 			}
 		} else {
-			$thisyear = gmdate( 'Y', $ts );
+			$thisyear  = gmdate( 'Y', $ts );
 			$thismonth = gmdate( 'm', $ts );
 		}
 
-		$unixmonth = mktime( 0, 0 , 0, $thismonth, 1, $thisyear );
-		$last_day = date( 't', $unixmonth );
+		$unixmonth = mktime( 0, 0, 0, $thismonth, 1, $thisyear );
+		$last_day  = date( 't', $unixmonth );
 
 		// Get the next and previous month and year with at least one post
-		$previous = $wpdb->get_row( "SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
+		$previous = $wpdb->get_row(
+			"SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
 			FROM $wpdb->posts $join_clause
 			WHERE post_date < '$thisyear-$thismonth-01'
 			AND post_type = 'post' AND post_status = 'publish' $where_clause
 				ORDER BY post_date DESC
-				LIMIT 1" ); #modified#
-		$next = $wpdb->get_row( "SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
+				LIMIT 1"
+		); #modified#
+		$next     = $wpdb->get_row(
+			"SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
 			FROM $wpdb->posts $join_clause
 			WHERE post_date > '$thisyear-$thismonth-{$last_day} 23:59:59'
 			AND post_type = 'post' AND post_status = 'publish' $where_clause
 				ORDER BY post_date ASC
-				LIMIT 1" ); #modified#
+				LIMIT 1"
+		); #modified#
 
 		/* translators: Calendar caption: 1: month name, 2: 4-digit year */
 		$calendar_caption = _x( '%1$s %2$s', 'calendar caption' );
-		$calendar_output = '<table id="wp-calendar">
+		$calendar_output  = '<table id="wp-calendar">
 		<caption>' . sprintf(
 			$calendar_caption,
 			$wp_locale->get_month( $thismonth ),
@@ -138,15 +142,15 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		<thead>
 		<tr>';
 
-		$myweek = array();
+		$myweek = [];
 
 		for ( $wdcount = 0; $wdcount <= 6; $wdcount++ ) {
 			$myweek[] = $wp_locale->get_weekday( ( $wdcount + $week_begins ) % 7 );
 		}
 
 		foreach ( $myweek as $wd ) {
-			$day_name = $initial ? $wp_locale->get_weekday_initial( $wd ) : $wp_locale->get_weekday_abbrev( $wd );
-			$wd = esc_attr( $wd );
+			$day_name         = $initial ? $wp_locale->get_weekday_initial( $wd ) : $wp_locale->get_weekday_abbrev( $wd );
+			$wd               = esc_attr( $wd );
 			$calendar_output .= "\n\t\t<th scope=\"col\" title=\"$wd\">$day_name</th>";
 		}
 
@@ -158,21 +162,21 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		<tr>';
 
 		if ( $previous ) {
-			$calendar_output .= "\n\t\t".'<td colspan="3" id="prev"><a href="' . get_month_link( $previous->year, $previous->month ) . '">&laquo; ' .
+			$calendar_output .= "\n\t\t" . '<td colspan="3" id="prev"><a href="' . get_month_link( $previous->year, $previous->month ) . '">&laquo; ' .
 				$wp_locale->get_month_abbrev( $wp_locale->get_month( $previous->month ) ) .
 			'</a></td>';
 		} else {
-			$calendar_output .= "\n\t\t".'<td colspan="3" id="prev" class="pad">&nbsp;</td>';
+			$calendar_output .= "\n\t\t" . '<td colspan="3" id="prev" class="pad">&nbsp;</td>';
 		}
 
-		$calendar_output .= "\n\t\t".'<td class="pad">&nbsp;</td>';
+		$calendar_output .= "\n\t\t" . '<td class="pad">&nbsp;</td>';
 
 		if ( $next ) {
-			$calendar_output .= "\n\t\t".'<td colspan="3" id="next"><a href="' . get_month_link( $next->year, $next->month ) . '">' .
+			$calendar_output .= "\n\t\t" . '<td colspan="3" id="next"><a href="' . get_month_link( $next->year, $next->month ) . '">' .
 				$wp_locale->get_month_abbrev( $wp_locale->get_month( $next->month ) ) .
 			' &raquo;</a></td>';
 		} else {
-			$calendar_output .= "\n\t\t".'<td colspan="3" id="next" class="pad">&nbsp;</td>';
+			$calendar_output .= "\n\t\t" . '<td colspan="3" id="next" class="pad">&nbsp;</td>';
 		}
 
 		$calendar_output .= '
@@ -182,14 +186,16 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		<tbody>
 		<tr>';
 
-		$daywithpost = array();
+		$daywithpost = [];
 
 		// Get days with posts
-		$dayswithposts = $wpdb->get_results( "SELECT DISTINCT DAYOFMONTH( post_date )
+		$dayswithposts = $wpdb->get_results(
+			"SELECT DISTINCT DAYOFMONTH( post_date )
 			FROM $wpdb->posts $join_clause
 			WHERE post_date >= '{$thisyear}-{$thismonth}-01 00:00:00'
 			AND post_type = 'post' AND post_status = 'publish' $where_clause
-			AND post_date <= '{$thisyear}-{$thismonth}-{$last_day} 23:59:59'", ARRAY_N ); #modified#
+			AND post_date <= '{$thisyear}-{$thismonth}-{$last_day} 23:59:59'", ARRAY_N
+		); #modified#
 		if ( $dayswithposts ) {
 			foreach ( (array) $dayswithposts as $daywith ) {
 				$daywithpost[] = $daywith[0];
@@ -199,14 +205,14 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		// See how much we should pad in the beginning
 		$pad = calendar_week_mod( date( 'w', $unixmonth ) - $week_begins );
 		if ( 0 != $pad ) {
-			$calendar_output .= "\n\t\t".'<td colspan="'. esc_attr( $pad ) .'" class="pad">&nbsp;</td>';
+			$calendar_output .= "\n\t\t" . '<td colspan="' . esc_attr( $pad ) . '" class="pad">&nbsp;</td>';
 		}
 
-		$newrow = false;
+		$newrow      = false;
 		$daysinmonth = (int) date( 't', $unixmonth );
 
 		for ( $day = 1; $day <= $daysinmonth; ++$day ) {
-			if ( isset($newrow) && $newrow ) {
+			if ( isset( $newrow ) && $newrow ) {
 				$calendar_output .= "\n\t</tr>\n\t<tr>\n\t\t";
 			}
 			$newrow = false;
@@ -221,8 +227,8 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 
 			if ( in_array( $day, $daywithpost ) ) {
 				// any posts today?
-				$date_format = date( _x( 'F j, Y', 'daily archives date format' ), strtotime( "{$thisyear}-{$thismonth}-{$day}" ) );
-				$label = sprintf( __( 'Posts published on %s' ), $date_format );
+				$date_format      = date( _x( 'F j, Y', 'daily archives date format' ), strtotime( "{$thisyear}-{$thismonth}-{$day}" ) );
+				$label            = sprintf( __( 'Posts published on %s' ), $date_format );
 				$calendar_output .= sprintf(
 					'<a href="%s" aria-label="%s">%s</a>',
 					get_day_link( $thisyear, $thismonth, $day ),
@@ -234,14 +240,14 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 			}
 			$calendar_output .= '</td>';
 
-			if ( 6 == calendar_week_mod( date( 'w', mktime(0, 0 , 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
+			if ( 6 == calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
 				$newrow = true;
 			}
 		}
 
-		$pad = 7 - calendar_week_mod( date( 'w', mktime( 0, 0 , 0, $thismonth, $day, $thisyear ) ) - $week_begins );
+		$pad = 7 - calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
 		if ( $pad != 0 && $pad != 7 ) {
-			$calendar_output .= "\n\t\t".'<td class="pad" colspan="'. esc_attr( $pad ) .'">&nbsp;</td>';
+			$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr( $pad ) . '">&nbsp;</td>';
 		}
 		$calendar_output .= "\n\t</tr>\n\t</tbody>\n\t</table>";
 

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -16,10 +16,10 @@ class PLL_Widget_Languages extends WP_Widget {
 		parent::__construct(
 			'polylang',
 			__( 'Language Switcher', 'polylang' ),
-			array(
+			[
 				'description' => __( 'Displays a language switcher', 'polylang' ),
 				'customize_selective_refresh' => true,
-			)
+			]
 		);
 	}
 
@@ -35,7 +35,7 @@ class PLL_Widget_Languages extends WP_Widget {
 		// Sets a unique id for dropdown
 		$instance['dropdown'] = empty( $instance['dropdown'] ) ? 0 : $args['widget_id'];
 
-		if ( $list = pll_the_languages( array_merge( $instance, array( 'echo' => 0 ) ) ) ) {
+		if ( $list = pll_the_languages( array_merge( $instance, [ 'echo' => 0 ] ) ) ) {
 			$title = empty( $instance['title'] ) ? '' : $instance['title'];
 			/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 			$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
@@ -81,7 +81,7 @@ class PLL_Widget_Languages extends WP_Widget {
 	 */
 	function form( $instance ) {
 		// Default values
-		$instance = wp_parse_args( (array) $instance, array_merge( array( 'title' => '' ), PLL_Switcher::get_switcher_options( 'widget', 'default' ) ) );
+		$instance = wp_parse_args( (array) $instance, array_merge( [ 'title' => '' ], PLL_Switcher::get_switcher_options( 'widget', 'default' ) ) );
 
 		// Title
 		printf(
@@ -100,8 +100,8 @@ class PLL_Widget_Languages extends WP_Widget {
 				$this->get_field_name( $key ),
 				$instance[ $key ] ? ' checked="checked"' : '',
 				esc_html( $str ),
-				in_array( $key, array( 'show_names', 'show_flags', 'hide_current' ) ) ? ' class="no-dropdown-' . $this->id . '"' : '',
-				! empty( $instance['dropdown'] ) && in_array( $key, array( 'show_names', 'show_flags', 'hide_current' ) ) ? ' style="display:none;"' : '',
+				in_array( $key, [ 'show_names', 'show_flags', 'hide_current' ] ) ? ' class="no-dropdown-' . $this->id . '"' : '',
+				! empty( $instance['dropdown'] ) && in_array( $key, [ 'show_names', 'show_flags', 'hide_current' ] ) ? ' style="display:none;"' : '',
 				'pll-' . $key
 			);
 		}

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -100,8 +100,8 @@ class PLL_Widget_Languages extends WP_Widget {
 				$this->get_field_name( $key ),
 				$instance[ $key ] ? ' checked="checked"' : '',
 				esc_html( $str ),
-				in_array( $key, [ 'show_names', 'show_flags', 'hide_current' ] ) ? ' class="no-dropdown-' . $this->id . '"' : '',
-				! empty( $instance['dropdown'] ) && in_array( $key, [ 'show_names', 'show_flags', 'hide_current' ] ) ? ' style="display:none;"' : '',
+				in_array( $key, [ 'show_names', 'show_flags', 'hide_current' ], true ) ? ' class="no-dropdown-' . $this->id . '"' : '',
+				! empty( $instance['dropdown'] ) && in_array( $key, [ 'show_names', 'show_flags', 'hide_current' ], true ) ? ' style="display:none;"' : '',
 				'pll-' . $key
 			);
 		}
@@ -138,7 +138,7 @@ class PLL_Widget_Languages extends WP_Widget {
 				// Remove all options if dropdown is checked
 				$( '.widgets-sortables,.control-section-sidebar' ).on( 'change', '.pll-dropdown', function() {
 					var this_id = $( this ).parent().parent().parent().children( '.widget-id' ).attr( 'value' );
-					pll_toggle( $( '.no-dropdown-' + this_id ), 'checked' != $( this ).attr( 'checked' ) );
+					pll_toggle( $( '.no-dropdown-' + this_id ), 'checked' !== $( this ).attr( 'checked' ) );
 				} );
 
 				// Disallow unchecking both show names and show flags
@@ -146,7 +146,7 @@ class PLL_Widget_Languages extends WP_Widget {
 				$.each( options, function( i, v ) {
 					$( '.widgets-sortables,.control-section-sidebar' ).on( 'change', '.pll' + v, function() {
 						var this_id = $( this ).parent().parent().parent().children( '.widget-id' ).attr( 'value' );
-						if ( 'checked' != $( this ).attr( 'checked' ) ) {
+						if ( 'checked' !== $( this ).attr( 'checked' ) ) {
 							$( '#widget-' + this_id + options[ 1-i ] ).prop( 'checked', true );
 						}
 					} );

--- a/install/install-base.php
+++ b/install/install-base.php
@@ -34,7 +34,7 @@ class PLL_Install_Base {
 	 * @return bool true if the plugin is currently beeing deactivated
 	 */
 	public function is_deactivation() {
-		return isset( $_GET['action'], $_GET['plugin'] ) && 'deactivate' == $_GET['action'] && $this->plugin_basename == $_GET['plugin'];
+		return isset( $_GET['action'], $_GET['plugin'] ) && 'deactivate' === $_GET['action'] && $this->plugin_basename === $_GET['plugin'];
 	}
 
 	/**
@@ -52,12 +52,12 @@ class PLL_Install_Base {
 
 			foreach ( $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" ) as $blog_id ) {
 				switch_to_blog( $blog_id );
-				'activate' == $what ? $this->_activate() : $this->_deactivate();
+				'activate' === $what ? $this->_activate() : $this->_deactivate();
 			}
 			restore_current_blog();
 		} // Single blog
 		else {
-			'activate' == $what ? $this->_activate() : $this->_deactivate();
+			'activate' === $what ? $this->_activate() : $this->_deactivate();
 		}
 	}
 

--- a/install/install-base.php
+++ b/install/install-base.php
@@ -19,11 +19,11 @@ class PLL_Install_Base {
 		$this->plugin_basename = $plugin_basename;
 
 		// Manages plugin activation and deactivation
-		register_activation_hook( $plugin_basename, array( $this, 'activate' ) );
-		register_deactivation_hook( $plugin_basename, array( $this, 'deactivate' ) );
+		register_activation_hook( $plugin_basename, [ $this, 'activate' ] );
+		register_deactivation_hook( $plugin_basename, [ $this, 'deactivate' ] );
 
 		// Blog creation on multisite
-		add_action( 'wpmu_new_blog', array( $this, 'wpmu_new_blog' ), 5 ); // Before WP attempts to send mails which can break on some PHP versions
+		add_action( 'wpmu_new_blog', [ $this, 'wpmu_new_blog' ], 5 ); // Before WP attempts to send mails which can break on some PHP versions
 	}
 
 	/**
@@ -55,9 +55,7 @@ class PLL_Install_Base {
 				'activate' == $what ? $this->_activate() : $this->_deactivate();
 			}
 			restore_current_blog();
-		}
-
-		// Single blog
+		} // Single blog
 		else {
 			'activate' == $what ? $this->_activate() : $this->_deactivate();
 		}

--- a/install/install.php
+++ b/install/install.php
@@ -22,13 +22,17 @@ class PLL_Install extends PLL_Install_Base {
 		load_plugin_textdomain( 'polylang', false, basename( POLYLANG_DIR ) . '/languages' ); // plugin i18n
 
 		if ( version_compare( $wp_version, PLL_MIN_WP_VERSION, '<' ) ) {
-			die( sprintf( '<p style = "font-family: sans-serif; font-size: 12px; color: #333; margin: -5px">%s</p>',
-				/* translators: %1$s and %2$s are WordPress version numbers */
-				sprintf( esc_html__( 'You are using WordPress %1$s. Polylang requires at least WordPress %2$s.', 'polylang' ),
-					esc_html( $wp_version ),
-					PLL_MIN_WP_VERSION
+			die(
+				sprintf(
+					'<p style = "font-family: sans-serif; font-size: 12px; color: #333; margin: -5px">%s</p>',
+					/* translators: %1$s and %2$s are WordPress version numbers */
+					sprintf(
+						esc_html__( 'You are using WordPress %1$s. Polylang requires at least WordPress %2$s.', 'polylang' ),
+						esc_html( $wp_version ),
+						PLL_MIN_WP_VERSION
+					)
 				)
-			) );
+			);
 		}
 		$this->do_for_all_blogs( 'activate', $networkwide );
 	}
@@ -41,7 +45,7 @@ class PLL_Install extends PLL_Install_Base {
 	 * return array
 	 */
 	static public function get_default_options() {
-		return array(
+		return [
 			'browser'       => 1, // Default language for the front page is set by browser preference
 			'rewrite'       => 1, // Remove /language/ in permalinks ( was the opposite before 0.7.2 )
 			'hide_default'  => 1, // Remove URL language information for default language ( was the opposite before 2.1.5 )
@@ -49,12 +53,12 @@ class PLL_Install extends PLL_Install_Base {
 			'redirect_lang' => 0, // Do not redirect the language page to the homepage
 			'media_support' => 1, // Support languages and translation for media by default
 			'uninstall'     => 0, // Do not remove data when uninstalling Polylang
-			'sync'          => array(), // Synchronisation is disabled by default ( was the opposite before 1.2 )
-			'post_types'    => array(),
-			'taxonomies'    => array(),
-			'domains'       => array(),
+			'sync'          => [], // Synchronisation is disabled by default ( was the opposite before 1.2 )
+			'post_types'    => [],
+			'taxonomies'    => [],
+			'domains'       => [],
 			'version'       => POLYLANG_VERSION,
-		);
+		];
 	}
 
 	/**
@@ -69,15 +73,14 @@ class PLL_Install extends PLL_Install_Base {
 				$upgrade = new PLL_Upgrade( $options );
 				$upgrade->can_activate();
 			}
-		}
-		// Defines default values for options in case this is the first installation
+		} // Defines default values for options in case this is the first installation
 		else {
 			update_option( 'polylang', self::get_default_options() );
 		}
 
 		// Avoid 1 query on every pages if no wpml strings is registered
 		if ( ! get_option( 'polylang_wpml_strings' ) ) {
-			update_option( 'polylang_wpml_strings', array() );
+			update_option( 'polylang_wpml_strings', [] );
 		}
 
 		// Don't use flush_rewrite_rules at network activation. See #32471

--- a/install/install.php
+++ b/install/install.php
@@ -25,8 +25,8 @@ class PLL_Install extends PLL_Install_Base {
 			die(
 				sprintf(
 					'<p style = "font-family: sans-serif; font-size: 12px; color: #333; margin: -5px">%s</p>',
-					/* translators: %1$s and %2$s are WordPress version numbers */
 					sprintf(
+						/* translators: %1$s and %2$s are WordPress version numbers */
 						esc_html__( 'You are using WordPress %1$s. Polylang requires at least WordPress %2$s.', 'polylang' ),
 						esc_html( $wp_version ),
 						PLL_MIN_WP_VERSION

--- a/install/plugin-updater.php
+++ b/install/plugin-updater.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class PLL_Plugin_Updater {
 
 	private $api_url     = '';
-	private $api_data    = array();
+	private $api_data    = [];
 	private $name        = '';
 	private $slug        = '';
 	private $version     = '';
@@ -61,11 +61,11 @@ class PLL_Plugin_Updater {
 	 */
 	public function init() {
 
-		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_update' ) );
-		add_filter( 'plugins_api', array( $this, 'plugins_api_filter' ), 10, 3 );
+		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ] );
+		add_filter( 'plugins_api', [ $this, 'plugins_api_filter' ], 10, 3 );
 		remove_action( 'after_plugin_row_' . $this->name, 'wp_plugin_update_row', 10 );
-		add_action( 'after_plugin_row_' . $this->name, array( $this, 'show_update_notification' ), 10, 2 );
-		add_action( 'admin_init', array( $this, 'show_changelog' ) );
+		add_action( 'after_plugin_row_' . $this->name, [ $this, 'show_update_notification' ], 10, 2 );
+		add_action( 'admin_init', [ $this, 'show_changelog' ] );
 
 	}
 
@@ -101,7 +101,12 @@ class PLL_Plugin_Updater {
 		$version_info = $this->get_cached_version_info();
 
 		if ( false === $version_info ) {
-			$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug, 'beta' => $this->beta ) );
+			$version_info = $this->api_request(
+				'plugin_latest_version', [
+					'slug' => $this->slug,
+					'beta' => $this->beta,
+				]
+			);
 
 			$this->set_version_info_cache( $version_info );
 
@@ -135,11 +140,11 @@ class PLL_Plugin_Updater {
 			return;
 		}
 
-		if( ! current_user_can( 'update_plugins' ) ) {
+		if ( ! current_user_can( 'update_plugins' ) ) {
 			return;
 		}
 
-		if( ! is_multisite() ) {
+		if ( ! is_multisite() ) {
 			return;
 		}
 
@@ -148,7 +153,7 @@ class PLL_Plugin_Updater {
 		}
 
 		// Remove our filter on the site transient
-		remove_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_update' ), 10 );
+		remove_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ], 10 );
 
 		$update_cache = get_site_transient( 'update_plugins' );
 
@@ -159,7 +164,12 @@ class PLL_Plugin_Updater {
 			$version_info = $this->get_cached_version_info();
 
 			if ( false === $version_info ) {
-				$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug, 'beta' => $this->beta ) );
+				$version_info = $this->api_request(
+					'plugin_latest_version', [
+						'slug' => $this->slug,
+						'beta' => $this->beta,
+					]
+				);
 
 				$this->set_version_info_cache( $version_info );
 			}
@@ -174,7 +184,7 @@ class PLL_Plugin_Updater {
 
 			}
 
-			$update_cache->last_checked = current_time( 'timestamp' );
+			$update_cache->last_checked           = current_time( 'timestamp' );
 			$update_cache->checked[ $this->name ] = $this->version;
 
 			set_site_transient( 'update_plugins', $update_cache );
@@ -186,7 +196,7 @@ class PLL_Plugin_Updater {
 		}
 
 		// Restore our filter
-		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_update' ) );
+		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ] );
 
 		if ( ! empty( $update_cache->response[ $this->name ] ) && version_compare( $this->version, $version_info->new_version, '<' ) ) {
 
@@ -216,7 +226,7 @@ class PLL_Plugin_Updater {
 					'<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
 					esc_html( $version_info->new_version ),
 					'</a>',
-					'<a href="' . esc_url( wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $this->name, 'upgrade-plugin_' . $this->name ) ) .'">',
+					'<a href="' . esc_url( wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $this->name, 'upgrade-plugin_' . $this->name ) ) . '">',
 					'</a>'
 				);
 			}
@@ -251,14 +261,14 @@ class PLL_Plugin_Updater {
 
 		}
 
-		$to_send = array(
+		$to_send = [
 			'slug'   => $this->slug,
 			'is_ssl' => is_ssl(),
-			'fields' => array(
-				'banners' => array(),
-				'reviews' => false
-			)
-		);
+			'fields' => [
+				'banners' => [],
+				'reviews' => false,
+			],
+		];
 
 		$cache_key = 'edd_api_request_' . md5( serialize( $this->slug . $this->api_data['license'] . $this->beta ) );
 
@@ -276,14 +286,13 @@ class PLL_Plugin_Updater {
 			if ( false !== $api_response ) {
 				$_data = $api_response;
 			}
-
 		} else {
 			$_data = $edd_api_request_transient;
 		}
 
 		// Convert sections into an associative array, since we're getting an object, but Core expects an array.
 		if ( isset( $_data->sections ) && ! is_array( $_data->sections ) ) {
-			$new_sections = array();
+			$new_sections = [];
 			foreach ( $_data->sections as $key => $value ) {
 				$new_sections[ $key ] = $value;
 			}
@@ -293,7 +302,7 @@ class PLL_Plugin_Updater {
 
 		// Convert banners into an associative array, since we're getting an object, but Core expects an array.
 		if ( isset( $_data->banners ) && ! is_array( $_data->banners ) ) {
-			$new_banners = array();
+			$new_banners = [];
 			foreach ( $_data->banners as $key => $value ) {
 				$new_banners[ $key ] = $value;
 			}
@@ -342,11 +351,11 @@ class PLL_Plugin_Updater {
 			return;
 		}
 
-		if( $this->api_url == trailingslashit (home_url() ) ) {
+		if ( $this->api_url == trailingslashit( home_url() ) ) {
 			return false; // Don't allow a plugin to ping itself
 		}
 
-		$api_params = array(
+		$api_params = [
 			'edd_action' => 'get_version',
 			'license'    => ! empty( $data['license'] ) ? $data['license'] : '',
 			'item_name'  => isset( $data['item_name'] ) ? $data['item_name'] : false,
@@ -356,10 +365,16 @@ class PLL_Plugin_Updater {
 			'author'     => $data['author'],
 			'url'        => home_url(),
 			'beta'       => ! empty( $data['beta'] ),
-		);
+		];
 
 		$verify_ssl = $this->verify_ssl();
-		$request    = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => $verify_ssl, 'body' => $api_params ) );
+		$request    = wp_remote_post(
+			$this->api_url, [
+				'timeout' => 15,
+				'sslverify' => $verify_ssl,
+				'body' => $api_params,
+			]
+		);
 
 		if ( ! is_wp_error( $request ) ) {
 			$request = json_decode( wp_remote_retrieve_body( $request ) );
@@ -375,8 +390,8 @@ class PLL_Plugin_Updater {
 			$request->banners = maybe_unserialize( $request->banners );
 		}
 
-		if( ! empty( $request->sections ) ) {
-			foreach( $request->sections as $key => $section ) {
+		if ( ! empty( $request->sections ) ) {
+			foreach ( $request->sections as $key => $section ) {
 				$request->$key = (array) $section;
 			}
 		}
@@ -388,20 +403,20 @@ class PLL_Plugin_Updater {
 
 		global $edd_plugin_data;
 
-		if( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' != $_REQUEST['edd_sl_action'] ) {
+		if ( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' != $_REQUEST['edd_sl_action'] ) {
 			return;
 		}
 
-		if( empty( $_REQUEST['plugin'] ) ) {
+		if ( empty( $_REQUEST['plugin'] ) ) {
 			return;
 		}
 
-		if( empty( $_REQUEST['slug'] ) ) {
+		if ( empty( $_REQUEST['slug'] ) ) {
 			return;
 		}
 
-		if( ! current_user_can( 'update_plugins' ) ) {
-			wp_die( __( 'You do not have permission to install plugin updates', 'polylang' ), __( 'Error', 'polylang' ), array( 'response' => 403 ) );
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			wp_die( __( 'You do not have permission to install plugin updates', 'polylang' ), __( 'Error', 'polylang' ), [ 'response' => 403 ] );
 		}
 
 		$data         = $edd_plugin_data[ $_REQUEST['slug'] ];
@@ -409,25 +424,30 @@ class PLL_Plugin_Updater {
 		$cache_key    = md5( 'edd_plugin_' . sanitize_key( $_REQUEST['plugin'] ) . '_' . $beta . '_version_info' );
 		$version_info = $this->get_cached_version_info( $cache_key );
 
-		if( false === $version_info ) {
+		if ( false === $version_info ) {
 
-			$api_params = array(
+			$api_params = [
 				'edd_action' => 'get_version',
 				'item_name'  => isset( $data['item_name'] ) ? $data['item_name'] : false,
 				'item_id'    => isset( $data['item_id'] ) ? $data['item_id'] : false,
 				'slug'       => $_REQUEST['slug'],
 				'author'     => $data['author'],
 				'url'        => home_url(),
-				'beta'       => ! empty( $data['beta'] )
-			);
+				'beta'       => ! empty( $data['beta'] ),
+			];
 
 			$verify_ssl = $this->verify_ssl();
-			$request    = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => $verify_ssl, 'body' => $api_params ) );
+			$request    = wp_remote_post(
+				$this->api_url, [
+					'timeout' => 15,
+					'sslverify' => $verify_ssl,
+					'body' => $api_params,
+				]
+			);
 
 			if ( ! is_wp_error( $request ) ) {
 				$version_info = json_decode( wp_remote_retrieve_body( $request ) );
 			}
-
 
 			if ( ! empty( $version_info ) && isset( $version_info->sections ) ) {
 				$version_info->sections = maybe_unserialize( $version_info->sections );
@@ -435,8 +455,8 @@ class PLL_Plugin_Updater {
 				$version_info = false;
 			}
 
-			if( ! empty( $version_info ) ) {
-				foreach( $version_info->sections as $key => $section ) {
+			if ( ! empty( $version_info ) ) {
+				foreach ( $version_info->sections as $key => $section ) {
 					$version_info->$key = (array) $section;
 				}
 			}
@@ -445,7 +465,7 @@ class PLL_Plugin_Updater {
 
 		}
 
-		if( ! empty( $version_info ) && isset( $version_info->sections['changelog'] ) ) {
+		if ( ! empty( $version_info ) && isset( $version_info->sections['changelog'] ) ) {
 			echo '<div style="background:#fff;padding:10px;">' . $version_info->sections['changelog'] . '</div>';
 		}
 
@@ -454,13 +474,13 @@ class PLL_Plugin_Updater {
 
 	public function get_cached_version_info( $cache_key = '' ) {
 
-		if( empty( $cache_key ) ) {
+		if ( empty( $cache_key ) ) {
 			$cache_key = $this->cache_key;
 		}
 
 		$cache = get_option( $cache_key );
 
-		if( empty( $cache['timeout'] ) || current_time( 'timestamp' ) > $cache['timeout'] ) {
+		if ( empty( $cache['timeout'] ) || current_time( 'timestamp' ) > $cache['timeout'] ) {
 			return false; // Cache is expired
 		}
 
@@ -470,14 +490,14 @@ class PLL_Plugin_Updater {
 
 	public function set_version_info_cache( $value = '', $cache_key = '' ) {
 
-		if( empty( $cache_key ) ) {
+		if ( empty( $cache_key ) ) {
 			$cache_key = $this->cache_key;
 		}
 
-		$data = array(
+		$data = [
 			'timeout' => strtotime( '+3 hours', current_time( 'timestamp' ) ),
-			'value'   => json_encode( $value )
-		);
+			'value'   => json_encode( $value ),
+		];
 
 		update_option( $cache_key, $data, 'no' );
 

--- a/install/plugin-updater.php
+++ b/install/plugin-updater.php
@@ -90,7 +90,7 @@ class PLL_Plugin_Updater {
 			$_transient_data = new stdClass;
 		}
 
-		if ( 'plugins.php' == $pagenow && is_multisite() ) {
+		if ( 'plugins.php' === $pagenow && is_multisite() ) {
 			return $_transient_data;
 		}
 
@@ -148,7 +148,7 @@ class PLL_Plugin_Updater {
 			return;
 		}
 
-		if ( $this->name != $file ) {
+		if ( $this->name !== $file ) {
 			return;
 		}
 
@@ -249,13 +249,13 @@ class PLL_Plugin_Updater {
 	 */
 	public function plugins_api_filter( $_data, $_action = '', $_args = null ) {
 
-		if ( $_action != 'plugin_information' ) {
+		if ( $_action !== 'plugin_information' ) {
 
 			return $_data;
 
 		}
 
-		if ( ! isset( $_args->slug ) || ( $_args->slug != $this->slug ) ) {
+		if ( ! isset( $_args->slug ) || ( $_args->slug !== $this->slug ) ) {
 
 			return $_data;
 
@@ -347,11 +347,11 @@ class PLL_Plugin_Updater {
 
 		$data = array_merge( $this->api_data, $_data );
 
-		if ( $data['slug'] != $this->slug ) {
+		if ( $data['slug'] !== $this->slug ) {
 			return;
 		}
 
-		if ( $this->api_url == trailingslashit( home_url() ) ) {
+		if ( $this->api_url === trailingslashit( home_url() ) ) {
 			return false; // Don't allow a plugin to ping itself
 		}
 
@@ -403,7 +403,7 @@ class PLL_Plugin_Updater {
 
 		global $edd_plugin_data;
 
-		if ( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' != $_REQUEST['edd_sl_action'] ) {
+		if ( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' !== $_REQUEST['edd_sl_action'] ) {
 			return;
 		}
 

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -328,7 +328,7 @@ class PLL_Upgrade {
 		if ( version_compare( $this->options['version'], '1.1', '<' ) ) {
 			if ( $menu_lang = get_option( 'polylang_nav_menus' ) ) {
 				foreach ( $menu_lang as $location => $arr ) {
-					if ( ! in_array( $location, array_keys( get_registered_nav_menus() ) ) ) {
+					if ( ! in_array( $location, array_keys( get_registered_nav_menus() ), true ) ) {
 						continue;
 					}
 
@@ -464,7 +464,7 @@ class PLL_Upgrade {
 	 * @since 1.4.1
 	 */
 	protected function upgrade_1_4_1() {
-		if ( 3 == $this->options['force_lang'] ) {
+		if ( 3 === $this->options['force_lang'] ) {
 			$this->options['browser'] = $this->options['hide_default'] = 0;
 		}
 	}
@@ -540,7 +540,7 @@ class PLL_Upgrade {
 		}
 
 		foreach ( $translations as $translation ) {
-			if ( in_array( $translation['language'], $languages ) ) {
+			if ( in_array( $translation['language'], $languages, true ) ) {
 				$translation['type']    = 'core';
 				$translations_to_load[] = (object) $translation;
 			}

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -228,6 +228,7 @@ class PLL_Upgrade {
 
 		// Assign language to each term
 		if ( ! empty( $terms ) ) {
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $terms ) );
 		}
 
@@ -237,6 +238,7 @@ class PLL_Upgrade {
 			$terms = $slugs = $tts = $trs = [];
 
 			// Get all translated objects
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$objects = $wpdb->get_col( "SELECT DISTINCT meta_value FROM {$wpdb->$table} WHERE meta_key = '_translations'" );
 
 			if ( empty( $objects ) ) {
@@ -255,10 +257,12 @@ class PLL_Upgrade {
 
 			// Insert terms
 			if ( ! empty( $terms ) ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "INSERT INTO $wpdb->terms ( slug, name ) VALUES " . implode( ',', $terms ) );
 			}
 
 			// Get all terms with their term_id
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$terms = $wpdb->get_results( "SELECT term_id, slug FROM $wpdb->terms WHERE slug IN ( " . implode( ',', $slugs ) . ' )' );
 
 			// Prepare terms taxonomy relationship
@@ -270,6 +274,7 @@ class PLL_Upgrade {
 
 			// Insert term_taxonomy
 			if ( ! empty( $tts ) ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "INSERT INTO $wpdb->term_taxonomy ( term_id, taxonomy, description ) VALUES " . implode( ',', $tts ) );
 			}
 
@@ -290,6 +295,7 @@ class PLL_Upgrade {
 
 			// Insert term_relationships
 			if ( ! empty( $trs ) ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $trs ) );
 			}
 		}

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,119 +1,119 @@
-jQuery( document ).ready(function( $ ) {
-	var transitionTimeout;
+jQuery( document ).ready( function ( $ ) {
+	let transitionTimeout;
 
 	// languages list table
 	// accessibility to row actions on focus
 	// mainly copy paste of WP code from common.js
-	$( 'table.languages' ).on({ // restricted to languages list table
-		focusin: function() {
+	$( 'table.languages' ).on( { // restricted to languages list table
+		focusin: function () {
 			clearTimeout( transitionTimeout );
 			focusedRowActions = $( this ).find( '.row-actions' );
 			// transitionTimeout is necessary for Firefox, but Chrome won't remove the CSS class without a little help.
 			$( '.row-actions' ).not( this ).removeClass( 'visible' );
 			focusedRowActions.addClass( 'visible' );
 		},
-		focusout: function() {
+		focusout: function () {
 			// Tabbing between post title and .row-actions links needs a brief pause, otherwise
 			// the .row-actions div gets hidden in transit in some browsers ( ahem, Firefox ).
-			transitionTimeout = setTimeout(function() {
+			transitionTimeout = setTimeout( function () {
 				focusedRowActions.removeClass( 'visible' );
 			}, 30 );
-		}
+		},
 	}, 'tr' ); // acts on the whole tr instead of single td as we have actions links in several columns
 
 	// extends selectmenu to add flags in menu items
-	$.widget( "custom.iconselectmenu", $.ui.selectmenu, {
-		_renderItem: function( ul, item ) {
-			var li = $( "<li>", { text: item.label } );
+	$.widget( 'custom.iconselectmenu', $.ui.selectmenu, {
+		_renderItem: function ( ul, item ) {
+			let li = $( '<li>', { text: item.label } );
 
 			if ( item.value ) {
-				$( "<img>", {
+				$( '<img>', {
 					src: pll_flag_base_url + item.value + '.png',
-					"class": "ui-icon"
-				}).appendTo( li );
+					'class': 'ui-icon',
+				} ).appendTo( li );
 			}
 
 			return li.appendTo( ul );
-		}
-	});
+		},
+	} );
 
 	// allows to display the flag for the selected menu item
 	function add_icon( event, ui ) {
-		var value = $( this ).val();
+		let value = $( this ).val();
 		if ( value ) {
-			var txt = $( this ).iconselectmenu( "widget" ).children( ":last" );
-			var img = $( '<img class="ui-icon" >' ).appendTo( txt );
-			img.attr( "src", pll_flag_base_url + value + '.png' );
+			let txt = $( this ).iconselectmenu( 'widget' ).children( ':last' );
+			let img = $( '<img class="ui-icon" >' ).appendTo( txt );
+			img.attr( 'src', pll_flag_base_url + value + '.png' );
 		}
 	}
 
 	// overrides the flag dropdown list with our customized jquery ui selectmenu
-	$( "#flag_list" ).iconselectmenu({
+	$( '#flag_list' ).iconselectmenu( {
 		create: add_icon,
 		select: add_icon,
-	});
+	} );
 
 	// languages form
 	// fills the fields based on the language dropdown list choice
-	$( '#lang_list' ).change(function() {
-		var value = $( this ).val().split( ':' );
-		var selected = $( "select option:selected" ).text().split( ' - ' );
+	$( '#lang_list' ).change( function () {
+		let value = $( this ).val().split( ':' );
+		let selected = $( 'select option:selected' ).text().split( ' - ' );
 		$( '#lang_slug' ).val( value[0] );
 		$( '#lang_locale' ).val( value[1] );
-		$( 'input[name="rtl"]' ).val( [value[2]] );
+		$( 'input[name="rtl"]' ).val( [ value[2] ] );
 		$( '#lang_name' ).val( selected[0] );
 		$( '#flag_list option[value="' + value[3] + '"]' ).attr( 'selected', 'selected' );
 
 		// recreate the jquery ui selectmenu
-		$( "#flag_list" ).iconselectmenu( 'destroy' ).iconselectmenu({
+		$( '#flag_list' ).iconselectmenu( 'destroy' ).iconselectmenu( {
 			create: add_icon,
 			select: add_icon,
-		})
-	});
+		} )
+	} );
 
 	// strings translations
 	// save translations when pressing enter
-	$( '.translation input' ).keypress(function( event ){
-		if ( 13 === event.keyCode ) {
+	$( '.translation input' ).keypress( function ( event ){
+		if ( event.keyCode === 13 ) {
 			event.preventDefault();
 			$( '#submit' ).click();
 		}
-	});
+	} );
 
 	// settings page
 	// click on configure link
-	$( '#the-list' ).on( 'click', '.configure>a', function(){
+	$( '#the-list' ).on( 'click', '.configure>a', function (){
 		$( '.pll-configure' ).hide().prev().show();
 		$( this ).closest( 'tr' ).hide().next().show();
 		return false;
-	});
+	} );
 
 	// cancel
-	$( '#the-list' ).on( 'click', '.cancel', function(){
+	$( '#the-list' ).on( 'click', '.cancel', function (){
 		$( this ).closest( 'tr' ).hide().prev().show();
-	});
+	} );
 
 	// save settings
-	$( '#the-list' ).on( 'click', '.save', function(){
-		var tr = $( this ).closest( 'tr' );
-		var parts = tr.attr( 'id' ).split( '-' );
+	$( '#the-list' ).on( 'click', '.save', function (){
+		let tr = $( this ).closest( 'tr' );
+		let parts = tr.attr( 'id' ).split( '-' );
 
-		var data = {
-			action:            'pll_save_options',
+		let data = {
+			action: 'pll_save_options',
 			pll_ajax_settings: true,
-			module:            parts[parts.length - 1],
-			_pll_nonce:        $( '#_pll_nonce' ).val()
+			module: parts[parts.length - 1],
+			_pll_nonce: $( '#_pll_nonce' ).val(),
 		}
 
 		data = tr.find( ':input' ).serialize() + '&' + $.param( data );
 
-		$.post( ajaxurl, data, function( response ) {
-			var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
-			$.each( res.responses, function() {
+		$.post( ajaxurl, data, function ( response ) {
+			let res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+			$.each( res.responses, function () {
 				switch ( this.what ) {
 					case 'license-update':
 						$( '#pll-license-' + this.data ).replaceWith( this.supplemental.html );
-					break;
+						break;
 					case 'success':
 						tr.hide().prev().show(); // close only if there is no error
 					case 'error':
@@ -122,8 +122,8 @@ jQuery( document ).ready(function( $ ) {
 
 						// Make notices dismissible
 						// copy paste of common.js from WP 4.2.2
-						$( '.notice.is-dismissible' ).each(function() {
-							var $this = $( this ),
+						$( '.notice.is-dismissible' ).each( function () {
+							let $this = $( this ),
 								$button = $( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ),
 								btnText = commonL10n.dismiss || '';
 
@@ -132,60 +132,60 @@ jQuery( document ).ready(function( $ ) {
 
 							$this.append( $button );
 
-							$button.on( 'click.wp-dismiss-notice', function( event ) {
+							$button.on( 'click.wp-dismiss-notice', function ( event ) {
 								event.preventDefault();
-								$this.fadeTo( 100 , 0, function() {
-									$( this ).slideUp( 100, function() {
+								$this.fadeTo( 100, 0, function () {
+									$( this ).slideUp( 100, function () {
 										$( this ).remove();
-									});
-								});
-							});
-						});
-					break;
+									} );
+								} );
+							} );
+						} );
+						break;
 				}
-			});
-		});
-	});
+			} );
+		} );
+	} );
 
 	// act when pressing enter or esc in configurations
-	$( '.pll-configure' ).keypress(function( event ){
-		if ( 13 === event.keyCode ) {
+	$( '.pll-configure' ).keypress( function ( event ){
+		if ( event.keyCode === 13 ) {
 			event.preventDefault();
 			$( this ).find( '.save' ).click();
 		}
 
-		if ( 27 === event.keyCode ) {
+		if ( event.keyCode === 27 ) {
 			event.preventDefault();
 			$( this ).find( '.cancel' ).click();
 		}
-	});
+	} );
 
 	// settings URL modifications
 	// manages visibility of fields
-	$( "input[name='force_lang']" ).change(function() {
+	$( 'input[name=\'force_lang\']' ).change( function () {
 		function pll_toggle( a, test ) {
 			test ? a.show() : a.hide();
 		}
 
-		var value = $( this ).val();
-		pll_toggle( $( '#pll-domains-table' ), 3 == value );
-		pll_toggle( $( "#pll-hide-default" ), 3 > value );
-		pll_toggle( $( "#pll-rewrite" ), 2 > value );
-		pll_toggle( $( "#pll-redirect-lang" ), 2 > value );
-	});
+		let value = $( this ).val();
+		pll_toggle( $( '#pll-domains-table' ), value == 3 );
+		pll_toggle( $( '#pll-hide-default' ), value < 3 );
+		pll_toggle( $( '#pll-rewrite' ), value < 2 );
+		pll_toggle( $( '#pll-redirect-lang' ), value < 2 );
+	} );
 
 	// settings license
 	// deactivate button
-	$( '.pll-deactivate-license' ).on( 'click', function() {
-		var data = {
-			action:            'pll_deactivate_license',
+	$( '.pll-deactivate-license' ).on( 'click', function () {
+		let data = {
+			action: 'pll_deactivate_license',
 			pll_ajax_settings: true,
-			id:                $( this ).attr( 'id' ),
-			_pll_nonce:        $( '#_pll_nonce' ).val()
+			id: $( this ).attr( 'id' ),
+			_pll_nonce: $( '#_pll_nonce' ).val(),
 		}
-		$.post( ajaxurl, data , function( response ){
+		$.post( ajaxurl, data, function ( response ){
 			$( '#pll-license-' + response.id ).replaceWith( response.html );
-		});
-	});
+		} );
+	} );
 
-});
+} );

--- a/js/admin.min.js
+++ b/js/admin.min.js
@@ -1,1 +1,73 @@
-jQuery(document).ready(function(e){function t(){var t=e(this).val();if(t){var n=e(this).iconselectmenu("widget").children(":last"),i=e('<img class="ui-icon" >').appendTo(n);i.attr("src",pll_flag_base_url+t+".png")}}var n;e("table.languages").on({focusin:function(){clearTimeout(n),focusedRowActions=e(this).find(".row-actions"),e(".row-actions").not(this).removeClass("visible"),focusedRowActions.addClass("visible")},focusout:function(){n=setTimeout(function(){focusedRowActions.removeClass("visible")},30)}},"tr"),e.widget("custom.iconselectmenu",e.ui.selectmenu,{_renderItem:function(t,n){var i=e("<li>",{text:n.label});return n.value&&e("<img>",{src:pll_flag_base_url+n.value+".png","class":"ui-icon"}).appendTo(i),i.appendTo(t)}}),e("#flag_list").iconselectmenu({create:t,select:t}),e("#lang_list").change(function(){var n=e(this).val().split(":"),i=e("select option:selected").text().split(" - ");e("#lang_slug").val(n[0]),e("#lang_locale").val(n[1]),e('input[name="rtl"]').val([n[2]]),e("#lang_name").val(i[0]),e('#flag_list option[value="'+n[3]+'"]').attr("selected","selected"),e("#flag_list").iconselectmenu("destroy").iconselectmenu({create:t,select:t})}),e(".translation input").keypress(function(t){13===t.keyCode&&(t.preventDefault(),e("#submit").click())}),e("#the-list").on("click",".configure>a",function(){return e(".pll-configure").hide().prev().show(),e(this).closest("tr").hide().next().show(),!1}),e("#the-list").on("click",".cancel",function(){e(this).closest("tr").hide().prev().show()}),e("#the-list").on("click",".save",function(){var t=e(this).closest("tr"),n=t.attr("id").split("-"),i={action:"pll_save_options",pll_ajax_settings:!0,module:n[n.length-1],_pll_nonce:e("#_pll_nonce").val()};i=t.find(":input").serialize()+"&"+e.param(i),e.post(ajaxurl,i,function(n){var i=wpAjax.parseAjaxResponse(n,"ajax-response");e.each(i.responses,function(){switch(this.what){case"license-update":e("#pll-license-"+this.data).replaceWith(this.supplemental.html);break;case"success":t.hide().prev().show();case"error":e(".settings-error").remove(),e("h1").after(this.data),e(".notice.is-dismissible").each(function(){var t=e(this),n=e('<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>'),i=commonL10n.dismiss||"";n.find(".screen-reader-text").text(i),t.append(n),n.on("click.wp-dismiss-notice",function(n){n.preventDefault(),t.fadeTo(100,0,function(){e(this).slideUp(100,function(){e(this).remove()})})})})}})})}),e(".pll-configure").keypress(function(t){13===t.keyCode&&(t.preventDefault(),e(this).find(".save").click()),27===t.keyCode&&(t.preventDefault(),e(this).find(".cancel").click())}),e("input[name='force_lang']").change(function(){function t(e,t){t?e.show():e.hide()}var n=e(this).val();t(e("#pll-domains-table"),3==n),t(e("#pll-hide-default"),3>n),t(e("#pll-rewrite"),2>n),t(e("#pll-redirect-lang"),2>n)}),e(".pll-deactivate-license").on("click",function(){var t={action:"pll_deactivate_license",pll_ajax_settings:!0,id:e(this).attr("id"),_pll_nonce:e("#_pll_nonce").val()};e.post(ajaxurl,t,function(t){e("#pll-license-"+t.id).replaceWith(t.html)})})});
+jQuery( document ).ready( function ( e ){
+	function t(){
+		let t=e( this ).val(); if ( t ){
+			let n=e( this ).iconselectmenu( 'widget' ).children( ':last' ), i=e( '<img class="ui-icon" >' ).appendTo( n ); i.attr( 'src', pll_flag_base_url+t+'.png' )
+		}
+	} let n; e( 'table.languages' ).on( {
+		focusin: function (){
+			clearTimeout( n ), focusedRowActions=e( this ).find( '.row-actions' ), e( '.row-actions' ).not( this ).removeClass( 'visible' ), focusedRowActions.addClass( 'visible' )
+		},
+		focusout: function (){
+			n=setTimeout( function (){
+				focusedRowActions.removeClass( 'visible' )
+			}, 30 )
+		},
+	}, 'tr' ), e.widget( 'custom.iconselectmenu', e.ui.selectmenu, {
+		_renderItem: function ( t, n ){
+			let i=e( '<li>', { text: n.label } ); return n.value&&e( '<img>', {
+				src: pll_flag_base_url+n.value+'.png',
+				'class': 'ui-icon',
+			} ).appendTo( i ), i.appendTo( t )
+		},
+	} ), e( '#flag_list' ).iconselectmenu( {
+		create: t,
+		select: t,
+	} ), e( '#lang_list' ).change( function (){
+		let n=e( this ).val().split( ':' ), i=e( 'select option:selected' ).text().split( ' - ' ); e( '#lang_slug' ).val( n[0] ), e( '#lang_locale' ).val( n[1] ), e( 'input[name="rtl"]' ).val( [ n[2] ] ), e( '#lang_name' ).val( i[0] ), e( '#flag_list option[value="'+n[3]+'"]' ).attr( 'selected', 'selected' ), e( '#flag_list' ).iconselectmenu( 'destroy' ).iconselectmenu( {
+			create: t,
+			select: t,
+		} )
+	} ), e( '.translation input' ).keypress( function ( t ){
+		t.keyCode===13&&( t.preventDefault(), e( '#submit' ).click() )
+	} ), e( '#the-list' ).on( 'click', '.configure>a', function (){
+		return e( '.pll-configure' ).hide().prev().show(), e( this ).closest( 'tr' ).hide().next().show(), ! 1
+	} ), e( '#the-list' ).on( 'click', '.cancel', function (){
+		e( this ).closest( 'tr' ).hide().prev().show()
+	} ), e( '#the-list' ).on( 'click', '.save', function (){
+		let t=e( this ).closest( 'tr' ), n=t.attr( 'id' ).split( '-' ), i={
+			action: 'pll_save_options',
+			pll_ajax_settings: ! 0,
+			module: n[n.length-1],
+			_pll_nonce: e( '#_pll_nonce' ).val(),
+		}; i=t.find( ':input' ).serialize()+'&'+e.param( i ), e.post( ajaxurl, i, function ( n ){
+			let i=wpAjax.parseAjaxResponse( n, 'ajax-response' ); e.each( i.responses, function (){
+				switch ( this.what ){
+					case 'license-update':e( '#pll-license-'+this.data ).replaceWith( this.supplemental.html ); break; case 'success':t.hide().prev().show(); case 'error':e( '.settings-error' ).remove(), e( 'h1' ).after( this.data ), e( '.notice.is-dismissible' ).each( function (){
+						let t=e( this ), n=e( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ), i=commonL10n.dismiss||''; n.find( '.screen-reader-text' ).text( i ), t.append( n ), n.on( 'click.wp-dismiss-notice', function ( n ){
+							n.preventDefault(), t.fadeTo( 100, 0, function (){
+								e( this ).slideUp( 100, function (){
+									e( this ).remove()
+								} )
+							} )
+						} )
+					} )
+				}
+			} )
+		} )
+	} ), e( '.pll-configure' ).keypress( function ( t ){
+		t.keyCode===13&&( t.preventDefault(), e( this ).find( '.save' ).click() ), t.keyCode===27&&( t.preventDefault(), e( this ).find( '.cancel' ).click() )
+	} ), e( 'input[name=\'force_lang\']' ).change( function (){
+		function t( e, t ){
+			t?e.show():e.hide()
+		} let n=e( this ).val(); t( e( '#pll-domains-table' ), n==3 ), t( e( '#pll-hide-default' ), n<3 ), t( e( '#pll-rewrite' ), n<2 ), t( e( '#pll-redirect-lang' ), n<2 )
+	} ), e( '.pll-deactivate-license' ).on( 'click', function (){
+		let t={
+			action: 'pll_deactivate_license',
+			pll_ajax_settings: ! 0,
+			id: e( this ).attr( 'id' ),
+			_pll_nonce: e( '#_pll_nonce' ).val(),
+		}; e.post( ajaxurl, t, function ( t ){
+			e( '#pll-license-'+t.id ).replaceWith( t.html )
+		} )
+	} )
+} );

--- a/js/media.js
+++ b/js/media.js
@@ -1,6 +1,6 @@
 // when clicking on attach link, filters find post list per media language
-(function( $ ){
-	$.ajaxPrefilter(function ( options, originalOptions, jqXHR ) {
+( function ( $ ){
+	$.ajaxPrefilter( function ( options, originalOptions, jqXHR ) {
 		options.data = 'pll_post_id=' + $( '#affected' ).val() + '&' + options.data;
-	});
-})( jQuery )
+	} );
+} )( jQuery )

--- a/js/media.min.js
+++ b/js/media.min.js
@@ -1,1 +1,5 @@
-!function(a){a.ajaxPrefilter(function(t){t.data="pll_post_id="+a("#affected").val()+"&"+t.data})}(jQuery);
+! function ( a ){
+	a.ajaxPrefilter( function ( t ){
+		t.data='pll_post_id='+a( '#affected' ).val()+'&'+t.data
+	} )
+}( jQuery );

--- a/js/nav-menu.js
+++ b/js/nav-menu.js
@@ -1,68 +1,68 @@
-jQuery( document ).ready(function( $ ) {
-	$( '#update-nav-menu' ).bind( 'click', function( e ) {
-		if ( e.target && e.target.className && -1 != e.target.className.indexOf( 'item-edit' ) ) {
-			$( "input[value='#pll_switcher'][type=text]" ).parent().parent().parent().each(function(){
-				var item = $( this ).attr( 'id' ).substring( 19 );
+jQuery( document ).ready( function ( $ ) {
+	$( '#update-nav-menu' ).bind( 'click', function ( e ) {
+		if ( e.target && e.target.className && e.target.className.indexOf( 'item-edit' ) != -1 ) {
+			$( 'input[value=\'#pll_switcher\'][type=text]' ).parent().parent().parent().each( function (){
+				let item = $( this ).attr( 'id' ).substring( 19 );
 				$( this ).children( 'p:not( .field-move )' ).remove(); // remove default fields we don't need
 
-				h = $( '<input>' ).attr({
-					type:  'hidden',
-					id:    'edit-menu-item-title-' + item,
-					name:  'menu-item-title[' + item + ']',
-					value: pll_data.title
-				});
+				h = $( '<input>' ).attr( {
+					type: 'hidden',
+					id: 'edit-menu-item-title-' + item,
+					name: 'menu-item-title[' + item + ']',
+					value: pll_data.title,
+				} );
 				$( this ).append( h );
 
-				h = $( '<input>' ).attr({
-					type:  'hidden',
-					id:    'edit-menu-item-url-' + item,
-					name:  'menu-item-url[' + item + ']',
-					value: '#pll_switcher'
-				});
+				h = $( '<input>' ).attr( {
+					type: 'hidden',
+					id: 'edit-menu-item-url-' + item,
+					name: 'menu-item-url[' + item + ']',
+					value: '#pll_switcher',
+				} );
 				$( this ).append( h );
 
 				// a hidden field which exits only if our jQuery code has been executed
-				h = $( '<input>' ).attr({
-					type:  'hidden',
-					id:    'edit-menu-item-pll-detect-' + item,
-					name:  'menu-item-pll-detect[' + item + ']',
-					value: 1
-				});
+				h = $( '<input>' ).attr( {
+					type: 'hidden',
+					id: 'edit-menu-item-pll-detect-' + item,
+					name: 'menu-item-pll-detect[' + item + ']',
+					value: 1,
+				} );
 				$( this ).append( h );
 
 				ids = Array( 'hide_if_no_translation', 'hide_current', 'force_home', 'show_flags', 'show_names', 'dropdown' ); // reverse order
 
 				// add the fields
-				for ( var i = 0; i < ids.length; i++ ) {
+				for ( let i = 0; i < ids.length; i++ ) {
 					p = $( '<p>' ).attr( 'class', 'description' );
 					$( this ).prepend( p );
 					label = $( '<label>' ).attr( 'for', 'edit-menu-item-' + ids[ i ] + '-' + item ).text( ' ' + pll_data.strings[ ids[ i ] ] );
 					p.append( label );
-					cb = $( '<input>' ).attr({
-						type:  'checkbox',
-						id:    'edit-menu-item-' + ids[ i ] + '-' + item,
-						name:  'menu-item-' + ids[ i ] + '[' + item + ']',
-						value: 1
-					});
-					if ( ( typeof( pll_data.val[ item ] ) != 'undefined' && pll_data.val[ item ][ ids[ i ] ] == 1 ) || ( typeof( pll_data.val[ item ] ) == 'undefined' && ids[ i ] == 'show_names' ) ) { // show_names as default value
+					cb = $( '<input>' ).attr( {
+						type: 'checkbox',
+						id: 'edit-menu-item-' + ids[ i ] + '-' + item,
+						name: 'menu-item-' + ids[ i ] + '[' + item + ']',
+						value: 1,
+					} );
+					if ( ( typeof ( pll_data.val[ item ] ) !== 'undefined' && pll_data.val[ item ][ ids[ i ] ] == 1 ) || ( typeof ( pll_data.val[ item ] ) === 'undefined' && ids[ i ] == 'show_names' ) ) { // show_names as default value
 						cb.prop( 'checked', true );
 					}
 					label.prepend( cb );
 				}
-			});
+			} );
 
 			// disallow unchecking both show names and show flags
-			$( '.menu-item-data-object-id' ).each(function() {
-				var id = $( this ).val();
-				var options = ['names-', 'flags-'];
-				$.each( options, function( i, v ) {
-					$( '#edit-menu-item-show_' + v + id ).change(function() {
-						if ( 'checked' != $( this ).attr( 'checked' ) ) {
+			$( '.menu-item-data-object-id' ).each( function () {
+				let id = $( this ).val();
+				let options = [ 'names-', 'flags-' ];
+				$.each( options, function ( i, v ) {
+					$( '#edit-menu-item-show_' + v + id ).change( function () {
+						if ( $( this ).attr( 'checked' ) != 'checked' ) {
 							$( '#edit-menu-item-show_' + options[ 1 - i ] + id ).prop( 'checked', true );
 						}
-					});
-				});
-			});
+					} );
+				} );
+			} );
 		}
-	});
-});
+	} );
+} );

--- a/js/nav-menu.min.js
+++ b/js/nav-menu.min.js
@@ -1,1 +1,41 @@
-jQuery(document).ready(function(a){a("#update-nav-menu").bind("click",function(b){if(b.target&&b.target.className&&-1!=b.target.className.indexOf("item-edit")){a("input[value='#pll_switcher'][type=text]").parent().parent().parent().each(function(){var d=a(this).attr("id").substring(19);a(this).children("p:not( .field-move )").remove();h=a("<input>").attr({type:"hidden",id:"edit-menu-item-title-"+d,name:"menu-item-title["+d+"]",value:pll_data.title});a(this).append(h);h=a("<input>").attr({type:"hidden",id:"edit-menu-item-url-"+d,name:"menu-item-url["+d+"]",value:"#pll_switcher"});a(this).append(h);h=a("<input>").attr({type:"hidden",id:"edit-menu-item-pll-detect-"+d,name:"menu-item-pll-detect["+d+"]",value:1});a(this).append(h);ids=Array("hide_if_no_translation","hide_current","force_home","show_flags","show_names","dropdown");for(var c=0;c<ids.length;c++){p=a("<p>").attr("class","description");a(this).prepend(p);label=a("<label>").attr("for","edit-menu-item-"+ids[c]+"-"+d).text(" "+pll_data.strings[ids[c]]);p.append(label);cb=a("<input>").attr({type:"checkbox",id:"edit-menu-item-"+ids[c]+"-"+d,name:"menu-item-"+ids[c]+"["+d+"]",value:1});if((typeof(pll_data.val[d])!="undefined"&&pll_data.val[d][ids[c]]==1)||(typeof(pll_data.val[d])=="undefined"&&ids[c]=="show_names")){cb.prop("checked",true)}label.prepend(cb)}});a(".menu-item-data-object-id").each(function(){var d=a(this).val();var c=["names-","flags-"];a.each(c,function(f,e){a("#edit-menu-item-show_"+e+d).change(function(){if("checked"!=a(this).attr("checked")){a("#edit-menu-item-show_"+c[1-f]+d).prop("checked",true)}})})})}})});
+jQuery( document ).ready( function ( a ){
+	a( '#update-nav-menu' ).bind( 'click', function ( b ){
+		if ( b.target&&b.target.className&&b.target.className.indexOf( 'item-edit' )!=-1 ){
+			a( 'input[value=\'#pll_switcher\'][type=text]' ).parent().parent().parent().each( function (){
+				let d=a( this ).attr( 'id' ).substring( 19 ); a( this ).children( 'p:not( .field-move )' ).remove(); h=a( '<input>' ).attr( {
+					type: 'hidden',
+					id: 'edit-menu-item-title-'+d,
+					name: 'menu-item-title['+d+']',
+					value: pll_data.title,
+				} ); a( this ).append( h ); h=a( '<input>' ).attr( {
+					type: 'hidden',
+					id: 'edit-menu-item-url-'+d,
+					name: 'menu-item-url['+d+']',
+					value: '#pll_switcher',
+				} ); a( this ).append( h ); h=a( '<input>' ).attr( {
+					type: 'hidden',
+					id: 'edit-menu-item-pll-detect-'+d,
+					name: 'menu-item-pll-detect['+d+']',
+					value: 1,
+				} ); a( this ).append( h ); ids=Array( 'hide_if_no_translation', 'hide_current', 'force_home', 'show_flags', 'show_names', 'dropdown' ); for ( let c=0; c<ids.length; c++ ){
+					p=a( '<p>' ).attr( 'class', 'description' ); a( this ).prepend( p ); label=a( '<label>' ).attr( 'for', 'edit-menu-item-'+ids[c]+'-'+d ).text( ' '+pll_data.strings[ids[c]] ); p.append( label ); cb=a( '<input>' ).attr( {
+						type: 'checkbox',
+						id: 'edit-menu-item-'+ids[c]+'-'+d,
+						name: 'menu-item-'+ids[c]+'['+d+']',
+						value: 1,
+					} ); if ( ( typeof ( pll_data.val[d] )!=='undefined'&&pll_data.val[d][ids[c]]==1 )||( typeof ( pll_data.val[d] )==='undefined'&&ids[c]=='show_names' ) ){
+						cb.prop( 'checked', true )
+					}label.prepend( cb )
+				}
+			} ); a( '.menu-item-data-object-id' ).each( function (){
+				let d=a( this ).val(); let c=[ 'names-', 'flags-' ]; a.each( c, function ( f, e ){
+					a( '#edit-menu-item-show_'+e+d ).change( function (){
+						if ( a( this ).attr( 'checked' )!='checked' ){
+							a( '#edit-menu-item-show_'+c[1-f]+d ).prop( 'checked', true )
+						}
+					} )
+				} )
+			} )
+		}
+	} )
+} );

--- a/js/post.js
+++ b/js/post.js
@@ -1,148 +1,147 @@
 // tag suggest
 // valid for both tag metabox and quick edit
-(function( $ ){
-	$.ajaxPrefilter(function( options, originalOptions, jqXHR ) {
-		if ( 'string' === typeof options.data && ( -1 !== options.url.indexOf( 'action=ajax-tag-search' ) || -1 !== options.data.indexOf( 'action=ajax-tag-search' ) ) && ( ( lang = $( '.post_lang_choice' ).val() ) || ( lang = $( ':input[name="inline_lang_choice"]' ).val() ) ) ) {
+( function ( $ ){
+	$.ajaxPrefilter( function ( options, originalOptions, jqXHR ) {
+		if ( typeof options.data === 'string' && ( options.url.indexOf( 'action=ajax-tag-search' ) !== -1 || options.data.indexOf( 'action=ajax-tag-search' ) !== -1 ) && ( ( lang = $( '.post_lang_choice' ).val() ) || ( lang = $( ':input[name="inline_lang_choice"]' ).val() ) ) ) {
 			options.data = 'lang=' + lang + '&' + options.data;
 		}
-	});
-})( jQuery );
+	} );
+} )( jQuery );
 
 // overrides tagBox.get
-(function( $ ){
+( function ( $ ){
 	// overrides function to add the language
-	tagBox.get = function( id ) {
-		var tax = id.substr( id.indexOf( '-' ) + 1 );
+	tagBox.get = function ( id ) {
+		let tax = id.substr( id.indexOf( '-' ) + 1 );
 
 		// add the language in the $_POST variable
-		var data = {
+		let data = {
 			action: 'get-tagcloud',
-			lang:   $( '.post_lang_choice' ).val(),
-			tax:    tax
+			lang: $( '.post_lang_choice' ).val(),
+			tax: tax,
 		}
 
-		$.post( ajaxurl, data, function( r, stat ) {
-			if ( 0 == r || 'success' != stat ) {
+		$.post( ajaxurl, data, function ( r, stat ) {
+			if ( r == 0 || stat != 'success' ) {
 				r = wpAjax.broken;
 			}
 
 			r = $( '<div id="tagcloud-' + tax + '" class="the-tagcloud">' + r + '</div>' );
-			$( 'a', r ).click(function(){
+			$( 'a', r ).click( function (){
 				tagBox.flushTags( $( this ).closest( '.inside' ).children( '.tagsdiv' ), this );
 				return false;
-			});
+			} );
 
 			// add an if else condition to allow modifying the tags outputed when switching the language
 			if ( v = $( '.the-tagcloud' ).css( 'display' ) ) {
 				$( '.the-tagcloud' ).replaceWith( r );
 				$( '.the-tagcloud' ).css( 'display', v );
-			}
-			else {
+			} else {
 				$( '#' + id ).after( r );
 			}
-		});
+		} );
 	}
-})( jQuery );
+} )( jQuery );
 
 // quick edit
-(function( $ ) {
-	$( document ).bind( 'DOMNodeInserted', function( e ) {
-		var t = $( e.target );
+( function ( $ ) {
+	$( document ).bind( 'DOMNodeInserted', function ( e ) {
+		let t = $( e.target );
 
 		// WP inserts the quick edit from
-		if ( 'inline-edit' == t.attr( 'id' ) ) {
-			var post_id = t.prev().attr( 'id' ).replace( "post-", "" );
+		if ( t.attr( 'id' ) == 'inline-edit' ) {
+			let post_id = t.prev().attr( 'id' ).replace( 'post-', '' );
 
 			if ( post_id > 0 ) {
 				// language dropdown
-				var select = t.find( ':input[name="inline_lang_choice"]' );
-				var lang = $( '#lang_' + post_id ).html();
+				let select = t.find( ':input[name="inline_lang_choice"]' );
+				let lang = $( '#lang_' + post_id ).html();
 				select.val( lang ); // populates the dropdown
 
 				filter_terms( lang ); // initial filter for category checklist
 				filter_pages( lang ); // initial filter for parent dropdown
 
 				// modify category checklist an parent dropdown on language change
-				select.change(function() {
+				select.change( function () {
 					filter_terms( $( this ).val() );
 					filter_pages( $( this ).val() );
-				});
+				} );
 			}
 		}
 
 		// filter category checklist
 		function filter_terms( lang ) {
-			if ( "undefined" != typeof( pll_term_languages ) ) {
-				$.each( pll_term_languages, function( lg, term_tax ) {
-					$.each( term_tax, function( tax, terms ) {
-						$.each( terms, function( i ) {
+			if ( typeof ( pll_term_languages ) !== 'undefined' ) {
+				$.each( pll_term_languages, function ( lg, term_tax ) {
+					$.each( term_tax, function ( tax, terms ) {
+						$.each( terms, function ( i ) {
 							id = '#' + tax + '-' + pll_term_languages[ lg ][ tax ][ i ];
 							lang == lg ? $( id ).show() : $( id ).hide();
-						});
-					});
-				});
+						} );
+					} );
+				} );
 			}
 		}
 
 		// filter parent page dropdown list
 		function filter_pages( lang ) {
-			if ( "undefined" != typeof( pll_page_languages ) ) {
-				$.each( pll_page_languages, function( lg, pages ) {
-					$.each( pages, function( i ) {
+			if ( typeof ( pll_page_languages ) !== 'undefined' ) {
+				$.each( pll_page_languages, function ( lg, pages ) {
+					$.each( pages, function ( i ) {
 						v = $( '#post_parent option[value="' + pll_page_languages[ lg ][ i ] + '"]' );
 						lang == lg ? v.show() : v.hide();
-					});
-				});
+					} );
+				} );
 			}
 		}
-	});
-})( jQuery );
+	} );
+} )( jQuery );
 
 // update rows of translated posts when the language is modified in quick edit
 // acts on ajaxSuccess event
-(function( $ ) {
-	$( document ).ajaxSuccess(function( event, xhr, settings ) {
+( function ( $ ) {
+	$( document ).ajaxSuccess( function ( event, xhr, settings ) {
 		function update_rows( post_id ) {
 			// collect old translations
-			var translations = new Array;
-			$( '.translation_' + post_id ).each(function() {
+			let translations = new Array();
+			$( '.translation_' + post_id ).each( function () {
 				translations.push( $( this ).parent().parent().attr( 'id' ).substring( 5 ) );
-			});
+			} );
 
-			var data = {
-				action:       'pll_update_post_rows',
-				post_id:      post_id,
+			let data = {
+				action: 'pll_update_post_rows',
+				post_id: post_id,
 				translations: translations.join( ',' ),
-				post_type:    $( "input[name='post_type']" ).val(),
-				screen:       $( "input[name='screen']" ).val(),
-				_pll_nonce:   $( "input[name='_inline_edit']" ).val() // reuse quick edit nonce
+				post_type: $( 'input[name=\'post_type\']' ).val(),
+				screen: $( 'input[name=\'screen\']' ).val(),
+				_pll_nonce: $( 'input[name=\'_inline_edit\']' ).val(), // reuse quick edit nonce
 			}
 
 			// get the modified rows in ajax and update them
-			$.post( ajaxurl, data, function( response ) {
+			$.post( ajaxurl, data, function ( response ) {
 				if ( response ) {
-					var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
-					$.each( res.responses, function() {
-						if ( 'row' == this.what ) {
-							$( "#post-" + this.supplemental.post_id ).replaceWith( this.data );
+					let res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+					$.each( res.responses, function () {
+						if ( this.what == 'row' ) {
+							$( '#post-' + this.supplemental.post_id ).replaceWith( this.data );
 						}
-					});
+					} );
 				}
-			});
+			} );
 		}
 
-		var data = wpAjax.unserialize( settings.data ); // what were the data sent by the ajax request?
-		if ( 'undefined' != typeof( data['action'] ) && 'inline-save' == data['action'] ) {
+		let data = wpAjax.unserialize( settings.data ); // what were the data sent by the ajax request?
+		if ( typeof ( data['action'] ) !== 'undefined' && data['action'] == 'inline-save' ) {
 			update_rows( data['post_ID'] );
 		}
-	});
-})( jQuery );
+	} );
+} )( jQuery );
 
-jQuery( document ).ready(function( $ ) {
+jQuery( document ).ready( function ( $ ) {
 	// collect taxonomies - code partly copied from WordPress
-	var taxonomies = new Array();
-	$( '.categorydiv' ).each(function(){
-		var this_id = $( this ).attr( 'id' ), taxonomyParts, taxonomy;
+	let taxonomies = new Array();
+	$( '.categorydiv' ).each( function (){
+		let this_id = $( this ).attr( 'id' ), taxonomyParts, taxonomy;
 
 		taxonomyParts = this_id.split( '-' );
 		taxonomyParts.shift();
@@ -157,73 +156,73 @@ jQuery( document ).ready(function( $ ) {
 			.attr( 'name', 'term_lang_choice' )
 			.attr( 'value', $( '.post_lang_choice' ).val() )
 		);
-	});
+	} );
 
 	// ajax for changing the post's language in the languages metabox
-	$( '.post_lang_choice' ).change(function() {
-		var value = $( this ).val();
-		var lang  = $( this ).children( 'option[value="' + value + '"]' ).attr( 'lang' );
-		var dir   = $( '.pll-translation-column > span[lang="' + lang + '"]' ).attr( 'dir' );
+	$( '.post_lang_choice' ).change( function () {
+		let value = $( this ).val();
+		let lang  = $( this ).children( 'option[value="' + value + '"]' ).attr( 'lang' );
+		let dir   = $( '.pll-translation-column > span[lang="' + lang + '"]' ).attr( 'dir' );
 
-		var data = {
-			action:     'post_lang_choice',
-			lang:       value,
-			post_type:  $( '#post_type' ).val(),
+		let data = {
+			action: 'post_lang_choice',
+			lang: value,
+			post_type: $( '#post_type' ).val(),
 			taxonomies: taxonomies,
-			post_id:    $( '#post_ID' ).val(),
-			_pll_nonce: $( '#_pll_nonce' ).val()
+			post_id: $( '#post_ID' ).val(),
+			_pll_nonce: $( '#_pll_nonce' ).val(),
 		}
 
-		$.post( ajaxurl, data , function( response ) {
-			var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
-			$.each( res.responses, function() {
+		$.post( ajaxurl, data, function ( response ) {
+			let res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+			$.each( res.responses, function () {
 				switch ( this.what ) {
 					case 'translations': // translations fields
 						$( '.translations' ).html( this.data );
 						init_translations();
-					break;
+						break;
 					case 'taxonomy': // categories metabox for posts
 						var tax = this.data;
 						$( '#' + tax + 'checklist' ).html( this.supplemental.all );
 						$( '#' + tax + 'checklist-pop' ).html( this.supplemental.populars );
 						$( '#new' + tax + '_parent' ).replaceWith( this.supplemental.dropdown );
 						$( '#' + tax + '-lang' ).val( $( '.post_lang_choice' ).val() ); // hidden field
-					break;
+						break;
 					case 'pages': // parent dropdown list for pages
 						$( '#parent_id' ).html( this.data );
-					break;
+						break;
 					case 'flag': // flag in front of the select dropdown
 						$( '.pll-select-flag' ).html( this.data );
-					break;
+						break;
 					case 'permalink': // Sample permalink
 						var div = $( '#edit-slug-box' );
-						if ( '-1' != this.data && div.children().length ) {
+						if ( this.data != '-1' && div.children().length ) {
 							div.html( this.data );
 						}
-					break;
+						break;
 				}
-			});
+			} );
 
 			// modifies the language in the tag cloud
-			$( '.tagcloud-link' ).each(function() {
-				var id = $( this ).attr( 'id' );
+			$( '.tagcloud-link' ).each( function () {
+				let id = $( this ).attr( 'id' );
 				tagBox.get( id );
-			});
+			} );
 
 			// Modifies the text direction
 			$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
 			$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', lang ).attr( 'dir', dir );
 			$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
-		});
-	});
+		} );
+	} );
 
 	// translations autocomplete input box
 	function init_translations() {
-		$( '.tr_lang' ).each(function(){
-			var tr_lang = $( this ).attr( 'id' ).substring( 8 );
-			var td = $( this ).parent().parent().siblings( '.pll-edit-column' );
+		$( '.tr_lang' ).each( function (){
+			let tr_lang = $( this ).attr( 'id' ).substring( 8 );
+			let td = $( this ).parent().parent().siblings( '.pll-edit-column' );
 
-			$( this ).autocomplete({
+			$( this ).autocomplete( {
 				minLength: 0,
 
 				source: ajaxurl + '?action=pll_posts_not_translated' +
@@ -232,21 +231,21 @@ jQuery( document ).ready(function( $ ) {
 					'&post_type=' + $( '#post_type' ).val() +
 					'&_pll_nonce=' + $( '#_pll_nonce' ).val(),
 
-				select: function( event, ui ) {
+				select: function ( event, ui ) {
 					$( '#htr_lang_' + tr_lang ).val( ui.item.id );
 					td.html( ui.item.link );
 				},
-			});
+			} );
 
 			// when the input box is emptied
-			$( this ).blur(function() {
+			$( this ).blur( function () {
 				if ( ! $( this ).val() ) {
 					$( '#htr_lang_' + tr_lang ).val( 0 );
 					td.html( td.siblings( '.hidden' ).children().clone() );
 				}
-			});
-		});
+			} );
+		} );
 	}
 
 	init_translations();
-});
+} );

--- a/js/post.min.js
+++ b/js/post.min.js
@@ -1,1 +1,95 @@
-!function(t){t.ajaxPrefilter(function(a){"string"!=typeof a.data||-1===a.url.indexOf("action=ajax-tag-search")&&-1===a.data.indexOf("action=ajax-tag-search")||!(lang=t(".post_lang_choice").val())&&!(lang=t(':input[name="inline_lang_choice"]').val())||(a.data="lang="+lang+"&"+a.data)})}(jQuery),function(t){tagBox.get=function(a){var n=a.substr(a.indexOf("-")+1),e={action:"get-tagcloud",lang:t(".post_lang_choice").val(),tax:n};t.post(ajaxurl,e,function(e,i){0!=e&&"success"==i||(e=wpAjax.broken),e=t('<div id="tagcloud-'+n+'" class="the-tagcloud">'+e+"</div>"),t("a",e).click(function(){return tagBox.flushTags(t(this).closest(".inside").children(".tagsdiv"),this),!1}),(v=t(".the-tagcloud").css("display"))?(t(".the-tagcloud").replaceWith(e),t(".the-tagcloud").css("display",v)):t("#"+a).after(e)})}}(jQuery),function(t){t(document).bind("DOMNodeInserted",function(a){function n(a){"undefined"!=typeof pll_term_languages&&t.each(pll_term_languages,function(n,e){t.each(e,function(e,i){t.each(i,function(i){id="#"+e+"-"+pll_term_languages[n][e][i],a==n?t(id).show():t(id).hide()})})})}function e(a){"undefined"!=typeof pll_page_languages&&t.each(pll_page_languages,function(n,e){t.each(e,function(e){v=t('#post_parent option[value="'+pll_page_languages[n][e]+'"]'),a==n?v.show():v.hide()})})}var i=t(a.target);if("inline-edit"==i.attr("id")){var l=i.prev().attr("id").replace("post-","");if(l>0){var s=i.find(':input[name="inline_lang_choice"]'),o=t("#lang_"+l).html();s.val(o),n(o),e(o),s.change(function(){n(t(this).val()),e(t(this).val())})}}})}(jQuery),function(t){t(document).ajaxSuccess(function(a,n,e){function i(a){var n=new Array;t(".translation_"+a).each(function(){n.push(t(this).parent().parent().attr("id").substring(5))});var e={action:"pll_update_post_rows",post_id:a,translations:n.join(","),post_type:t("input[name='post_type']").val(),screen:t("input[name='screen']").val(),_pll_nonce:t("input[name='_inline_edit']").val()};t.post(ajaxurl,e,function(a){if(a){var n=wpAjax.parseAjaxResponse(a,"ajax-response");t.each(n.responses,function(){"row"==this.what&&t("#post-"+this.supplemental.post_id).replaceWith(this.data)})}})}var l=wpAjax.unserialize(e.data);"undefined"!=typeof l.action&&"inline-save"==l.action&&i(l.post_ID)})}(jQuery),jQuery(document).ready(function(t){function a(){t(".tr_lang").each(function(){var a=t(this).attr("id").substring(8),n=t(this).parent().parent().siblings(".pll-edit-column");t(this).autocomplete({minLength:0,source:ajaxurl+"?action=pll_posts_not_translated&post_language="+t(".post_lang_choice").val()+"&translation_language="+a+"&post_type="+t("#post_type").val()+"&_pll_nonce="+t("#_pll_nonce").val(),select:function(e,i){t("#htr_lang_"+a).val(i.item.id),n.html(i.item.link)}}),t(this).blur(function(){t(this).val()||(t("#htr_lang_"+a).val(0),n.html(n.siblings(".hidden").children().clone()))})})}var n=new Array;t(".categorydiv").each(function(){var a,e,i=t(this).attr("id");a=i.split("-"),a.shift(),e=a.join("-"),n.push(e),t("#"+e+"-add-submit").before(t("<input />").attr("type","hidden").attr("id",e+"-lang").attr("name","term_lang_choice").attr("value",t(".post_lang_choice").val()))}),t(".post_lang_choice").change(function(){var e=t(this).val(),i=t(this).children('option[value="'+e+'"]').attr("lang"),l=t('.pll-translation-column > span[lang="'+i+'"]').attr("dir"),s={action:"post_lang_choice",lang:e,post_type:t("#post_type").val(),taxonomies:n,post_id:t("#post_ID").val(),_pll_nonce:t("#_pll_nonce").val()};t.post(ajaxurl,s,function(n){var e=wpAjax.parseAjaxResponse(n,"ajax-response");t.each(e.responses,function(){switch(this.what){case"translations":t(".translations").html(this.data),a();break;case"taxonomy":var n=this.data;t("#"+n+"checklist").html(this.supplemental.all),t("#"+n+"checklist-pop").html(this.supplemental.populars),t("#new"+n+"_parent").replaceWith(this.supplemental.dropdown),t("#"+n+"-lang").val(t(".post_lang_choice").val());break;case"pages":t("#parent_id").html(this.data);break;case"flag":t(".pll-select-flag").html(this.data);break;case"permalink":var e=t("#edit-slug-box");"-1"!=this.data&&e.children().length&&e.html(this.data)}}),t(".tagcloud-link").each(function(){var a=t(this).attr("id");tagBox.get(a)}),t("body").removeClass("pll-dir-rtl").removeClass("pll-dir-ltr").addClass("pll-dir-"+l),t("#content_ifr").contents().find("html").attr("lang",i).attr("dir",l),t("#content_ifr").contents().find("body").attr("dir",l)})}),a()});
+! function ( t ){
+	t.ajaxPrefilter( function ( a ){
+		typeof a.data!=='string'||a.url.indexOf( 'action=ajax-tag-search' )===-1&&a.data.indexOf( 'action=ajax-tag-search' )===-1||! ( lang=t( '.post_lang_choice' ).val() )&&! ( lang=t( ':input[name="inline_lang_choice"]' ).val() )||( a.data='lang='+lang+'&'+a.data )
+	} )
+}( jQuery ), function ( t ){
+	tagBox.get=function ( a ){
+		let n=a.substr( a.indexOf( '-' )+1 ), e={
+			action: 'get-tagcloud',
+			lang: t( '.post_lang_choice' ).val(),
+			tax: n,
+		}; t.post( ajaxurl, e, function ( e, i ){
+			e!=0&&i=='success'||( e=wpAjax.broken ), e=t( '<div id="tagcloud-'+n+'" class="the-tagcloud">'+e+'</div>' ), t( 'a', e ).click( function (){
+				return tagBox.flushTags( t( this ).closest( '.inside' ).children( '.tagsdiv' ), this ), ! 1
+			} ), ( v=t( '.the-tagcloud' ).css( 'display' ) )?( t( '.the-tagcloud' ).replaceWith( e ), t( '.the-tagcloud' ).css( 'display', v ) ):t( '#'+a ).after( e )
+		} )
+	}
+}( jQuery ), function ( t ){
+	t( document ).bind( 'DOMNodeInserted', function ( a ){
+		function n( a ){
+			typeof pll_term_languages!=='undefined'&&t.each( pll_term_languages, function ( n, e ){
+				t.each( e, function ( e, i ){
+					t.each( i, function ( i ){
+						id='#'+e+'-'+pll_term_languages[n][e][i], a==n?t( id ).show():t( id ).hide()
+					} )
+				} )
+			} )
+		} function e( a ){
+			typeof pll_page_languages!=='undefined'&&t.each( pll_page_languages, function ( n, e ){
+				t.each( e, function ( e ){
+					v=t( '#post_parent option[value="'+pll_page_languages[n][e]+'"]' ), a==n?v.show():v.hide()
+				} )
+			} )
+		} let i=t( a.target ); if ( i.attr( 'id' )=='inline-edit' ){
+			let l=i.prev().attr( 'id' ).replace( 'post-', '' ); if ( l>0 ){
+				let s=i.find( ':input[name="inline_lang_choice"]' ), o=t( '#lang_'+l ).html(); s.val( o ), n( o ), e( o ), s.change( function (){
+					n( t( this ).val() ), e( t( this ).val() )
+				} )
+			}
+		}
+	} )
+}( jQuery ), function ( t ){
+	t( document ).ajaxSuccess( function ( a, n, e ){
+		function i( a ){
+			let n=new Array(); t( '.translation_'+a ).each( function (){
+				n.push( t( this ).parent().parent().attr( 'id' ).substring( 5 ) )
+			} ); let e={
+				action: 'pll_update_post_rows',
+				post_id: a,
+				translations: n.join( ',' ),
+				post_type: t( 'input[name=\'post_type\']' ).val(),
+				screen: t( 'input[name=\'screen\']' ).val(),
+				_pll_nonce: t( 'input[name=\'_inline_edit\']' ).val(),
+			}; t.post( ajaxurl, e, function ( a ){
+				if ( a ){
+					let n=wpAjax.parseAjaxResponse( a, 'ajax-response' ); t.each( n.responses, function (){
+						this.what=='row'&&t( '#post-'+this.supplemental.post_id ).replaceWith( this.data )
+					} )
+				}
+			} )
+		} let l=wpAjax.unserialize( e.data ); typeof l.action!=='undefined'&&l.action=='inline-save'&&i( l.post_ID )
+	} )
+}( jQuery ), jQuery( document ).ready( function ( t ){
+	function a(){
+		t( '.tr_lang' ).each( function (){
+			let a=t( this ).attr( 'id' ).substring( 8 ), n=t( this ).parent().parent().siblings( '.pll-edit-column' ); t( this ).autocomplete( {
+				minLength: 0,
+				source: ajaxurl+'?action=pll_posts_not_translated&post_language='+t( '.post_lang_choice' ).val()+'&translation_language='+a+'&post_type='+t( '#post_type' ).val()+'&_pll_nonce='+t( '#_pll_nonce' ).val(),
+				select: function ( e, i ){
+					t( '#htr_lang_'+a ).val( i.item.id ), n.html( i.item.link )
+				},
+			} ), t( this ).blur( function (){
+				t( this ).val()||( t( '#htr_lang_'+a ).val( 0 ), n.html( n.siblings( '.hidden' ).children().clone() ) )
+			} )
+		} )
+	} let n=new Array(); t( '.categorydiv' ).each( function (){
+		let a, e, i=t( this ).attr( 'id' ); a=i.split( '-' ), a.shift(), e=a.join( '-' ), n.push( e ), t( '#'+e+'-add-submit' ).before( t( '<input />' ).attr( 'type', 'hidden' ).attr( 'id', e+'-lang' ).attr( 'name', 'term_lang_choice' ).attr( 'value', t( '.post_lang_choice' ).val() ) )
+	} ), t( '.post_lang_choice' ).change( function (){
+		let e=t( this ).val(), i=t( this ).children( 'option[value="'+e+'"]' ).attr( 'lang' ), l=t( '.pll-translation-column > span[lang="'+i+'"]' ).attr( 'dir' ), s={
+			action: 'post_lang_choice',
+			lang: e,
+			post_type: t( '#post_type' ).val(),
+			taxonomies: n,
+			post_id: t( '#post_ID' ).val(),
+			_pll_nonce: t( '#_pll_nonce' ).val(),
+		}; t.post( ajaxurl, s, function ( n ){
+			let e=wpAjax.parseAjaxResponse( n, 'ajax-response' ); t.each( e.responses, function (){
+				switch ( this.what ){
+					case 'translations':t( '.translations' ).html( this.data ), a(); break; case 'taxonomy':var n=this.data; t( '#'+n+'checklist' ).html( this.supplemental.all ), t( '#'+n+'checklist-pop' ).html( this.supplemental.populars ), t( '#new'+n+'_parent' ).replaceWith( this.supplemental.dropdown ), t( '#'+n+'-lang' ).val( t( '.post_lang_choice' ).val() ); break; case 'pages':t( '#parent_id' ).html( this.data ); break; case 'flag':t( '.pll-select-flag' ).html( this.data ); break; case 'permalink':var e=t( '#edit-slug-box' ); this.data!='-1'&&e.children().length&&e.html( this.data )
+				}
+			} ), t( '.tagcloud-link' ).each( function (){
+				let a=t( this ).attr( 'id' ); tagBox.get( a )
+			} ), t( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-'+l ), t( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', i ).attr( 'dir', l ), t( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', l )
+		} )
+	} ), a()
+} );

--- a/js/term.js
+++ b/js/term.js
@@ -1,167 +1,166 @@
 // quick edit
-(function( $ ) {
-	$( document ).bind( 'DOMNodeInserted', function( e ) {
-		var t = $( e.target );
+( function ( $ ) {
+	$( document ).bind( 'DOMNodeInserted', function ( e ) {
+		let t = $( e.target );
 
 		// WP inserts the quick edit from
-		if ( 'inline-edit' == t.attr( 'id' ) ) {
-			var term_id = t.prev().attr( 'id' ).replace( "tag-", "" );
+		if ( t.attr( 'id' ) == 'inline-edit' ) {
+			let term_id = t.prev().attr( 'id' ).replace( 'tag-', '' );
 
 			if ( term_id > 0 ) {
 				// language dropdown
-				var select = t.find( ':input[name="inline_lang_choice"]' );
-				var lang = $( '#lang_' + term_id ).html();
+				let select = t.find( ':input[name="inline_lang_choice"]' );
+				let lang = $( '#lang_' + term_id ).html();
 				select.val( lang ); // populates the dropdown
 
 				// disable the language dropdown for default categories
-				var default_cat = $( '#default_cat_' + term_id ).html();
+				let default_cat = $( '#default_cat_' + term_id ).html();
 				if ( term_id == default_cat ) {
 					select.prop( 'disabled', true );
 				}
 			}
 		}
-	});
-})( jQuery );
-
+	} );
+} )( jQuery );
 
 // update rows of translated terms when adding / deleting a translation or when the language is modified in quick edit
 // acts on ajaxSuccess event
-(function( $ ) {
-	$( document ).ajaxSuccess(function( event, xhr, settings ) {
+( function ( $ ) {
+	$( document ).ajaxSuccess( function ( event, xhr, settings ) {
 		function update_rows( term_id ) {
 			// collect old translations
-			var translations = new Array;
-			$( '.translation_' + term_id ).each(function() {
+			let translations = new Array();
+			$( '.translation_' + term_id ).each( function () {
 				translations.push( $( this ).parent().parent().attr( 'id' ).substring( 4 ) );
-			});
+			} );
 
-			var data = {
-				action:       'pll_update_term_rows',
-				term_id:      term_id,
+			let data = {
+				action: 'pll_update_term_rows',
+				term_id: term_id,
 				translations: translations.join( ',' ),
-				taxonomy:     $( "input[name='taxonomy']" ).val(),
-				post_type:    $( "input[name='post_type']" ).val(),
-				screen:       $( "input[name='screen']" ).val(),
-				_pll_nonce:   $( '#_pll_nonce' ).val()
+				taxonomy: $( 'input[name=\'taxonomy\']' ).val(),
+				post_type: $( 'input[name=\'post_type\']' ).val(),
+				screen: $( 'input[name=\'screen\']' ).val(),
+				_pll_nonce: $( '#_pll_nonce' ).val(),
 			}
 
 			// get the modified rows in ajax and update them
-			$.post( ajaxurl, data, function( response ) {
+			$.post( ajaxurl, data, function ( response ) {
 				if ( response ) {
-					var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
-					$.each( res.responses, function() {
-						if ( 'row' == this.what ) {
-							$( "#tag-" + this.supplemental.term_id ).replaceWith( this.data );
+					let res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+					$.each( res.responses, function () {
+						if ( this.what == 'row' ) {
+							$( '#tag-' + this.supplemental.term_id ).replaceWith( this.data );
 						}
-					});
+					} );
 				}
-			});
+			} );
 		}
 
-		var data = wpAjax.unserialize( settings.data ); // what were the data sent by the ajax request?
-		if ( 'undefined' != typeof( data['action'] ) ) {
+		let data = wpAjax.unserialize( settings.data ); // what were the data sent by the ajax request?
+		if ( typeof ( data['action'] ) !== 'undefined' ) {
 			switch ( data['action'] ) {
 				// when adding a term, the new term_id is in the ajax response
 				case 'add-tag':
 					res = wpAjax.parseAjaxResponse( xhr.responseXML, 'ajax-response' );
-					$.each( res.responses, function() {
-						if ( 'term' == this.what ) {
+					$.each( res.responses, function () {
+						if ( this.what == 'term' ) {
 							update_rows( this.supplemental.term_id );
 						}
-					});
+					} );
 
 					// and also reset translations hidden input fields
 					$( '.htr_lang' ).val( 0 );
-				break;
+					break;
 
 				// when deleting a term
 				case 'delete-tag':
 					update_rows( data['tag_ID'] );
-				break;
+					break;
 
 				// in case the language is modified in quick edit and breaks translations
 				case 'inline-save-tax':
 					update_rows( data['tax_ID'] );
-				break;
+					break;
 			}
 		}
-	});
-})( jQuery );
+	} );
+} )( jQuery );
 
-jQuery( document ).ready(function( $ ) {
+jQuery( document ).ready( function ( $ ) {
 	// translations autocomplete input box
 	function init_translations() {
-		$( '.tr_lang' ).each(function(){
-			var tr_lang = $( this ).attr( 'id' ).substring( 8 );
-			var td = $( this ).parent().parent().siblings( '.pll-edit-column' );
+		$( '.tr_lang' ).each( function (){
+			let tr_lang = $( this ).attr( 'id' ).substring( 8 );
+			let td = $( this ).parent().parent().siblings( '.pll-edit-column' );
 
-			$( this ).autocomplete({
+			$( this ).autocomplete( {
 				minLength: 0,
 
 				source: ajaxurl + '?action=pll_terms_not_translated' +
 					'&term_language=' + $( '#term_lang_choice' ).val() +
-					'&term_id=' + $( "input[name='tag_ID']" ).val() +
-					'&taxonomy=' + $( "input[name='taxonomy']" ).val() +
+					'&term_id=' + $( 'input[name=\'tag_ID\']' ).val() +
+					'&taxonomy=' + $( 'input[name=\'taxonomy\']' ).val() +
 					'&translation_language=' + tr_lang +
 					'&post_type=' + typenow +
 					'&_pll_nonce=' + $( '#_pll_nonce' ).val(),
 
-				select: function( event, ui ) {
+				select: function ( event, ui ) {
 					$( '#htr_lang_' + tr_lang ).val( ui.item.id );
 					td.html( ui.item.link );
 				},
-			});
+			} );
 
 			// when the input box is emptied
-			$( this ).blur(function() {
+			$( this ).blur( function () {
 				if ( ! $( this ).val() ) {
 					$( '#htr_lang_' + tr_lang ).val( 0 );
 					td.html( td.siblings( '.hidden' ).children().clone() );
 				}
-			});
-		});
+			} );
+		} );
 	}
 
 	init_translations();
 
 	// ajax for changing the term's language
-	$( '#term_lang_choice' ).change(function() {
-		var value = $( this ).val();
-		var lang  = $( this ).children( 'option[value="' + value + '"]' ).attr( 'lang' );
-		var dir   = $( '.pll-translation-column > span[lang="' + lang + '"]' ).attr( 'dir' );
+	$( '#term_lang_choice' ).change( function () {
+		let value = $( this ).val();
+		let lang  = $( this ).children( 'option[value="' + value + '"]' ).attr( 'lang' );
+		let dir   = $( '.pll-translation-column > span[lang="' + lang + '"]' ).attr( 'dir' );
 
-		var data = {
-			action:     'term_lang_choice',
-			lang:       value,
-			from_tag:   $( "input[name='from_tag']" ).val(),
-			term_id:    $( "input[name='tag_ID']" ).val(),
-			taxonomy:   $( "input[name='taxonomy']" ).val(),
-			post_type:  typenow,
-			_pll_nonce: $( '#_pll_nonce' ).val()
+		let data = {
+			action: 'term_lang_choice',
+			lang: value,
+			from_tag: $( 'input[name=\'from_tag\']' ).val(),
+			term_id: $( 'input[name=\'tag_ID\']' ).val(),
+			taxonomy: $( 'input[name=\'taxonomy\']' ).val(),
+			post_type: typenow,
+			_pll_nonce: $( '#_pll_nonce' ).val(),
 		}
 
-		$.post( ajaxurl, data, function( response ) {
-			var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
-			$.each( res.responses, function() {
+		$.post( ajaxurl, data, function ( response ) {
+			let res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+			$.each( res.responses, function () {
 				switch ( this.what ) {
 					case 'translations': // translations fields
-						$( "#term-translations" ).html( this.data );
+						$( '#term-translations' ).html( this.data );
 						init_translations();
-					break;
+						break;
 					case 'parent': // parent dropdown list for hierarchical taxonomies
 						$( '#parent' ).replaceWith( this.data );
-					break;
+						break;
 					case 'tag_cloud': // popular items
 						$( '.tagcloud' ).replaceWith( this.data );
-					break;
+						break;
 					case 'flag': // flag in front of the select dropdown
 						$( '.pll-select-flag' ).html( this.data );
-					break;
+						break;
 				}
-			});
+			} );
 
 			// Modifies the text direction
 			$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
-		});
-	});
-});
+		} );
+	} );
+} );

--- a/js/term.min.js
+++ b/js/term.min.js
@@ -1,1 +1,65 @@
-!function(a){a(document).bind("DOMNodeInserted",function(t){var n=a(t.target);if("inline-edit"==n.attr("id")){var e=n.prev().attr("id").replace("tag-","");if(e>0){var l=n.find(':input[name="inline_lang_choice"]'),i=a("#lang_"+e).html();l.val(i);var r=a("#default_cat_"+e).html();e==r&&l.prop("disabled",!0)}}})}(jQuery),function(a){a(document).ajaxSuccess(function(t,n,e){function l(t){var n=new Array;a(".translation_"+t).each(function(){n.push(a(this).parent().parent().attr("id").substring(4))});var e={action:"pll_update_term_rows",term_id:t,translations:n.join(","),taxonomy:a("input[name='taxonomy']").val(),post_type:a("input[name='post_type']").val(),screen:a("input[name='screen']").val(),_pll_nonce:a("#_pll_nonce").val()};a.post(ajaxurl,e,function(t){if(t){var n=wpAjax.parseAjaxResponse(t,"ajax-response");a.each(n.responses,function(){"row"==this.what&&a("#tag-"+this.supplemental.term_id).replaceWith(this.data)})}})}var i=wpAjax.unserialize(e.data);if("undefined"!=typeof i.action)switch(i.action){case"add-tag":res=wpAjax.parseAjaxResponse(n.responseXML,"ajax-response"),a.each(res.responses,function(){"term"==this.what&&l(this.supplemental.term_id)}),a(".htr_lang").val(0);break;case"delete-tag":l(i.tag_ID);break;case"inline-save-tax":l(i.tax_ID)}})}(jQuery),jQuery(document).ready(function(a){function t(){a(".tr_lang").each(function(){var t=a(this).attr("id").substring(8),n=a(this).parent().parent().siblings(".pll-edit-column");a(this).autocomplete({minLength:0,source:ajaxurl+"?action=pll_terms_not_translated&term_language="+a("#term_lang_choice").val()+"&term_id="+a("input[name='tag_ID']").val()+"&taxonomy="+a("input[name='taxonomy']").val()+"&translation_language="+t+"&post_type="+typenow+"&_pll_nonce="+a("#_pll_nonce").val(),select:function(e,l){a("#htr_lang_"+t).val(l.item.id),n.html(l.item.link)}}),a(this).blur(function(){a(this).val()||(a("#htr_lang_"+t).val(0),n.html(n.siblings(".hidden").children().clone()))})})}t(),a("#term_lang_choice").change(function(){var n=a(this).val(),e=a(this).children('option[value="'+n+'"]').attr("lang"),l=a('.pll-translation-column > span[lang="'+e+'"]').attr("dir"),i={action:"term_lang_choice",lang:n,from_tag:a("input[name='from_tag']").val(),term_id:a("input[name='tag_ID']").val(),taxonomy:a("input[name='taxonomy']").val(),post_type:typenow,_pll_nonce:a("#_pll_nonce").val()};a.post(ajaxurl,i,function(n){var e=wpAjax.parseAjaxResponse(n,"ajax-response");a.each(e.responses,function(){switch(this.what){case"translations":a("#term-translations").html(this.data),t();break;case"parent":a("#parent").replaceWith(this.data);break;case"tag_cloud":a(".tagcloud").replaceWith(this.data);break;case"flag":a(".pll-select-flag").html(this.data)}}),a("body").removeClass("pll-dir-rtl").removeClass("pll-dir-ltr").addClass("pll-dir-"+l)})})});
+! function ( a ){
+	a( document ).bind( 'DOMNodeInserted', function ( t ){
+		let n=a( t.target ); if ( n.attr( 'id' )=='inline-edit' ){
+			let e=n.prev().attr( 'id' ).replace( 'tag-', '' ); if ( e>0 ){
+				let l=n.find( ':input[name="inline_lang_choice"]' ), i=a( '#lang_'+e ).html(); l.val( i ); let r=a( '#default_cat_'+e ).html(); e==r&&l.prop( 'disabled', ! 0 )
+			}
+		}
+	} )
+}( jQuery ), function ( a ){
+	a( document ).ajaxSuccess( function ( t, n, e ){
+		function l( t ){
+			let n=new Array(); a( '.translation_'+t ).each( function (){
+				n.push( a( this ).parent().parent().attr( 'id' ).substring( 4 ) )
+			} ); let e={
+				action: 'pll_update_term_rows',
+				term_id: t,
+				translations: n.join( ',' ),
+				taxonomy: a( 'input[name=\'taxonomy\']' ).val(),
+				post_type: a( 'input[name=\'post_type\']' ).val(),
+				screen: a( 'input[name=\'screen\']' ).val(),
+				_pll_nonce: a( '#_pll_nonce' ).val(),
+			}; a.post( ajaxurl, e, function ( t ){
+				if ( t ){
+					let n=wpAjax.parseAjaxResponse( t, 'ajax-response' ); a.each( n.responses, function (){
+						this.what=='row'&&a( '#tag-'+this.supplemental.term_id ).replaceWith( this.data )
+					} )
+				}
+			} )
+		} let i=wpAjax.unserialize( e.data ); if ( typeof i.action!=='undefined' ) switch ( i.action ){
+			case 'add-tag':res=wpAjax.parseAjaxResponse( n.responseXML, 'ajax-response' ), a.each( res.responses, function (){
+				this.what=='term'&&l( this.supplemental.term_id )
+			} ), a( '.htr_lang' ).val( 0 ); break; case 'delete-tag':l( i.tag_ID ); break; case 'inline-save-tax':l( i.tax_ID )
+		}
+	} )
+}( jQuery ), jQuery( document ).ready( function ( a ){
+	function t(){
+		a( '.tr_lang' ).each( function (){
+			let t=a( this ).attr( 'id' ).substring( 8 ), n=a( this ).parent().parent().siblings( '.pll-edit-column' ); a( this ).autocomplete( {
+				minLength: 0,
+				source: ajaxurl+'?action=pll_terms_not_translated&term_language='+a( '#term_lang_choice' ).val()+'&term_id='+a( 'input[name=\'tag_ID\']' ).val()+'&taxonomy='+a( 'input[name=\'taxonomy\']' ).val()+'&translation_language='+t+'&post_type='+typenow+'&_pll_nonce='+a( '#_pll_nonce' ).val(),
+				select: function ( e, l ){
+					a( '#htr_lang_'+t ).val( l.item.id ), n.html( l.item.link )
+				},
+			} ), a( this ).blur( function (){
+				a( this ).val()||( a( '#htr_lang_'+t ).val( 0 ), n.html( n.siblings( '.hidden' ).children().clone() ) )
+			} )
+		} )
+	}t(), a( '#term_lang_choice' ).change( function (){
+		let n=a( this ).val(), e=a( this ).children( 'option[value="'+n+'"]' ).attr( 'lang' ), l=a( '.pll-translation-column > span[lang="'+e+'"]' ).attr( 'dir' ), i={
+			action: 'term_lang_choice',
+			lang: n,
+			from_tag: a( 'input[name=\'from_tag\']' ).val(),
+			term_id: a( 'input[name=\'tag_ID\']' ).val(),
+			taxonomy: a( 'input[name=\'taxonomy\']' ).val(),
+			post_type: typenow,
+			_pll_nonce: a( '#_pll_nonce' ).val(),
+		}; a.post( ajaxurl, i, function ( n ){
+			let e=wpAjax.parseAjaxResponse( n, 'ajax-response' ); a.each( e.responses, function (){
+				switch ( this.what ){
+					case 'translations':a( '#term-translations' ).html( this.data ), t(); break; case 'parent':a( '#parent' ).replaceWith( this.data ); break; case 'tag_cloud':a( '.tagcloud' ).replaceWith( this.data ); break; case 'flag':a( '.pll-select-flag' ).html( this.data )
+				}
+			} ), a( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-'+l )
+		} )
+	} )
+} );

--- a/js/user.js
+++ b/js/user.js
@@ -1,20 +1,20 @@
-jQuery( document ).ready(function( $ ) {
+jQuery( document ).ready( function ( $ ) {
 	// biography
 	// FIXME there is probably a more efficient way to do this
-	var td = $( '#description' ).parent();
-	var d = $( '#description' ).clone();
-	var span = td.children( '.description' ).clone();
+	let td = $( '#description' ).parent();
+	let d = $( '#description' ).clone();
+	let span = td.children( '.description' ).clone();
 	td.children().remove();
 
-	$( '.biography' ).each(function(){
+	$( '.biography' ).each( function (){
 		lang = $( this ).attr( 'name' ).split( '___' );
 		desc = d.clone();
 		desc.attr( 'name', 'description_' + lang[0] );
 		desc.html( $( this ).val() );
 		td.append( '<div>' + lang[1] + '</div' );
 		td.append( desc );
-	});
+	} );
 
 	td.append( '<br />' );
 	td.append( span );
-});
+} );

--- a/js/user.min.js
+++ b/js/user.min.js
@@ -1,1 +1,5 @@
-jQuery(document).ready(function(e){var n=e("#description").parent(),d=e("#description").clone(),i=n.children(".description").clone();n.children().remove(),e(".biography").each(function(){lang=e(this).attr("name").split("___"),desc=d.clone(),desc.attr("name","description_"+lang[0]),desc.html(e(this).val()),n.append("<div>"+lang[1]+"</div"),n.append(desc)}),n.append("<br />"),n.append(i)});
+jQuery( document ).ready( function ( e ){
+	let n=e( '#description' ).parent(), d=e( '#description' ).clone(), i=n.children( '.description' ).clone(); n.children().remove(), e( '.biography' ).each( function (){
+		lang=e( this ).attr( 'name' ).split( '___' ), desc=d.clone(), desc.attr( 'name', 'description_'+lang[0] ), desc.html( e( this ).val() ), n.append( '<div>'+lang[1]+'</div' ), n.append( desc )
+	} ), n.append( '<br />' ), n.append( i )
+} );

--- a/lingotek/lingotek.php
+++ b/lingotek/lingotek.php
@@ -21,47 +21,47 @@ class PLL_Lingotek {
 		$options = get_option( 'polylang' );
 
 		// The Lingotek tab
-		add_filter( 'pll_settings_tabs', array( $this, 'add_tab' ) );
-		add_action( 'pll_settings_active_tab_lingotek', array( $this, 'display_tab' ) );
+		add_filter( 'pll_settings_tabs', [ $this, 'add_tab' ] );
+		add_action( 'pll_settings_active_tab_lingotek', [ $this, 'display_tab' ] );
 
 		if ( PLL_SETTINGS && isset( $_GET['page'] ) && 'mlang_lingotek' == $_GET['page'] ) {
-			add_action( 'admin_print_styles', array( $this, 'print_css' ) );
+			add_action( 'admin_print_styles', [ $this, 'print_css' ] );
 		}
 
 		// The pointer
 		$content = __( 'You’ve just upgraded to the latest version of Polylang! Would you like to automatically translate your website for free?', 'polylang' );
 
-		$buttons = array(
-			array(
+		$buttons = [
+			[
 				'label' => __( 'Close' ),
-			),
-			array(
+			],
+			[
 				'label' => __( 'Learn more', 'polylang' ),
 				'link' => admin_url( 'admin.php?page=mlang&tab=lingotek' ),
-			),
-		);
+			],
+		];
 
 		if ( $link = $this->get_activate_link() ) {
 			$content .= ' ' . __( 'Click on Activate Lingotek to start translating.', 'polylang' );
 
-			$buttons[] = array(
+			$buttons[] = [
 				'label' => __( 'Activate Lingotek', 'polylang' ),
 				'link' => str_replace( '&amp;', '&', $link ), // wp_nonce_url escapes the url for html display. Here we want it for js
-			);
+			];
 		}
 
-		$args = array(
+		$args = [
 			'pointer' => 'pll_lgt',
 			'id' => empty( $options['previous_version'] ) ? 'nav-tab-lingotek' : 'wp-admin-bar-languages',
-			'position' => array(
+			'position' => [
 				'edge' => 'top',
 				'align' => 'left',
-			),
+			],
 			'width' => 400,
 			'title' => __( 'Congratulations!', 'polylang' ),
 			'content' => $content,
 			'buttons' => $buttons,
-		);
+		];
 
 		new PLL_Pointer( $args );
 	}
@@ -87,75 +87,75 @@ class PLL_Lingotek {
 	public function display_tab() {
 		$activate_link = $this->get_activate_link();
 
-		$links = array(
-			'activate' => array(
+		$links = [
+			'activate' => [
 				'label'   => is_plugin_active( self::LINGOTEK ) ? __( 'Activated', 'polylang' ) : __( 'Activate', 'polylang' ),
 				'link'    => $activate_link,
 				'classes' => 'button button-primary' . ( $activate_link ? '' : ' disabled' ),
-			),
-			'translation' => array(
+			],
+			'translation' => [
 				'label'   => __( 'Request Translation', 'polylang' ),
 				'link'    => 'http://www.lingotek.com/wordpress/translation_bid',
 				'new_tab' => true,
 				'classes' => 'button button-primary',
-			),
-			'services' => array(
+			],
+			'services' => [
 				'label'   => __( 'Request Services', 'polylang' ),
 				'link'    => 'http://www.lingotek.com/wordpress/extra_services',
 				'new_tab' => true,
 				'classes' => 'button button-primary',
-			),
-		);
+			],
+		];
 
 		printf( '<p>%s</p>', esc_html__( 'Polylang is now fully integrated with Lingotek, a professional translation management system!', 'polylang' ) );
 
 		$this->box(
 			__( 'Automatically Translate My Site', 'polylang' ),
 			__( 'Polylang is now fully integrated with Lingotek!', 'polylang' ),
-			array(
+			[
 				__( 'Access free machine translation for your site for up to 100,000 characters.', 'polylang' ),
 				__( 'Machine translation is an excellent option if you\'re on a tight budget, looking for near-instant results, and are okay with less-than-perfect quality.', 'polylang' ),
-			),
-			array_intersect_key( $links, array_flip( array( 'activate' ) ) ),
+			],
+			array_intersect_key( $links, array_flip( [ 'activate' ] ) ),
 			'image01.gif'
 		);
 
 		$this->box(
 			__( 'Translation Management System', 'polylang' ),
 			__( 'Do you need to connect to a professional translation management system?', 'polylang' ),
-			array(
+			[
 				__( 'Access free machine translation for your site for up to 100,000 characters.', 'polylang' ),
 				__( 'Access an online translator workbench.', 'polylang' ),
 				__( 'Have linguists compare side-by-side versions of original and translated text.', 'polylang' ),
 				__( 'Save and re-use previously translated material (leverage translation memory (TM)).', 'polylang' ),
-			),
-			array_intersect_key( $links, array_flip( array( 'activate' ) ) ),
+			],
+			array_intersect_key( $links, array_flip( [ 'activate' ] ) ),
 			'image02.png'
 		);
 
 		$this->box(
 			__( 'Professionally Translate My Site', 'polylang' ),
 			__( 'Do you need to professionally translate your site?', 'polylang' ),
-			array(
+			[
 				__( 'Start the process of getting a professional translation bid.', 'polylang' ),
 				__( 'Activate account so Lingotek can get an accurate count of how many words you have on your site and which languages you wish to translate into.', 'polylang' ),
 				__( 'Once activated click on the request translation bid and a certified translation project manager will contact you to give a no obligations translation bid.', 'polylang' ),
-			),
-			array_intersect_key( $links, array_flip( array( 'activate', 'translation' ) ) ),
+			],
+			array_intersect_key( $links, array_flip( [ 'activate', 'translation' ] ) ),
 			'image03.png'
 		);
 
 		$this->box(
 			__( 'Need Extra Services?', 'polylang' ),
 			__( 'Do you need help translating your site?', 'polylang' ),
-			array(
+			[
 				__( 'Start the process of getting extra services.', 'polylang' ),
 				__( 'Do you need someone to run your localization project?', 'polylang' ),
 				__( 'Do you need customized workflows?', 'polylang' ),
 				__( 'Do you have existing Translation Memories you would like to use?', 'polylang' ),
 				__( 'Do you need help creating glossaries and terminologies?', 'polylang' ),
-			),
-			array_intersect_key( $links, array_flip( array( 'activate', 'services' ) ) ),
+			],
+			array_intersect_key( $links, array_flip( [ 'activate', 'services' ] ) ),
 			'image04.png'
 		);
 	}
@@ -288,9 +288,7 @@ class PLL_Lingotek {
 				$plugin = dirname( self::LINGOTEK );
 				return wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=' . $plugin ), 'install-plugin_' . $plugin );
 			}
-		}
-
-		elseif ( current_user_can( 'activate_plugins' ) ) {
+		} elseif ( current_user_can( 'activate_plugins' ) ) {
 			if ( ! is_plugin_active( self::LINGOTEK ) ) {
 				return wp_nonce_url( 'plugins.php?action=activate&plugin=' . self::LINGOTEK, 'activate-plugin_' . self::LINGOTEK );
 			}
@@ -300,4 +298,4 @@ class PLL_Lingotek {
 	}
 }
 
-add_action( 'wp_loaded', array( new PLL_Lingotek(), 'init' ) );
+add_action( 'wp_loaded', [ new PLL_Lingotek(), 'init' ] );

--- a/lingotek/lingotek.php
+++ b/lingotek/lingotek.php
@@ -24,7 +24,7 @@ class PLL_Lingotek {
 		add_filter( 'pll_settings_tabs', [ $this, 'add_tab' ] );
 		add_action( 'pll_settings_active_tab_lingotek', [ $this, 'display_tab' ] );
 
-		if ( PLL_SETTINGS && isset( $_GET['page'] ) && 'mlang_lingotek' == $_GET['page'] ) {
+		if ( PLL_SETTINGS && isset( $_GET['page'] ) && 'mlang_lingotek' === $_GET['page'] ) {
 			add_action( 'admin_print_styles', [ $this, 'print_css' ] );
 		}
 

--- a/modules/plugins/cache-compat.php
+++ b/modules/plugins/cache-compat.php
@@ -14,9 +14,9 @@ class PLL_Cache_Compat {
 	 */
 	public function init() {
 		if ( PLL_COOKIE ) {
-			add_action( 'wp_print_footer_scripts', array( $this, 'add_cookie_script' ) );
+			add_action( 'wp_print_footer_scripts', [ $this, 'add_cookie_script' ] );
 		}
-		add_action( 'wp', array( $this, 'do_not_cache_site_home' ) );
+		add_action( 'wp', [ $this, 'do_not_cache_site_home' ] );
 	}
 
 	/**
@@ -28,7 +28,8 @@ class PLL_Cache_Compat {
 	 */
 	public function add_cookie_script() {
 		$domain = ( 2 == PLL()->options['force_lang'] ) ? parse_url( PLL()->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN;
-		$js = sprintf( '
+		$js     = sprintf(
+			'
 			var date = new Date();
 			date.setTime( date.getTime() + %d );
 			document.cookie = "%s=%s; expires=" + date.toUTCString() + "; path=%s%s";',

--- a/modules/plugins/cache-compat.php
+++ b/modules/plugins/cache-compat.php
@@ -27,7 +27,7 @@ class PLL_Cache_Compat {
 	 * @since 2.3
 	 */
 	public function add_cookie_script() {
-		$domain = ( 2 == PLL()->options['force_lang'] ) ? parse_url( PLL()->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN;
+		$domain = ( 2 === PLL()->options['force_lang'] ) ? parse_url( PLL()->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN;
 		$js     = sprintf(
 			'
 			var date = new Date();

--- a/modules/plugins/jetpack.php
+++ b/modules/plugins/jetpack.php
@@ -19,7 +19,7 @@ class PLL_Jetpack {
 		add_filter( 'jetpack_relatedposts_filter_filters', [ $this, 'jetpack_relatedposts_filter_filters' ], 10, 2 );
 
 		// Jetpack infinite scroll
-		if ( isset( $_GET['infinity'], $_POST['action'] ) && 'infinite_scroll' == $_POST['action'] ) {
+		if ( isset( $_GET['infinity'], $_POST['action'] ) && 'infinite_scroll' === $_POST['action'] ) {
 			add_filter( 'pll_is_ajax_on_front', '__return_true' );
 		}
 	}

--- a/modules/plugins/jetpack.php
+++ b/modules/plugins/jetpack.php
@@ -12,11 +12,11 @@ class PLL_Jetpack {
 	 * @since 2.3
 	 */
 	public function __construct() {
-		add_action( 'init', array( $this, 'jetpack_init' ) );
-		add_action( 'jetpack_widget_get_top_posts', array( $this, 'jetpack_widget_get_top_posts' ), 10, 3 );
-		add_filter( 'grunion_contact_form_field_html', array( $this, 'grunion_contact_form_field_html_filter' ), 10, 3 );
-		add_filter( 'jetpack_open_graph_tags', array( $this, 'jetpack_ogp' ) );
-		add_filter( 'jetpack_relatedposts_filter_filters', array( $this, 'jetpack_relatedposts_filter_filters' ), 10, 2 );
+		add_action( 'init', [ $this, 'jetpack_init' ] );
+		add_action( 'jetpack_widget_get_top_posts', [ $this, 'jetpack_widget_get_top_posts' ], 10, 3 );
+		add_filter( 'grunion_contact_form_field_html', [ $this, 'grunion_contact_form_field_html_filter' ], 10, 3 );
+		add_filter( 'jetpack_open_graph_tags', [ $this, 'jetpack_ogp' ] );
+		add_filter( 'jetpack_relatedposts_filter_filters', [ $this, 'jetpack_relatedposts_filter_filters' ], 10, 2 );
 
 		// Jetpack infinite scroll
 		if ( isset( $_GET['infinity'], $_POST['action'] ) && 'infinite_scroll' == $_POST['action'] ) {
@@ -36,8 +36,8 @@ class PLL_Jetpack {
 
 		// Infinite scroll ajax url must be on the right domain
 		if ( did_action( 'pll_init' ) && PLL()->options['force_lang'] > 1 ) {
-			add_filter( 'infinite_scroll_ajax_url', array( PLL()->links_model, 'site_url' ) );
-			add_filter( 'infinite_scroll_js_settings', array( $this, 'jetpack_infinite_scroll_js_settings' ) );
+			add_filter( 'infinite_scroll_ajax_url', [ PLL()->links_model, 'site_url' ] );
+			add_filter( 'infinite_scroll_js_settings', [ $this, 'jetpack_infinite_scroll_js_settings' ] );
 		}
 	}
 
@@ -78,7 +78,7 @@ class PLL_Jetpack {
 		if ( function_exists( 'icl_translate' ) ) {
 			if ( pll_current_language() !== pll_default_language() ) {
 				$label_translation = icl_translate( 'jetpack ', $field_label . '_label', $field_label );
-				$r = str_replace( $field_label, $label_translation, $r );
+				$r                 = str_replace( $field_label, $label_translation, $r );
 			}
 		}
 
@@ -117,8 +117,8 @@ class PLL_Jetpack {
 	 * @return array
 	 */
 	function jetpack_relatedposts_filter_filters( $filters, $post_id ) {
-		$slug = sanitize_title( pll_get_post_language( $post_id, 'slug' ) );
-		$filters[] = array( 'term' => array( 'taxonomy.language.slug' => $slug ) );
+		$slug      = sanitize_title( pll_get_post_language( $post_id, 'slug' ) );
+		$filters[] = [ 'term' => [ 'taxonomy.language.slug' => $slug ] ];
 		return $filters;
 	}
 

--- a/modules/plugins/plugins-compat.php
+++ b/modules/plugins/plugins-compat.php
@@ -214,7 +214,7 @@ class PLL_Plugins_Compat {
 	 * @return array modified featured posts ids ( include all languages )
 	 */
 	public function twenty_fourteen_featured_content_ids( $featured_ids ) {
-		if ( 'twentyfourteen' != get_template() || ! did_action( 'pll_init' ) || false !== $featured_ids ) {
+		if ( 'twentyfourteen' !== get_template() || ! did_action( 'pll_init' ) || false !== $featured_ids ) {
 			return $featured_ids;
 		}
 
@@ -266,7 +266,7 @@ class PLL_Plugins_Compat {
 	 * @return array modified $settings
 	 */
 	public function twenty_fourteen_option_featured_content( $settings ) {
-		if ( 'twentyfourteen' == get_template() && PLL() instanceof PLL_Frontend && $settings['tag-id'] && $tr = pll_get_term( $settings['tag-id'] ) ) {
+		if ( 'twentyfourteen' === get_template() && PLL() instanceof PLL_Frontend && $settings['tag-id'] && $tr = pll_get_term( $settings['tag-id'] ) ) {
 			$settings['tag-id'] = $tr;
 		}
 

--- a/modules/plugins/plugins-compat.php
+++ b/modules/plugins/plugins-compat.php
@@ -15,44 +15,44 @@ class PLL_Plugins_Compat {
 	 * @since 1.0
 	 */
 	protected function __construct() {
-		add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ), 0 );
+		add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ], 0 );
 
 		// WordPress Importer
-		add_action( 'init', array( $this, 'maybe_wordpress_importer' ) );
-		add_filter( 'wp_import_terms', array( $this, 'wp_import_terms' ) );
+		add_action( 'init', [ $this, 'maybe_wordpress_importer' ] );
+		add_filter( 'wp_import_terms', [ $this, 'wp_import_terms' ] );
 
 		// YARPP
-		add_action( 'init', array( $this, 'yarpp_init' ) ); // after Polylang has registered its taxonomy in setup_theme
+		add_action( 'init', [ $this, 'yarpp_init' ] ); // after Polylang has registered its taxonomy in setup_theme
 
 		// Custom field template
-		add_action( 'add_meta_boxes', array( $this, 'cft_copy' ), 10, 2 );
+		add_action( 'add_meta_boxes', [ $this, 'cft_copy' ], 10, 2 );
 
 		// Aqua Resizer
-		add_filter( 'pll_home_url_black_list', array( $this, 'aq_home_url_black_list' ) );
+		add_filter( 'pll_home_url_black_list', [ $this, 'aq_home_url_black_list' ] );
 
 		// Twenty Fourteen
-		add_filter( 'transient_featured_content_ids', array( $this, 'twenty_fourteen_featured_content_ids' ) );
-		add_filter( 'option_featured-content', array( $this, 'twenty_fourteen_option_featured_content' ) );
+		add_filter( 'transient_featured_content_ids', [ $this, 'twenty_fourteen_featured_content_ids' ] );
+		add_filter( 'option_featured-content', [ $this, 'twenty_fourteen_option_featured_content' ] );
 
 		// Duplicate post
-		add_filter( 'option_duplicate_post_taxonomies_blacklist', array( $this, 'duplicate_post_taxonomies_blacklist' ) );
+		add_filter( 'option_duplicate_post_taxonomies_blacklist', [ $this, 'duplicate_post_taxonomies_blacklist' ] );
 
 		// Jetpack
 		$this->jetpack = new PLL_Jetpack(); // Must be loaded before the plugin is active
 
 		// WP Sweep
-		add_filter( 'wp_sweep_excluded_taxonomies', array( $this, 'wp_sweep_excluded_taxonomies' ) );
+		add_filter( 'wp_sweep_excluded_taxonomies', [ $this, 'wp_sweep_excluded_taxonomies' ] );
 
 		// Twenty Seventeen
-		add_action( 'init', array( $this, 'twenty_seventeen_init' ) );
+		add_action( 'init', [ $this, 'twenty_seventeen_init' ] );
 
 		// No category base (works for Yoast SEO too)
-		add_filter( 'get_terms_args', array( $this, 'no_category_base_get_terms_args' ), 5 ); // Before adding cache domain
+		add_filter( 'get_terms_args', [ $this, 'no_category_base_get_terms_args' ], 5 ); // Before adding cache domain
 
 		// WordPress MU Domain Mapping
 		if ( function_exists( 'redirect_to_mapped_domain' ) && ! get_site_option( 'dm_no_primary_domain' ) ) {
 			remove_action( 'template_redirect', 'redirect_to_mapped_domain' );
-			add_action( 'template_redirect', array( $this, 'dm_redirect_to_mapped_domain' ) );
+			add_action( 'template_redirect', [ $this, 'dm_redirect_to_mapped_domain' ] );
 		}
 	}
 
@@ -79,28 +79,28 @@ class PLL_Plugins_Compat {
 	public function plugins_loaded() {
 		// Yoast SEO
 		if ( defined( 'WPSEO_VERSION' ) ) {
-			add_action( 'pll_language_defined', array( $this->wpseo = new PLL_WPSEO(), 'init' ) );
+			add_action( 'pll_language_defined', [ $this->wpseo = new PLL_WPSEO(), 'init' ] );
 		}
 
 		// Cache plugins, with specific test for WP Fastest Cache which doesn't use WP_CACHE
 		if ( ( defined( 'WP_CACHE' ) && WP_CACHE ) || defined( 'WPFC_MAIN_PATH' ) ) {
-			add_action( 'pll_init', array( $this->cache_compat = new PLL_Cache_Compat(), 'init' ) );
+			add_action( 'pll_init', [ $this->cache_compat = new PLL_Cache_Compat(), 'init' ] );
 		}
 
 		// Advanced Custom Fields Pro
 		// The function acf_get_value() is not defined in ACF 4
 		if ( class_exists( 'acf' ) && function_exists( 'acf_get_value' ) && class_exists( 'PLL_ACF' ) ) {
-			add_action( 'init', array( $this->acf = new PLL_ACF(), 'init' ) );
+			add_action( 'init', [ $this->acf = new PLL_ACF(), 'init' ] );
 		}
 
 		// Custom Post Type UI
 		if ( defined( 'CPTUI_VERSION' ) && class_exists( 'PLL_CPTUI' ) ) {
-			add_action( 'pll_init', array( $this->cptui = new PLL_CPTUI(), 'init' ) );
+			add_action( 'pll_init', [ $this->cptui = new PLL_CPTUI(), 'init' ] );
 		}
 
 		// The Event Calendar
 		if ( defined( 'TRIBE_EVENTS_FILE' ) && class_exists( 'PLL_TEC' ) ) {
-			add_action( 'pll_init', array( $this->tec = new PLL_TEC(), 'init' ) );
+			add_action( 'pll_init', [ $this->tec = new PLL_TEC(), 'init' ] );
 		}
 
 		// Beaver Builder
@@ -123,7 +123,7 @@ class PLL_Plugins_Compat {
 	function maybe_wordpress_importer() {
 		if ( defined( 'WP_LOAD_IMPORTERS' ) && class_exists( 'WP_Import' ) ) {
 			remove_action( 'admin_init', 'wordpress_importer_init' );
-			add_action( 'admin_init', array( $this, 'wordpress_importer_init' ) );
+			add_action( 'admin_init', [ $this, 'wordpress_importer_init' ] );
 		}
 	}
 
@@ -138,7 +138,7 @@ class PLL_Plugins_Compat {
 		load_plugin_textdomain( 'wordpress-importer', false, basename( dirname( $class->getFileName() ) ) . '/languages' );
 
 		$GLOBALS['wp_import'] = new PLL_WP_Import();
-		register_importer( 'wordpress', 'WordPress', __( 'Import <strong>posts, pages, comments, custom fields, categories, and tags</strong> from a WordPress export file.', 'wordpress-importer' ), array( $GLOBALS['wp_import'], 'dispatch' ) ); // WPCS: spelling ok.
+		register_importer( 'wordpress', 'WordPress', __( 'Import <strong>posts, pages, comments, custom fields, categories, and tags</strong> from a WordPress export file.', 'wordpress-importer' ), [ $GLOBALS['wp_import'], 'dispatch' ] ); // WPCS: spelling ok.
 	}
 
 	/**
@@ -158,7 +158,7 @@ class PLL_Plugins_Compat {
 			if ( 'language' === $term['term_taxonomy'] ) {
 				$description = maybe_unserialize( $term['term_description'] );
 				if ( empty( $description['flag_code'] ) && isset( $languages[ $description['locale'] ] ) ) {
-					$description['flag_code'] = $languages[ $description['locale'] ]['flag'];
+					$description['flag_code']          = $languages[ $description['locale'] ]['flag'];
 					$terms[ $key ]['term_description'] = serialize( $description );
 				}
 			}
@@ -185,7 +185,7 @@ class PLL_Plugins_Compat {
 	 * @return array
 	 */
 	public function aq_home_url_black_list( $arr ) {
-		return array_merge( $arr, array( array( 'function' => 'aq_resize' ) ) );
+		return array_merge( $arr, [ [ 'function' => 'aq_resize' ] ] );
 	}
 
 	/**
@@ -226,22 +226,24 @@ class PLL_Plugins_Compat {
 
 		// Get featured tag translations
 		$tags = PLL()->model->term->get_translations( $term->term_id );
-		$ids = array();
+		$ids  = [];
 
 		// Query for featured posts in all languages
 		// One query per language to get the correct number of posts per language
 		foreach ( $tags as $tag ) {
-			$_ids = get_posts( array(
-				'lang'        => 0, // avoid language filters
-				'fields'      => 'ids',
-				'numberposts' => Featured_Content::$max_posts,
-				'tax_query'   => array(
-					array(
-						'taxonomy' => 'post_tag',
-						'terms'    => (int) $tag,
-					),
-				),
-			) );
+			$_ids = get_posts(
+				[
+					'lang'        => 0, // avoid language filters
+					'fields'      => 'ids',
+					'numberposts' => Featured_Content::$max_posts,
+					'tax_query'   => [
+						[
+							'taxonomy' => 'post_tag',
+							'terms'    => (int) $tag,
+						],
+					],
+				]
+			);
 
 			$ids = array_merge( $ids, $_ids );
 		}
@@ -282,7 +284,7 @@ class PLL_Plugins_Compat {
 	 */
 	function duplicate_post_taxonomies_blacklist( $taxonomies ) {
 		if ( empty( $taxonomies ) ) {
-			$taxonomies = array(); // As we get an empty string when there is no taxonomy
+			$taxonomies = []; // As we get an empty string when there is no taxonomy
 		}
 
 		$taxonomies[] = 'post_translations';
@@ -299,7 +301,7 @@ class PLL_Plugins_Compat {
 	 * @return array
 	 */
 	public function wp_sweep_excluded_taxonomies( $excluded_taxonomies ) {
-		return array_merge( $excluded_taxonomies, array( 'term_language', 'term_translations' ) );
+		return array_merge( $excluded_taxonomies, [ 'term_language', 'term_translations' ] );
 	}
 
 	/**
@@ -361,10 +363,10 @@ class PLL_Plugins_Compat {
 
 			// If we can't associate the requested domain to a language, redirect to the default domain
 			$hosts = PLL()->links_model->get_hosts();
-			$lang = array_search( $_SERVER['HTTP_HOST'], $hosts );
+			$lang  = array_search( $_SERVER['HTTP_HOST'], $hosts );
 
 			if ( empty( $lang ) ) {
-				$status = get_site_option( 'dm_301_redirect' ) ? '301' : '302'; // Honor status redirect option
+				$status   = get_site_option( 'dm_301_redirect' ) ? '301' : '302'; // Honor status redirect option
 				$redirect = ( is_ssl() ? 'https://' : 'http://' ) . $hosts[ $options['default_lang'] ] . $_SERVER['REQUEST_URI'];
 				wp_redirect( $redirect, $status );
 				exit;

--- a/modules/plugins/wp-import.php
+++ b/modules/plugins/wp-import.php
@@ -6,7 +6,7 @@
  * @since 1.2
  */
 class PLL_WP_Import extends WP_Import {
-	public $post_translations = array();
+	public $post_translations = [];
 
 	/**
 	 * overrides WP_Import::process_terms to remap terms translations
@@ -14,7 +14,7 @@ class PLL_WP_Import extends WP_Import {
 	 * @since 1.2
 	 */
 	function process_terms() {
-		$term_translations = array();
+		$term_translations = [];
 
 		// store this for future usage as parent function unsets $this->terms
 		foreach ( $this->terms as $term ) {
@@ -35,7 +35,7 @@ class PLL_WP_Import extends WP_Import {
 
 		if ( ( $options = get_option( 'polylang' ) ) && empty( $options['default_lang'] ) && ( $languages = PLL()->model->get_languages_list() ) ) {
 			// assign the default language if importer created the first language
-			$default_lang = reset( $languages );
+			$default_lang            = reset( $languages );
 			$options['default_lang'] = $default_lang->slug;
 			update_option( 'polylang', $options );
 		}
@@ -51,7 +51,7 @@ class PLL_WP_Import extends WP_Import {
 	 * @since 1.2
 	 */
 	function process_posts() {
-		$menu_items = $mo_posts = array();
+		$menu_items = $mo_posts = [];
 
 		// store this for future usage as parent function unset $this->posts
 		foreach ( $this->posts as $post ) {
@@ -131,11 +131,13 @@ class PLL_WP_Import extends WP_Import {
 			$trs = array_unique( $trs );
 
 			// make sure we don't attempt to insert already existing term relationships
-			$existing_trs = $wpdb->get_results( "
+			$existing_trs = $wpdb->get_results(
+				"
 				SELECT tr.object_id, tr.term_taxonomy_id FROM $wpdb->term_relationships AS tr
 				INNER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 				WHERE tt.taxonomy IN ( 'term_language', 'term_translations' )
-			" );
+			"
+			);
 
 			foreach ( $existing_trs as $key => $tr ) {
 				$existing_trs[ $key ] = $wpdb->prepare( '( %d, %d )', $tr->object_id, $tr->term_taxonomy_id );
@@ -161,8 +163,8 @@ class PLL_WP_Import extends WP_Import {
 		global $wpdb;
 
 		foreach ( $terms as $term ) {
-			$translations = unserialize( $term['term_description'] );
-			$new_translations = array();
+			$translations     = unserialize( $term['term_description'] );
+			$new_translations = [];
 
 			foreach ( $translations as $slug => $old_id ) {
 				if ( $old_id && ! empty( $processed_objects[ $old_id ] ) ) {
@@ -172,14 +174,16 @@ class PLL_WP_Import extends WP_Import {
 
 			if ( ! empty( $new_translations ) ) {
 				$u['case'][] = $wpdb->prepare( 'WHEN %d THEN %s', $this->processed_terms[ $term['term_id'] ], serialize( $new_translations ) );
-				$u['in'][] = (int) $this->processed_terms[ $term['term_id'] ];
+				$u['in'][]   = (int) $this->processed_terms[ $term['term_id'] ];
 			}
 		}
 
 		if ( ! empty( $u ) ) {
-			$wpdb->query( "UPDATE $wpdb->term_taxonomy
+			$wpdb->query(
+				"UPDATE $wpdb->term_taxonomy
 				SET description = ( CASE term_id " . implode( ' ', $u['case'] ) . ' END )
-				WHERE term_id IN ( ' . implode( ',', $u['in'] ) . ' )' );
+				WHERE term_id IN ( ' . implode( ',', $u['in'] ) . ' )'
+			);
 		}
 	}
 }

--- a/modules/plugins/wp-import.php
+++ b/modules/plugins/wp-import.php
@@ -146,6 +146,7 @@ class PLL_WP_Import extends WP_Import {
 			$trs = array_diff( $trs, $existing_trs );
 
 			if ( ! empty( $trs ) ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $trs ) );
 			}
 		}
@@ -179,11 +180,13 @@ class PLL_WP_Import extends WP_Import {
 		}
 
 		if ( ! empty( $u ) ) {
+			// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query(
 				"UPDATE $wpdb->term_taxonomy
 				SET description = ( CASE term_id " . implode( ' ', $u['case'] ) . ' END )
 				WHERE term_id IN ( ' . implode( ',', $u['in'] ) . ' )'
 			);
+			// phpcs:enable
 		}
 	}
 }

--- a/modules/plugins/wp-import.php
+++ b/modules/plugins/wp-import.php
@@ -18,10 +18,10 @@ class PLL_WP_Import extends WP_Import {
 
 		// store this for future usage as parent function unsets $this->terms
 		foreach ( $this->terms as $term ) {
-			if ( 'post_translations' == $term['term_taxonomy'] ) {
+			if ( 'post_translations' === $term['term_taxonomy'] ) {
 				$this->post_translations[] = $term;
 			}
-			if ( 'term_translations' == $term['term_taxonomy'] ) {
+			if ( 'term_translations' === $term['term_taxonomy'] ) {
 				$term_translations[] = $term;
 			}
 		}
@@ -55,7 +55,7 @@ class PLL_WP_Import extends WP_Import {
 
 		// store this for future usage as parent function unset $this->posts
 		foreach ( $this->posts as $post ) {
-			if ( 'nav_menu_item' == $post['post_type'] ) {
+			if ( 'nav_menu_item' === $post['post_type'] ) {
 				$menu_items[] = $post;
 			}
 
@@ -78,7 +78,7 @@ class PLL_WP_Import extends WP_Import {
 		// language switcher menu items
 		foreach ( $menu_items as $item ) {
 			foreach ( $item['postmeta'] as $meta ) {
-				if ( '_pll_menu_item' == $meta['key'] ) {
+				if ( '_pll_menu_item' === $meta['key'] ) {
 					update_post_meta( $this->processed_menu_items[ $item['post_id'] ], '_pll_menu_item', maybe_unserialize( $meta['value'] ) );
 				}
 			}

--- a/modules/plugins/wpseo.php
+++ b/modules/plugins/wpseo.php
@@ -17,13 +17,13 @@ class PLL_WPSEO {
 		}
 
 		if ( PLL() instanceof PLL_Frontend ) {
-			add_filter( 'option_wpseo_titles', array( $this, 'wpseo_translate_titles' ) );
+			add_filter( 'option_wpseo_titles', [ $this, 'wpseo_translate_titles' ] );
 
 			// Reloads options once the language has been defined to enable translations
 			// Useful only when the language is set from content
 			if ( version_compare( WPSEO_VERSION, '7.0', '<' ) && did_action( 'wp_loaded' ) ) {
 				$wpseo_front = WPSEO_Frontend::get_instance();
-				$options = WPSEO_Options::get_option_names();
+				$options     = WPSEO_Options::get_option_names();
 				foreach ( $options as $opt ) {
 					$wpseo_front->options = array_merge( $wpseo_front->options, (array) get_option( $opt ) );
 				}
@@ -32,33 +32,33 @@ class PLL_WPSEO {
 			// Filters sitemap queries to remove inactive language or to get
 			// one sitemap per language when using multiple domains or subdomains
 			// because WPSEO does not accept several domains or subdomains in one sitemap
-			add_filter( 'wpseo_posts_join', array( $this, 'wpseo_posts_join' ), 10, 2 );
-			add_filter( 'wpseo_posts_where', array( $this, 'wpseo_posts_where' ), 10, 2 );
-			add_filter( 'wpseo_typecount_join', array( $this, 'wpseo_posts_join' ), 10, 2 );
-			add_filter( 'wpseo_typecount_where', array( $this, 'wpseo_posts_where' ), 10, 2 );
+			add_filter( 'wpseo_posts_join', [ $this, 'wpseo_posts_join' ], 10, 2 );
+			add_filter( 'wpseo_posts_where', [ $this, 'wpseo_posts_where' ], 10, 2 );
+			add_filter( 'wpseo_typecount_join', [ $this, 'wpseo_posts_join' ], 10, 2 );
+			add_filter( 'wpseo_typecount_where', [ $this, 'wpseo_posts_where' ], 10, 2 );
 
 			if ( PLL()->options['force_lang'] > 1 ) {
 				add_filter( 'wpseo_enable_xml_sitemap_transient_caching', '__return_false' ); // Disable cache! otherwise WPSEO keeps only one domain (thanks to Junaid Bhura)
-				add_filter( 'home_url', array( $this, 'wpseo_home_url' ), 10, 2 ); // Fix home_url
+				add_filter( 'home_url', [ $this, 'wpseo_home_url' ], 10, 2 ); // Fix home_url
 			} else {
 				// Get all terms in all languages when the language is set from the content or directory name
-				add_filter( 'get_terms_args', array( $this, 'wpseo_remove_terms_filter' ) );
+				add_filter( 'get_terms_args', [ $this, 'wpseo_remove_terms_filter' ] );
 
 				// Add the homepages for all languages to the sitemap when the front page displays posts
 				if ( ! get_option( 'page_on_front' ) ) {
-					add_filter( 'wpseo_sitemap_post_content', array( $this, 'add_language_home_urls' ) );
+					add_filter( 'wpseo_sitemap_post_content', [ $this, 'add_language_home_urls' ] );
 				}
 			}
 
-			add_filter( 'pll_home_url_white_list', array( $this, 'wpseo_home_url_white_list' ) );
-			add_action( 'wpseo_opengraph', array( $this, 'wpseo_ogp' ), 2 );
-			add_filter( 'wpseo_canonical', array( $this, 'wpseo_canonical' ) );
+			add_filter( 'pll_home_url_white_list', [ $this, 'wpseo_home_url_white_list' ] );
+			add_action( 'wpseo_opengraph', [ $this, 'wpseo_ogp' ], 2 );
+			add_filter( 'wpseo_canonical', [ $this, 'wpseo_canonical' ] );
 		} else {
-			add_action( 'admin_init', array( $this, 'wpseo_register_strings' ) );
+			add_action( 'admin_init', [ $this, 'wpseo_register_strings' ] );
 
 			// Primary category
-			add_filter( 'pll_copy_post_metas', array( $this, 'copy_post_metas' ) );
-			add_filter( 'pll_translate_post_meta', array( $this, 'translate_post_meta' ), 10, 3 );
+			add_filter( 'pll_copy_post_metas', [ $this, 'copy_post_metas' ] );
+			add_filter( 'pll_translate_post_meta', [ $this, 'translate_post_meta' ], 10, 3 );
 		}
 	}
 
@@ -69,19 +69,34 @@ class PLL_WPSEO {
 	 */
 	function wpseo_register_strings() {
 		$options = get_option( 'wpseo_titles' );
-		foreach ( get_post_types( array( 'public' => true, '_builtin' => false ) ) as $t ) {
+		foreach ( get_post_types(
+			[
+				'public' => true,
+				'_builtin' => false,
+			]
+		) as $t ) {
 			if ( pll_is_translated_post_type( $t ) ) {
-				$this->_wpseo_register_strings( $options, array( 'title-' . $t, 'metadesc-' . $t ) );
+				$this->_wpseo_register_strings( $options, [ 'title-' . $t, 'metadesc-' . $t ] );
 			}
 		}
-		foreach ( get_post_types( array( 'has_archive' => true, '_builtin' => false ) ) as $t ) {
+		foreach ( get_post_types(
+			[
+				'has_archive' => true,
+				'_builtin' => false,
+			]
+		) as $t ) {
 			if ( pll_is_translated_post_type( $t ) ) {
-				$this->_wpseo_register_strings( $options, array( 'title-ptarchive-' . $t, 'metadesc-ptarchive-' . $t, 'bctitle-ptarchive-' . $t ) );
+				$this->_wpseo_register_strings( $options, [ 'title-ptarchive-' . $t, 'metadesc-ptarchive-' . $t, 'bctitle-ptarchive-' . $t ] );
 			}
 		}
-		foreach ( get_taxonomies( array( 'public' => true, '_builtin' => false ) ) as $t ) {
+		foreach ( get_taxonomies(
+			[
+				'public' => true,
+				'_builtin' => false,
+			]
+		) as $t ) {
 			if ( pll_is_translated_taxonomy( $t ) ) {
-				$this->_wpseo_register_strings( $options, array( 'title-tax-' . $t, 'metadesc-tax-' . $t ) );
+				$this->_wpseo_register_strings( $options, [ 'title-tax-' . $t, 'metadesc-tax-' . $t ] );
 			}
 		}
 	}
@@ -114,19 +129,34 @@ class PLL_WPSEO {
 	 */
 	function wpseo_translate_titles( $options ) {
 		if ( PLL() instanceof PLL_Frontend ) {
-			foreach ( get_post_types( array( 'public' => true, '_builtin' => false ) ) as $t ) {
+			foreach ( get_post_types(
+				[
+					'public' => true,
+					'_builtin' => false,
+				]
+			) as $t ) {
 				if ( pll_is_translated_post_type( $t ) ) {
-					$options = $this->_wpseo_translate_titles( $options, array( 'title-' . $t, 'metadesc-' . $t ) );
+					$options = $this->_wpseo_translate_titles( $options, [ 'title-' . $t, 'metadesc-' . $t ] );
 				}
 			}
-			foreach ( get_post_types( array( 'has_archive' => true, '_builtin' => false ) ) as $t ) {
+			foreach ( get_post_types(
+				[
+					'has_archive' => true,
+					'_builtin' => false,
+				]
+			) as $t ) {
 				if ( pll_is_translated_post_type( $t ) ) {
-					$options = $this->_wpseo_translate_titles( $options, array( 'title-ptarchive-' . $t, 'metadesc-ptarchive-' . $t, 'bctitle-ptarchive-' . $t ) );
+					$options = $this->_wpseo_translate_titles( $options, [ 'title-ptarchive-' . $t, 'metadesc-ptarchive-' . $t, 'bctitle-ptarchive-' . $t ] );
 				}
 			}
-			foreach ( get_taxonomies( array( 'public' => true, '_builtin' => false ) ) as $t ) {
+			foreach ( get_taxonomies(
+				[
+					'public' => true,
+					'_builtin' => false,
+				]
+			) as $t ) {
 				if ( pll_is_translated_taxonomy( $t ) ) {
-					$options = $this->_wpseo_translate_titles( $options, array( 'title-tax-' . $t, 'metadesc-tax-' . $t ) );
+					$options = $this->_wpseo_translate_titles( $options, [ 'title-tax-' . $t, 'metadesc-tax-' . $t ] );
 				}
 			}
 		}
@@ -162,10 +192,10 @@ class PLL_WPSEO {
 	 */
 	protected function wpseo_get_active_languages() {
 		$languages = PLL()->model->get_languages_list();
-		if ( wp_list_filter( $languages, array( 'active' => false ) ) ) {
-			return wp_list_pluck( wp_list_filter( $languages, array( 'active' => false ), 'NOT' ), 'slug' );
+		if ( wp_list_filter( $languages, [ 'active' => false ] ) ) {
+			return wp_list_pluck( wp_list_filter( $languages, [ 'active' => false ], 'NOT' ), 'slug' );
 		}
-		return array();
+		return [];
 	}
 
 	/**
@@ -233,15 +263,17 @@ class PLL_WPSEO {
 		global $wpseo_sitemaps;
 		$renderer = version_compare( WPSEO_VERSION, '3.2', '<' ) ? $wpseo_sitemaps : $wpseo_sitemaps->renderer;
 
-		$languages = wp_list_pluck( wp_list_filter( PLL()->model->get_languages_list(), array( 'active' => false ), 'NOT' ), 'slug' );
+		$languages = wp_list_pluck( wp_list_filter( PLL()->model->get_languages_list(), [ 'active' => false ], 'NOT' ), 'slug' );
 
 		foreach ( $languages as $lang ) {
 			if ( empty( PLL()->options['hide_default'] ) || pll_default_language() !== $lang ) {
-				$str .= $renderer->sitemap_url( array(
-					'loc' => pll_home_url( $lang ),
-					'pri' => 1,
-					'chf' => apply_filters( 'wpseo_sitemap_homepage_change_freq', 'daily', pll_home_url( $lang ) ),
-				) );
+				$str .= $renderer->sitemap_url(
+					[
+						'loc' => pll_home_url( $lang ),
+						'pri' => 1,
+						'chf' => apply_filters( 'wpseo_sitemap_homepage_change_freq', 'daily', pll_home_url( $lang ) ),
+					]
+				);
 			}
 		}
 		return $str;
@@ -256,7 +288,7 @@ class PLL_WPSEO {
 	 * @return array
 	 */
 	public function wpseo_home_url_white_list( $arr ) {
-		return array_merge( $arr, array( array( 'file' => 'wordpress-seo' ) ) );
+		return array_merge( $arr, [ [ 'file' => 'wordpress-seo' ] ] );
 	}
 
 	/**

--- a/modules/share-slug/settings-share-slug.php
+++ b/modules/share-slug/settings-share-slug.php
@@ -15,14 +15,16 @@ class PLL_Settings_Share_Slug extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'      => 'share-slugs',
-			'title'       => __( 'Share slugs', 'polylang' ),
-			'description' => __( 'Allows to share the same url slug across languages for posts and terms.', 'polylang' ),
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'      => 'share-slugs',
+				'title'       => __( 'Share slugs', 'polylang' ),
+				'description' => __( 'Allows to share the same url slug across languages for posts and terms.', 'polylang' ),
+			]
+		);
 
 		if ( class_exists( 'PLL_Share_Post_Slug', true ) && get_option( 'permalink_structure' ) ) {
-			add_action( 'admin_print_footer_scripts', array( $this, 'print_js' ) );
+			add_action( 'admin_print_footer_scripts', [ $this, 'print_js' ] );
 		}
 	}
 
@@ -57,7 +59,7 @@ class PLL_Settings_Share_Slug extends PLL_Settings_Module {
 	public function print_js() {
 		wp_enqueue_script( 'jquery' );
 
-		$activated = sprintf( '<span class="activated">%s</span>', $this->action_links['activated'] );
+		$activated   = sprintf( '<span class="activated">%s</span>', $this->action_links['activated'] );
 		$deactivated = sprintf( '<span class="deactivated">%s</span>', $this->action_links['deactivated'] );
 
 		?>

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -63,7 +63,7 @@ class PLL_Admin_Sync {
 	 * @param object $post      current post object
 	 */
 	public function add_meta_boxes( $post_type, $post ) {
-		if ( 'post-new.php' == $GLOBALS['pagenow'] && isset( $_GET['from_post'], $_GET['new_lang'] ) && $this->model->is_translated_post_type( $post->post_type ) ) {
+		if ( 'post-new.php' === $GLOBALS['pagenow'] && isset( $_GET['from_post'], $_GET['new_lang'] ) && $this->model->is_translated_post_type( $post->post_type ) ) {
 			// Capability check already done in post-new.php
 			$from_post_id = (int) $_GET['from_post'];
 			$from_post    = get_post( $from_post_id );
@@ -81,7 +81,7 @@ class PLL_Admin_Sync {
 			}
 
 			// Copy the date only if the synchronization is activated
-			if ( in_array( 'post_date', $this->options['sync'] ) ) {
+			if ( in_array( 'post_date', $this->options['sync'], true ) ) {
 				$post->post_date     = $from_post->post_date;
 				$post->post_date_gmt = $from_post->post_date_gmt;
 			}
@@ -106,12 +106,12 @@ class PLL_Admin_Sync {
 
 		// Prepare properties to synchronize
 		foreach ( [ 'comment_status', 'ping_status', 'menu_order' ] as $property ) {
-			if ( in_array( $property, $this->options['sync'] ) ) {
+			if ( in_array( $property, $this->options['sync'], true ) ) {
 				$postarr[ $property ] = $post->$property;
 			}
 		}
 
-		if ( in_array( 'post_date', $this->options['sync'] ) ) {
+		if ( in_array( 'post_date', $this->options['sync'], true ) ) {
 			// For new drafts, save the date now otherwise it is overriden by WP. Thanks to JoryHogeveen. See #32.
 			if ( 'post-new.php' === $GLOBALS['pagenow'] && isset( $_GET['from_post'], $_GET['new_lang'] ) ) {
 				$original = get_post( (int) $_GET['from_post'] );
@@ -145,7 +145,7 @@ class PLL_Admin_Sync {
 			// Add post parent to synchronization
 			// Make sure not to impact media translations when creating them at the same time as post
 			// Do not udpate the translation parent if the user set a parent with no translation
-			if ( in_array( 'post_parent', $this->options['sync'] ) && isset( $post_type ) && $post_type === $post->post_type ) {
+			if ( in_array( 'post_parent', $this->options['sync'], true ) && isset( $post_type ) && $post_type === $post->post_type ) {
 				$post_parent = ( $parent_id = wp_get_post_parent_id( $post_id ) ) ? $this->model->post->get_translation( $parent_id, $lang ) : 0;
 				if ( ! ( $parent_id && ! $post_parent ) ) {
 					$tr_arr['post_parent'] = $post_parent;
@@ -161,7 +161,7 @@ class PLL_Admin_Sync {
 		}
 
 		// Sticky posts
-		if ( in_array( 'sticky_posts', $this->options['sync'] ) ) {
+		if ( in_array( 'sticky_posts', $this->options['sync'], true ) ) {
 			$stickies = get_option( 'sticky_posts' );
 			if ( isset( $_REQUEST['sticky'] ) && 'sticky' === $_REQUEST['sticky'] ) {
 				$stickies = array_merge( $stickies, array_values( $translations ) );
@@ -227,7 +227,7 @@ class PLL_Admin_Sync {
 	 * @return array
 	 */
 	public function sync_sticky_posts( $value, $old_value ) {
-		if ( in_array( 'sticky_posts', $this->options['sync'] ) ) {
+		if ( in_array( 'sticky_posts', $this->options['sync'], true ) ) {
 			// Stick post
 			if ( $sticked = array_diff( $value, $old_value ) ) {
 				$translations = $this->model->post->get_translations( reset( $sticked ) );

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -260,7 +260,7 @@ class PLL_Admin_Sync {
 
 		if ( is_object( $this->$obj ) && method_exists( $this->$obj, 'copy' ) ) {
 			if ( WP_DEBUG ) {
-				$debug = debug_backtrace();
+				$debug = debug_backtrace( 1, 3 );
 				$i     = 1 + empty( $debug[1]['line'] ); // The file and line are in $debug[2] if the function was called using call_user_func
 
 				trigger_error(
@@ -273,7 +273,7 @@ class PLL_Admin_Sync {
 			return call_user_func_array( [ $this->$obj, 'copy' ], $args );
 		}
 
-		$debug = debug_backtrace();
+		$debug = debug_backtrace( 1, 1 );
 		trigger_error( sprintf( 'Call to undefined function PLL()->sync->%1$s() in %2$s on line %3$s' . "\nError handler", $func, $debug[0]['file'], $debug[0]['line'] ), E_USER_ERROR );
 	}
 }

--- a/modules/sync/settings-sync.php
+++ b/modules/sync/settings-sync.php
@@ -15,11 +15,13 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'      => 'sync',
-			'title'       => __( 'Synchronization', 'polylang' ),
-			'description' => __( 'The synchronization options allow to maintain exact same values (or translations in the case of taxonomies and page parent) of meta content between the translations of a post or page.', 'polylang' ),
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'      => 'sync',
+				'title'       => __( 'Synchronization', 'polylang' ),
+				'description' => __( 'The synchronization options allow to maintain exact same values (or translations in the case of taxonomies and page parent) of meta content between the translations of a post or page.', 'polylang' ),
+			]
+		);
 	}
 
 	/**
@@ -28,7 +30,7 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 	 * @since 1.8
 	 */
 	public function deactivate() {
-		$this->options['sync'] = array();
+		$this->options['sync'] = [];
 		update_option( 'polylang', $this->options );
 	}
 
@@ -62,7 +64,7 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 	 * @param array $options
 	 */
 	protected function update( $options ) {
-		$newoptions['sync'] = empty( $options['sync'] ) ? array() : array_keys( $options['sync'], 1 );
+		$newoptions['sync'] = empty( $options['sync'] ) ? [] : array_keys( $options['sync'], 1 );
 		return $newoptions; // take care to return only validated options
 	}
 
@@ -74,7 +76,7 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 	 * @return array
 	 */
 	protected function get_actions() {
-		return empty( $this->options['sync'] ) ? array( 'configure' ) : array( 'configure', 'deactivate' );
+		return empty( $this->options['sync'] ) ? [ 'configure' ] : [ 'configure', 'deactivate' ];
 	}
 
 	/**
@@ -85,7 +87,7 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 	 * @return array
 	 */
 	static public function list_metas_to_sync() {
-		return array(
+		return [
 			'taxonomies'        => __( 'Taxonomies', 'polylang' ),
 			'post_meta'         => __( 'Custom fields', 'polylang' ),
 			'comment_status'    => __( 'Comment status', 'polylang' ),
@@ -97,6 +99,6 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 			'_wp_page_template' => __( 'Page template', 'polylang' ),
 			'menu_order'        => __( 'Page order', 'polylang' ),
 			'_thumbnail_id'     => __( 'Featured image', 'polylang' ),
-		);
+		];
 	}
 }

--- a/modules/sync/settings-sync.php
+++ b/modules/sync/settings-sync.php
@@ -47,7 +47,7 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 				printf(
 					'<li><label><input name="sync[%s]" type="checkbox" value="1" %s /> %s</label></li>',
 					esc_attr( $key ),
-					in_array( $key, $this->options['sync'] ) ? 'checked="checked"' : '',
+					in_array( $key, $this->options['sync'], true ) ? 'checked="checked"' : '',
 					esc_html( $str )
 				);
 			}

--- a/modules/sync/sync-metas.php
+++ b/modules/sync/sync-metas.php
@@ -146,7 +146,7 @@ abstract class PLL_Sync_Metas {
 			foreach ( $tr_ids as $lang => $tr_id ) {
 				if ( $tr_id !== $id ) {
 					$to_copy = $this->get_metas_to_copy( $id, $tr_id, $lang, true );
-					if ( in_array( $meta_key, $to_copy ) ) {
+					if ( in_array( $meta_key, $to_copy, true ) ) {
 						$meta_value = $this->maybe_translate_value( $meta_value, $meta_key, $id, $tr_id, $lang );
 						add_metadata( $this->meta_type, $tr_id, $meta_key, $meta_value );
 					}
@@ -197,9 +197,9 @@ abstract class PLL_Sync_Metas {
 			$tr_ids = $this->model->{$this->meta_type}->get_translations( $id );
 
 			foreach ( $tr_ids as $lang => $tr_id ) {
-				if ( $tr_id != $id ) {
+				if ( $tr_id !== $id ) {
 					$to_copy = $this->get_metas_to_copy( $id, $tr_id, $lang, true );
-					if ( in_array( $meta_key, $to_copy ) ) {
+					if ( in_array( $meta_key, $to_copy, true ) ) {
 						$meta_value = $this->maybe_translate_value( $meta_value, $meta_key, $id, $tr_id, $lang );
 						$prev_meta  = get_metadata_by_mid( $this->meta_type, $mid );
 						if ( empty( $this->prev_value[ $hash ] ) || $this->prev_value[ $hash ] === $prev_meta->meta_value ) {
@@ -253,7 +253,7 @@ abstract class PLL_Sync_Metas {
 
 			foreach ( $tr_ids as $lang => $tr_id ) {
 				if ( $tr_id !== $id ) {
-					if ( in_array( $key, $this->to_copy[ $id ][ $tr_id ] ) ) {
+					if ( in_array( $key, $this->to_copy[ $id ][ $tr_id ], true ) ) {
 						if ( '' !== $value && null !== $value && false !== $value ) { // Same test as WP
 							$value = $this->maybe_translate_value( $value, $key, $id, $tr_id, $lang );
 						}

--- a/modules/sync/sync-metas.php
+++ b/modules/sync/sync-metas.php
@@ -21,7 +21,7 @@ abstract class PLL_Sync_Metas {
 
 		$this->add_all_meta_actions();
 
-		add_action( "pll_save_{$this->meta_type}", array( $this, 'save_object' ), 10, 3 );
+		add_action( "pll_save_{$this->meta_type}", [ $this, 'save_object' ], 10, 3 );
 	}
 
 	/**
@@ -30,7 +30,7 @@ abstract class PLL_Sync_Metas {
 	 * @since 2.3
 	 */
 	protected function remove_add_meta_action() {
-		remove_action( "added_{$this->meta_type}_meta", array( $this, 'add_meta' ), 10, 4 );
+		remove_action( "added_{$this->meta_type}_meta", [ $this, 'add_meta' ], 10, 4 );
 	}
 
 	/**
@@ -41,11 +41,11 @@ abstract class PLL_Sync_Metas {
 	protected function remove_all_meta_actions() {
 		$this->remove_add_meta_action();
 
-		remove_filter( "update_{$this->meta_type}_metadata", array( $this, 'update_metadata' ), 999, 5 );
-		remove_action( "update_{$this->meta_type}_meta", array( $this, 'update_meta' ), 10, 4 );
+		remove_filter( "update_{$this->meta_type}_metadata", [ $this, 'update_metadata' ], 999, 5 );
+		remove_action( "update_{$this->meta_type}_meta", [ $this, 'update_meta' ], 10, 4 );
 
-		remove_action( "delete_{$this->meta_type}_meta", array( $this, 'store_metas_to_sync' ), 10, 2 );
-		remove_action( "deleted_{$this->meta_type}_meta", array( $this, 'delete_meta' ), 10, 4 );
+		remove_action( "delete_{$this->meta_type}_meta", [ $this, 'store_metas_to_sync' ], 10, 2 );
+		remove_action( "deleted_{$this->meta_type}_meta", [ $this, 'delete_meta' ], 10, 4 );
 	}
 
 	/**
@@ -54,7 +54,7 @@ abstract class PLL_Sync_Metas {
 	 * @since 2.3
 	 */
 	protected function restore_add_meta_action() {
-		add_action( "added_{$this->meta_type}_meta", array( $this, 'add_meta' ), 10, 4 );
+		add_action( "added_{$this->meta_type}_meta", [ $this, 'add_meta' ], 10, 4 );
 	}
 
 	/**
@@ -65,11 +65,11 @@ abstract class PLL_Sync_Metas {
 	protected function add_all_meta_actions() {
 		$this->restore_add_meta_action();
 
-		add_filter( "update_{$this->meta_type}_metadata", array( $this, 'update_metadata' ), 999, 5 ); // Very late in case a filter prevents the meta to be updated
-		add_action( "update_{$this->meta_type}_meta", array( $this, 'update_meta' ), 10, 4 );
+		add_filter( "update_{$this->meta_type}_metadata", [ $this, 'update_metadata' ], 999, 5 ); // Very late in case a filter prevents the meta to be updated
+		add_action( "update_{$this->meta_type}_meta", [ $this, 'update_meta' ], 10, 4 );
 
-		add_action( "delete_{$this->meta_type}_meta", array( $this, 'store_metas_to_sync' ), 10, 2 );
-		add_action( "deleted_{$this->meta_type}_meta", array( $this, 'delete_meta' ), 10, 4 );
+		add_action( "delete_{$this->meta_type}_meta", [ $this, 'store_metas_to_sync' ], 10, 2 );
+		add_action( "deleted_{$this->meta_type}_meta", [ $this, 'delete_meta' ], 10, 4 );
 	}
 
 	/**
@@ -123,7 +123,7 @@ abstract class PLL_Sync_Metas {
 		 * @param int    $to   Id of the post to which we paste informations
 		 * @param string $lang Language slug
 		 */
-		return array_unique( apply_filters( "pll_copy_{$this->meta_type}_metas", array(), $sync, $from, $to, $lang ) );
+		return array_unique( apply_filters( "pll_copy_{$this->meta_type}_metas", [], $sync, $from, $to, $lang ) );
 	}
 
 	/**
@@ -141,7 +141,7 @@ abstract class PLL_Sync_Metas {
 
 		if ( ! $avoid_recursion ) {
 			$avoid_recursion = true;
-			$tr_ids = $this->model->{$this->meta_type}->get_translations( $id );
+			$tr_ids          = $this->model->{$this->meta_type}->get_translations( $id );
 
 			foreach ( $tr_ids as $lang => $tr_id ) {
 				if ( $tr_id !== $id ) {
@@ -171,7 +171,7 @@ abstract class PLL_Sync_Metas {
 	 */
 	public function update_metadata( $r, $id, $meta_key, $meta_value, $prev_value ) {
 		if ( null === $r ) {
-			$hash = md5( "$id|$meta_key|" . maybe_serialize( $meta_value ) );
+			$hash                      = md5( "$id|$meta_key|" . maybe_serialize( $meta_value ) );
 			$this->prev_value[ $hash ] = $prev_value;
 		}
 		return $r;
@@ -192,7 +192,7 @@ abstract class PLL_Sync_Metas {
 
 		if ( ! $avoid_recursion ) {
 			$avoid_recursion = true;
-			$hash = md5( "$id|$meta_key|" . maybe_serialize( $meta_value ) );
+			$hash            = md5( "$id|$meta_key|" . maybe_serialize( $meta_value ) );
 
 			$tr_ids = $this->model->{$this->meta_type}->get_translations( $id );
 
@@ -201,7 +201,7 @@ abstract class PLL_Sync_Metas {
 					$to_copy = $this->get_metas_to_copy( $id, $tr_id, $lang, true );
 					if ( in_array( $meta_key, $to_copy ) ) {
 						$meta_value = $this->maybe_translate_value( $meta_value, $meta_key, $id, $tr_id, $lang );
-						$prev_meta = get_metadata_by_mid( $this->meta_type, $mid );
+						$prev_meta  = get_metadata_by_mid( $this->meta_type, $mid );
 						if ( empty( $this->prev_value[ $hash ] ) || $this->prev_value[ $hash ] === $prev_meta->meta_value ) {
 							$prev_value = $this->maybe_translate_value( $prev_meta->meta_value, $meta_key, $id, $tr_id, $lang );
 							$this->remove_add_meta_action(); // We don't want to sync back the new metas
@@ -279,11 +279,11 @@ abstract class PLL_Sync_Metas {
 	public function copy( $from, $to, $lang, $sync = false ) {
 		$this->remove_all_meta_actions();
 
-		remove_action( "delete_{$this->meta_type}_meta", array( $this, 'store_metas_to_sync' ), 10, 2 );
-		remove_action( "deleted_{$this->meta_type}_meta", array( $this, 'delete_meta' ), 10, 4 );
+		remove_action( "delete_{$this->meta_type}_meta", [ $this, 'store_metas_to_sync' ], 10, 2 );
+		remove_action( "deleted_{$this->meta_type}_meta", [ $this, 'delete_meta' ], 10, 4 );
 
-		$to_copy = $this->get_metas_to_copy( $from, $to, $lang, $sync );
-		$metas = get_metadata( $this->meta_type, $from );
+		$to_copy  = $this->get_metas_to_copy( $from, $to, $lang, $sync );
+		$metas    = get_metadata( $this->meta_type, $from );
 		$tr_metas = get_metadata( $this->meta_type, $to );
 
 		foreach ( $to_copy as $key ) {
@@ -295,8 +295,8 @@ abstract class PLL_Sync_Metas {
 			} else {
 				if ( ! empty( $tr_metas[ $key ] ) && 1 === count( $metas[ $key ] ) && 1 === count( $tr_metas[ $key ] ) ) {
 					// One custom field to update
-					$value = reset( $metas[ $key ] );
-					$value = maybe_unserialize( $value );
+					$value    = reset( $metas[ $key ] );
+					$value    = maybe_unserialize( $value );
 					$to_value = $this->maybe_translate_value( $value, $key, $from, $to, $lang );
 					update_metadata( $this->meta_type, $to, $key, $to_value );
 				} else {
@@ -307,7 +307,7 @@ abstract class PLL_Sync_Metas {
 					}
 
 					foreach ( $metas[ $key ] as $value ) {
-						$value = maybe_unserialize( $value );
+						$value    = maybe_unserialize( $value );
 						$to_value = $this->maybe_translate_value( $value, $key, $from, $to, $lang );
 						add_metadata( $this->meta_type, $to, $key, $to_value );
 					}

--- a/modules/sync/sync-post-metas.php
+++ b/modules/sync/sync-post-metas.php
@@ -22,7 +22,7 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 
 		$this->options = &$polylang->options;
 
-		add_filter( 'pll_translate_post_meta', array( $this, 'translate_thumbnail_id' ), 10, 3 );
+		add_filter( 'pll_translate_post_meta', [ $this, 'translate_thumbnail_id' ], 10, 3 );
 	}
 
 	/**
@@ -39,7 +39,7 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 	protected function get_metas_to_copy( $from, $to, $lang, $sync = false ) {
 		// Copy or synchronize post metas and allow plugins to do the same
 		$metas = get_post_custom( $from );
-		$keys = array();
+		$keys  = [];
 
 		// Get public meta keys ( including from translated post in case we just deleted a custom field )
 		if ( ! $sync || in_array( 'post_meta', $this->options['sync'] ) ) {
@@ -51,7 +51,7 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 		}
 
 		// Add page template and featured image
-		foreach ( array( '_wp_page_template', '_thumbnail_id' ) as $meta ) {
+		foreach ( [ '_wp_page_template', '_thumbnail_id' ] as $meta ) {
 			if ( ! $sync || in_array( $meta, $this->options['sync'] ) ) {
 				$keys[] = $meta;
 			}

--- a/modules/sync/sync-post-metas.php
+++ b/modules/sync/sync-post-metas.php
@@ -42,7 +42,7 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 		$keys  = [];
 
 		// Get public meta keys ( including from translated post in case we just deleted a custom field )
-		if ( ! $sync || in_array( 'post_meta', $this->options['sync'] ) ) {
+		if ( ! $sync || in_array( 'post_meta', $this->options['sync'], true ) ) {
 			foreach ( $keys = array_unique( array_merge( array_keys( $metas ), array_keys( get_post_custom( $to ) ) ) ) as $k => $meta_key ) {
 				if ( is_protected_meta( $meta_key ) ) {
 					unset( $keys[ $k ] );
@@ -52,7 +52,7 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 
 		// Add page template and featured image
 		foreach ( [ '_wp_page_template', '_thumbnail_id' ] as $meta ) {
-			if ( ! $sync || in_array( $meta, $this->options['sync'] ) ) {
+			if ( ! $sync || in_array( $meta, $this->options['sync'], true ) ) {
 				$keys[] = $meta;
 			}
 		}

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -37,8 +37,8 @@ class PLL_Sync_Tax {
 	 * @return array List of taxonomy names
 	 */
 	protected function get_taxonomies_to_copy( $sync, $from = null, $to = null, $lang = null ) {
-		$taxonomies = ! $sync || in_array( 'taxonomies', $this->options['sync'] ) ? $this->model->get_translated_taxonomies() : [];
-		if ( ! $sync || in_array( 'post_format', $this->options['sync'] ) ) {
+		$taxonomies = ! $sync || in_array( 'taxonomies', $this->options['sync'], true ) ? $this->model->get_translated_taxonomies() : [];
+		if ( ! $sync || in_array( 'post_format', $this->options['sync'], true ) ) {
 			$taxonomies[] = 'post_format';
 		}
 
@@ -125,7 +125,7 @@ class PLL_Sync_Tax {
 				if ( $tr_id !== $object_id ) {
 					$to_copy = $this->get_taxonomies_to_copy( true, $object_id, $tr_id, $lang );
 
-					if ( in_array( $taxonomy, $to_copy ) ) {
+					if ( in_array( $taxonomy, $to_copy, true ) ) {
 						$newterms = $this->maybe_translate_terms( $object_id, $terms, $taxonomy, $lang );
 
 						// For some reasons, the user may have untranslated terms in the translation. Don't forget them.
@@ -192,7 +192,7 @@ class PLL_Sync_Tax {
 	 * @param array  $translations Ids of the translations of the created term
 	 */
 	public function create_term( $term_id, $taxonomy, $translations ) {
-		if ( doing_action( 'create_term' ) && in_array( $taxonomy, $this->get_taxonomies_to_copy( true ) ) ) {
+		if ( doing_action( 'create_term' ) && in_array( $taxonomy, $this->get_taxonomies_to_copy( true ), true ) ) {
 			// Get all posts associated to the translated terms
 			$tr_posts = get_posts(
 				[

--- a/modules/translate-slugs/settings-translate-slugs.php
+++ b/modules/translate-slugs/settings-translate-slugs.php
@@ -14,11 +14,13 @@ class PLL_Settings_Translate_Slugs extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'      => 'translate-slugs',
-			'title'       => __( 'Translate slugs', 'polylang' ),
-			'description' => __( 'Allows to translate custom post types and taxonomies slugs in urls.', 'polylang' ),
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'      => 'translate-slugs',
+				'title'       => __( 'Translate slugs', 'polylang' ),
+				'description' => __( 'Allows to translate custom post types and taxonomies slugs in urls.', 'polylang' ),
+			]
+		);
 	}
 
 	/**

--- a/modules/wpml/settings-wpml.php
+++ b/modules/wpml/settings-wpml.php
@@ -15,11 +15,13 @@ class PLL_Settings_WPML extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'      => 'wpml',
-			'title'       => __( 'WPML Compatibility', 'polylang' ),
-			'description' => __( 'WPML compatibility mode of Polylang', 'polylang' ),
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'      => 'wpml',
+				'title'       => __( 'WPML Compatibility', 'polylang' ),
+				'description' => __( 'WPML compatibility mode of Polylang', 'polylang' ),
+			]
+		);
 	}
 
 	/**

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -17,16 +17,16 @@ class PLL_WPML_API {
 	public function __construct() {
 		// Site Wide Language informations
 
-		add_filter( 'wpml_active_languages', array( $this, 'wpml_active_languages' ), 10, 2 );
-		add_filter( 'wpml_display_language_names', array( $this, 'wpml_display_language_names' ), 10, 5 );
+		add_filter( 'wpml_active_languages', [ $this, 'wpml_active_languages' ], 10, 2 );
+		add_filter( 'wpml_display_language_names', [ $this, 'wpml_display_language_names' ], 10, 5 );
 		// wpml_translated_language_name      => not applicable
 		add_filter( 'wpml_current_language', 'pll_current_language', 10, 0 );
 		add_filter( 'wpml_default_language', 'pll_default_language', 10, 0 );
 		// wpml_add_language_selector         => not implemented
 		// wpml_footer_language_selector      => not applicable
-		add_action( 'wpml_add_language_form_field', array( $this, 'wpml_add_language_form_field' ) );
-		add_filter( 'wpml_language_is_active', array( $this, 'wpml_language_is_active' ), 10, 2 );
-		add_filter( 'wpml_is_rtl', array( $this, 'wpml_is_rtl' ) );
+		add_action( 'wpml_add_language_form_field', [ $this, 'wpml_add_language_form_field' ] );
+		add_filter( 'wpml_language_is_active', [ $this, 'wpml_language_is_active' ], 10, 2 );
+		add_filter( 'wpml_is_rtl', [ $this, 'wpml_is_rtl' ] );
 		// wpml_language_form_input_field     => See wpml_add_language_form_field
 		// wpml_language_has_switched         => not implemented
 
@@ -34,7 +34,7 @@ class PLL_WPML_API {
 
 		add_filter( 'wpml_post_language_details', 'wpml_get_language_information', 10, 2 );
 		// wpml_switch_language               => not implemented
-		add_filter( 'wpml_element_language_code', array( $this, 'wpml_element_language_code' ), 10, 3 );
+		add_filter( 'wpml_element_language_code', [ $this, 'wpml_element_language_code' ], 10, 3 );
 		// wpml_element_language_details      => not applicable
 
 		// Retrieving Localized Content
@@ -42,17 +42,17 @@ class PLL_WPML_API {
 		add_filter( 'wpml_home_url', 'pll_home_url', 10, 0 );
 		add_filter( 'wpml_element_link', 'icl_link_to_element', 10, 7 );
 		add_filter( 'wpml_object_id', 'icl_object_id', 10, 4 );
-		add_filter( 'wpml_translate_single_string', array( $this, 'wpml_translate_single_string' ), 10, 4 );
+		add_filter( 'wpml_translate_single_string', [ $this, 'wpml_translate_single_string' ], 10, 4 );
 		// wpml_translate_string              => not applicable
 		// wpml_unfiltered_admin_string       => not implemented
-		add_filter( 'wpml_permalink', array( $this, 'wpml_permalink' ), 10, 2 );
+		add_filter( 'wpml_permalink', [ $this, 'wpml_permalink' ], 10, 2 );
 		// wpml_elements_without_translations => not implemented
-		add_filter( 'wpml_get_translated_slug', array( $this, 'wpml_get_translated_slug' ), 10, 3 );
+		add_filter( 'wpml_get_translated_slug', [ $this, 'wpml_get_translated_slug' ], 10, 3 );
 
 		// Finding the Translation State of Content
 
 		// wpml_element_translation_type
-		add_filter( 'wpml_element_has_translations', array( $this, 'wpml_element_has_translations' ), 10, 3 );
+		add_filter( 'wpml_element_has_translations', [ $this, 'wpml_element_has_translations' ], 10, 3 );
 		// wpml_master_post_from_duplicate    => not applicable
 		// wpml_post_duplicates               => not applicable
 
@@ -122,7 +122,7 @@ class PLL_WPML_API {
 	 * @since 2.0
 	 */
 	public function wpml_add_language_form_field() {
-		$lang = pll_current_language();
+		$lang  = pll_current_language();
 		$field = sprintf( '<input type="hidden" name="lang" value="%s" />', esc_attr( $lang ) );
 		$field = apply_filters( 'wpml_language_form_input_field', $field, $lang );
 		echo $field;
@@ -164,8 +164,8 @@ class PLL_WPML_API {
 	 * @return string
 	 */
 	public function wpml_element_language_code( $language_code, $args ) {
-		$type = $args['element_type'];
-		$id = $args['element_id'];
+		$type     = $args['element_type'];
+		$id       = $args['element_id'];
 		$pll_type = ( 'post' == $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' == $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
 		if ( 'term' === $pll_type && $term = wpcom_vip_get_term_by( 'term_taxonomy_id', $id ) ) {
 			$id = $term->term_id;
@@ -240,7 +240,7 @@ class PLL_WPML_API {
 	 * @return bool
 	 */
 	public function wpml_element_has_translations( $null, $id, $type ) {
-		$pll_type = ( 'post' == $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' == $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
+		$pll_type                           = ( 'post' == $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' == $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
 		return ( $pll_type && $translations = call_user_func( "pll_get_{$pll_type}_translations", $id ) ) ? count( $translations ) > 1 : false;
 	}
 }

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -166,7 +166,7 @@ class PLL_WPML_API {
 	public function wpml_element_language_code( $language_code, $args ) {
 		$type     = $args['element_type'];
 		$id       = $args['element_id'];
-		$pll_type = ( 'post' == $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' == $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
+		$pll_type = ( 'post' === $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' === $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
 		if ( 'term' === $pll_type && $term = wpcom_vip_get_term_by( 'term_taxonomy_id', $id ) ) {
 			$id = $term->term_id;
 		}
@@ -240,7 +240,7 @@ class PLL_WPML_API {
 	 * @return bool
 	 */
 	public function wpml_element_has_translations( $null, $id, $type ) {
-		$pll_type                           = ( 'post' == $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' == $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
+		$pll_type                           = ( 'post' === $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' === $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
 		return ( $pll_type && $translations = call_user_func( "pll_get_{$pll_type}_translations", $id ) ) ? count( $translations ) > 1 : false;
 	}
 }

--- a/modules/wpml/wpml-compat.php
+++ b/modules/wpml/wpml-compat.php
@@ -22,11 +22,11 @@ class PLL_WPML_Compat {
 		require_once PLL_MODULES_INC . '/wpml/wpml-legacy-api.php';
 		$this->api = new PLL_WPML_API();
 
-		self::$strings = get_option( 'polylang_wpml_strings', array() );
+		self::$strings = get_option( 'polylang_wpml_strings', [] );
 
-		add_action( 'pll_language_defined', array( $this, 'define_constants' ) );
-		add_action( 'pll_no_language_defined', array( $this, 'define_constants' ) );
-		add_filter( 'pll_get_strings', array( $this, 'get_strings' ) );
+		add_action( 'pll_language_defined', [ $this, 'define_constants' ] );
+		add_action( 'pll_no_language_defined', [ $this, 'define_constants' ] );
+		add_filter( 'pll_get_strings', [ $this, 'get_strings' ] );
 	}
 
 	/**
@@ -83,7 +83,13 @@ class PLL_WPML_Compat {
 	 */
 	public function register_string( $context, $name, $string ) {
 		// Registers the string if it does not exist yet (multiline as in WPML)
-		$to_register = array( 'context' => $context, 'name' => $name, 'string' => $string, 'multiline' => true, 'icl' => true );
+		$to_register = [
+			'context' => $context,
+			'name' => $name,
+			'string' => $string,
+			'multiline' => true,
+			'icl' => true,
+		];
 		if ( ! in_array( $to_register, self::$strings ) && $to_register['string'] ) {
 			self::$strings[] = $to_register;
 			update_option( 'polylang_wpml_strings', self::$strings );

--- a/modules/wpml/wpml-compat.php
+++ b/modules/wpml/wpml-compat.php
@@ -90,7 +90,7 @@ class PLL_WPML_Compat {
 			'multiline' => true,
 			'icl' => true,
 		];
-		if ( ! in_array( $to_register, self::$strings ) && $to_register['string'] ) {
+		if ( ! in_array( $to_register, self::$strings, true ) && $to_register['string'] ) {
 			self::$strings[] = $to_register;
 			update_option( 'polylang_wpml_strings', self::$strings );
 		}
@@ -106,7 +106,7 @@ class PLL_WPML_Compat {
 	 */
 	public function unregister_string( $context, $name ) {
 		foreach ( self::$strings as $key => $string ) {
-			if ( $string['context'] == $context && $string['name'] == $name ) {
+			if ( $string['context'] === $context && $string['name'] === $name ) {
 				unset( self::$strings[ $key ] );
 				update_option( 'polylang_wpml_strings', self::$strings );
 			}
@@ -136,7 +136,7 @@ class PLL_WPML_Compat {
 	 */
 	public function get_string_by_context_and_name( $context, $name ) {
 		foreach ( self::$strings as $string ) {
-			if ( $string['context'] == $context && $string['name'] == $name ) {
+			if ( $string['context'] === $context && $string['name'] === $name ) {
 				return $string['string'];
 			}
 		}

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -42,12 +42,12 @@ class PLL_WPML_Config {
 	 * @since 1.0
 	 */
 	public function init() {
-		$this->xmls = array();
+		$this->xmls = [];
 
 		// Plugins
 		// Don't forget sitewide active plugins thanks to Reactorshop http://wordpress.org/support/topic/polylang-and-yoast-seo-plugin/page/2?replies=38#post-4801829
-		$plugins = ( is_multisite() && $sitewide_plugins = get_site_option( 'active_sitewide_plugins' ) ) && is_array( $sitewide_plugins ) ? array_keys( $sitewide_plugins ) : array();
-		$plugins = array_merge( $plugins, get_option( 'active_plugins', array() ) );
+		$plugins = ( is_multisite() && $sitewide_plugins = get_site_option( 'active_sitewide_plugins' ) ) && is_array( $sitewide_plugins ) ? array_keys( $sitewide_plugins ) : [];
+		$plugins = array_merge( $plugins, get_option( 'active_plugins', [] ) );
 
 		foreach ( $plugins as $plugin ) {
 			if ( file_exists( $file = WP_PLUGIN_DIR . '/' . dirname( $plugin ) . '/wpml-config.xml' ) && false !== $xml = simplexml_load_file( $file ) ) {
@@ -71,17 +71,17 @@ class PLL_WPML_Config {
 		}
 
 		if ( ! empty( $this->xmls ) ) {
-			add_filter( 'pll_copy_post_metas', array( $this, 'copy_post_metas' ), 10, 2 );
-			add_filter( 'pll_get_post_types', array( $this, 'translate_types' ), 10, 2 );
-			add_filter( 'pll_get_taxonomies', array( $this, 'translate_taxonomies' ), 10, 2 );
+			add_filter( 'pll_copy_post_metas', [ $this, 'copy_post_metas' ], 10, 2 );
+			add_filter( 'pll_get_post_types', [ $this, 'translate_types' ], 10, 2 );
+			add_filter( 'pll_get_taxonomies', [ $this, 'translate_taxonomies' ], 10, 2 );
 
 			foreach ( $this->xmls as $context => $xml ) {
 				foreach ( $xml->xpath( 'admin-texts/key' ) as $key ) {
 					$attributes = $key->attributes();
-					$name = (string) $attributes['name'];
+					$name       = (string) $attributes['name'];
 					if ( PLL() instanceof PLL_Frontend ) {
 						$this->options[ $name ] = $key;
-						add_filter( 'option_' . $name, array( $this, 'translate_strings' ) );
+						add_filter( 'option_' . $name, [ $this, 'translate_strings' ] );
 					} else {
 						$this->register_string_recursive( $context, get_option( $name ), $key );
 					}
@@ -103,10 +103,10 @@ class PLL_WPML_Config {
 		foreach ( $this->xmls as $xml ) {
 			foreach ( $xml->xpath( 'custom-fields/custom-field' ) as $cf ) {
 				$attributes = $cf->attributes();
-				if ( 'copy' == $attributes['action'] || ( ! $sync && in_array( $attributes['action'], array( 'translate', 'copy-once' ) ) ) ) {
+				if ( 'copy' == $attributes['action'] || ( ! $sync && in_array( $attributes['action'], [ 'translate', 'copy-once' ] ) ) ) {
 					$metas[] = (string) $cf;
 				} else {
-					$metas = array_diff( $metas, array( (string) $cf ) );
+					$metas = array_diff( $metas, [ (string) $cf ] );
 				}
 			}
 		}
@@ -186,7 +186,7 @@ class PLL_WPML_Config {
 		if ( count( $children ) ) {
 			foreach ( $children as $child ) {
 				$attributes = $child->attributes();
-				$name = (string) $attributes['name'];
+				$name       = (string) $attributes['name'];
 				if ( '*' === $name && is_array( $options ) ) {
 					foreach ( $options as $n => $option ) {
 						$this->register_wildcard_options_recursive( $context, $option, $n );
@@ -234,7 +234,7 @@ class PLL_WPML_Config {
 		if ( count( $children ) ) {
 			foreach ( $children as $child ) {
 				$attributes = $child->attributes();
-				$name = (string) $attributes['name'];
+				$name       = (string) $attributes['name'];
 				if ( '*' === $name && is_array( $values ) ) {
 					foreach ( $values as $n => $v ) {
 						$values[ $n ] = $this->translate_wildcard_options_recursive( $v, $n );

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -103,7 +103,7 @@ class PLL_WPML_Config {
 		foreach ( $this->xmls as $xml ) {
 			foreach ( $xml->xpath( 'custom-fields/custom-field' ) as $cf ) {
 				$attributes = $cf->attributes();
-				if ( 'copy' == $attributes['action'] || ( ! $sync && in_array( $attributes['action'], [ 'translate', 'copy-once' ] ) ) ) {
+				if ( 'copy' === $attributes['action'] || ( ! $sync && in_array( $attributes['action'], [ 'translate', 'copy-once' ], true ) ) ) {
 					$metas[] = (string) $cf;
 				} else {
 					$metas = array_diff( $metas, [ (string) $cf ] );
@@ -126,7 +126,7 @@ class PLL_WPML_Config {
 		foreach ( $this->xmls as $xml ) {
 			foreach ( $xml->xpath( 'custom-types/custom-type' ) as $pt ) {
 				$attributes = $pt->attributes();
-				if ( 1 == $attributes['translate'] && ! $hide ) {
+				if ( 1 === $attributes['translate'] && ! $hide ) {
 					$types[ (string) $pt ] = (string) $pt;
 				} else {
 					unset( $types[ (string) $pt ] ); // The theme/plugin author decided what to do with the post type so don't allow the user to change this
@@ -149,7 +149,7 @@ class PLL_WPML_Config {
 		foreach ( $this->xmls as $xml ) {
 			foreach ( $xml->xpath( 'taxonomies/taxonomy' ) as $tax ) {
 				$attributes = $tax->attributes();
-				if ( 1 == $attributes['translate'] && ! $hide ) {
+				if ( 1 === $attributes['translate'] && ! $hide ) {
 					$taxonomies[ (string) $tax ] = (string) $tax;
 				} else {
 					unset( $taxonomies[ (string) $tax ] ); // the theme/plugin author decided what to do with the taxonomy so don't allow the user to change this

--- a/modules/wpml/wpml-legacy-api.php
+++ b/modules/wpml/wpml-legacy-api.php
@@ -55,8 +55,8 @@ if ( ! function_exists( 'icl_get_languages' ) ) {
 				'order' => 'ASC',
 			]
 		);
-		$orderby = ( isset( $args['orderby'] ) && 'code' == $args['orderby'] ) ? 'slug' : ( isset( $args['orderby'] ) && 'name' == $args['orderby'] ? 'name' : 'id' );
-		$order   = ( ! empty( $args['order'] ) && 'desc' == $args['order'] ) ? 'DESC' : 'ASC';
+		$orderby = ( isset( $args['orderby'] ) && 'code' === $args['orderby'] ) ? 'slug' : ( isset( $args['orderby'] ) && 'name' === $args['orderby'] ? 'name' : 'id' );
+		$order   = ( ! empty( $args['order'] ) && 'desc' === $args['order'] ) ? 'DESC' : 'ASC';
 
 		$arr = [];
 
@@ -81,7 +81,7 @@ if ( ! function_exists( 'icl_get_languages' ) ) {
 
 			$arr[ $lang->slug ] = [
 				'id'               => $lang->term_id,
-				'active'           => isset( PLL()->curlang->slug ) && PLL()->curlang->slug == $lang->slug ? 1 : 0,
+				'active'           => isset( PLL()->curlang->slug ) && PLL()->curlang->slug === $lang->slug ? 1 : 0,
 				'native_name'      => $lang->name,
 				'missing'          => empty( $url ) ? 1 : 0,
 				'translated_name'  => '', // Does not exist in Polylang
@@ -117,11 +117,11 @@ if ( ! function_exists( 'icl_link_to_element' ) ) {
 	 * @return string a language dependent link
 	 */
 	function icl_link_to_element( $id, $type = 'post', $text = '', $args = [], $anchor = '', $echo = true, $return_original_if_missing = true ) {
-		if ( 'tag' == $type ) {
+		if ( 'tag' === $type ) {
 			$type = 'post_tag';
 		}
 
-		$pll_type = ( 'post' == $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' == $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
+		$pll_type = ( 'post' === $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' === $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
 		if ( $pll_type && ( $lang = pll_current_language() ) && ( $tr_id = PLL()->model->$pll_type->get_translation( $id, $lang ) ) && PLL()->links->current_user_can_read( $tr_id ) ) {
 			$id = $tr_id;
 		} elseif ( ! $return_original_if_missing ) {

--- a/modules/wpml/wpml-legacy-api.php
+++ b/modules/wpml/wpml-legacy-api.php
@@ -48,14 +48,20 @@ if ( ! function_exists( 'icl_get_languages' ) ) {
 	 * @return array array of arrays per language
 	 */
 	function icl_get_languages( $args = '' ) {
-		$args = wp_parse_args( $args, array( 'skip_missing' => 0, 'orderby' => 'id', 'order' => 'ASC' ) );
+		$args    = wp_parse_args(
+			$args, [
+				'skip_missing' => 0,
+				'orderby' => 'id',
+				'order' => 'ASC',
+			]
+		);
 		$orderby = ( isset( $args['orderby'] ) && 'code' == $args['orderby'] ) ? 'slug' : ( isset( $args['orderby'] ) && 'name' == $args['orderby'] ? 'name' : 'id' );
-		$order = ( ! empty( $args['order'] ) && 'desc' == $args['order'] ) ? 'DESC' : 'ASC';
+		$order   = ( ! empty( $args['order'] ) && 'desc' == $args['order'] ) ? 'DESC' : 'ASC';
 
-		$arr = array();
+		$arr = [];
 
 		// NB: When 'skip_missing' is false, WPML returns all languages even if there is no content
-		$languages = PLL()->model->get_languages_list( array( 'hide_empty' => $args['skip_missing'] ) );
+		$languages = PLL()->model->get_languages_list( [ 'hide_empty' => $args['skip_missing'] ] );
 
 		// FIXME: Backward compatibility with WP < 4.7
 		if ( function_exists( 'wp_list_sort' ) ) {
@@ -73,7 +79,7 @@ if ( ! function_exists( 'icl_get_languages' ) ) {
 				continue;
 			}
 
-			$arr[ $lang->slug ] = array(
+			$arr[ $lang->slug ] = [
 				'id'               => $lang->term_id,
 				'active'           => isset( PLL()->curlang->slug ) && PLL()->curlang->slug == $lang->slug ? 1 : 0,
 				'native_name'      => $lang->name,
@@ -84,7 +90,7 @@ if ( ! function_exists( 'icl_get_languages' ) ) {
 				'url'              => ! empty( $url ) ? $url :
 					( empty( $args['link_empty_to'] ) ? PLL()->links->get_home_url( $lang ) :
 					str_replace( '{$lang}', $lang->slug, $args['link_empty_to'] ) ),
-			);
+			];
 		}
 
 		// Apply undocumented WPML filter
@@ -110,7 +116,7 @@ if ( ! function_exists( 'icl_link_to_element' ) ) {
 	 * @param bool   $return_original_if_missing optional, whether to return a value if the translation is missing
 	 * @return string a language dependent link
 	 */
-	function icl_link_to_element( $id, $type = 'post', $text = '', $args = array(), $anchor = '', $echo = true, $return_original_if_missing = true ) {
+	function icl_link_to_element( $id, $type = 'post', $text = '', $args = [], $anchor = '', $echo = true, $return_original_if_missing = true ) {
 		if ( 'tag' == $type ) {
 			$type = 'post_tag';
 		}
@@ -224,14 +230,14 @@ if ( ! function_exists( 'wpml_get_language_information' ) ) {
 		}
 
 		// FIXME WPML may return a WP_Error object
-		return false === ( $lang = PLL()->model->post->get_language( $post_id ) ) ? array() : array(
+		return false === ( $lang = PLL()->model->post->get_language( $post_id ) ) ? [] : [
 			'language_code'      => $lang->slug,
 			'locale'             => $lang->locale,
 			'text_direction'     => (bool) $lang->is_rtl,
 			'display_name'       => $lang->name, // Seems to be the post language name displayed in the current language, not a feature in Polylang
 			'native_name'        => $lang->name,
 			'different_language' => pll_current_language() !== $lang->slug,
-		);
+		];
 	}
 }
 
@@ -325,7 +331,7 @@ if ( ! function_exists( 'wpml_get_copied_fields_for_post_edit' ) ) {
 	 */
 	function wpml_get_copied_fields_for_post_edit() {
 		if ( empty( $_GET['from_post'] ) ) {
-			return array();
+			return [];
 		}
 
 		// Don't know what WPML does but Polylang does copy all public meta keys by default
@@ -337,7 +343,7 @@ if ( ! function_exists( 'wpml_get_copied_fields_for_post_edit' ) ) {
 
 		// Apply our filter and fill the expected output ( see /types/embedded/includes/fields-post.php )
 		/** This filter is documented in modules/sync/admin-sync.php */
-		$arr['fields'] = array_unique( apply_filters( 'pll_copy_post_metas', empty( $keys ) ? array() : $keys, false ) );
+		$arr['fields']           = array_unique( apply_filters( 'pll_copy_post_metas', empty( $keys ) ? [] : $keys, false ) );
 		$arr['original_post_id'] = (int) $_GET['from_post'];
 		return $arr;
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,10 +11,12 @@
 		<exclude name="WordPress.VIP.DirectDatabaseQuery" />
 		<exclude name="WordPress.XSS.EscapeOutput" />
 		<exclude name="WordPress.VIP.AdminBarRemoval" />
+	    <exclude name="WordPress.VIP.SlowDBQuery"/>
 		<exclude name="Squiz.PHP.EmbeddedPhp.NoSemicolon" />
 		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
 		<exclude name="WordPress.PHP.YodaConditions" />
 	    <exclude name="WordPress.PHP.StrictInArray"/>
+	    <exclude name="WordPress.PHP.DevelopmentFunctions"/>
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
@@ -97,6 +99,10 @@
 
 	<rule ref="Generic.Commenting.Fixme.CommentFound" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="Squiz.Commenting.InlineComment.WrongStyle">
+	    <exclude-pattern>include/widget-calendar.php</exclude-pattern>
 	</rule>
 
 	<exclude-pattern>coverage/*</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,9 +2,22 @@
 <ruleset name="Polylang">
 	<description>Coding standards for Polylang</description>
 
+	<rule ref="WordPress-VIP">
+		<exclude name="WordPress.VIP.FileSystemWritesDisallow" />
+		<exclude name="WordPress.VIP.RestrictedFunctions" />
+		<exclude name="WordPress.VIP.RestrictedVariables" />
+		<exclude name="WordPress.VIP.SuperGlobalInputUsage" />
+		<exclude name="WordPress.VIP.ValidatedSanitizedInput" />
+		<exclude name="WordPress.VIP.DirectDatabaseQuery" />
+		<exclude name="WordPress.XSS.EscapeOutput" />
+		<exclude name="WordPress.VIP.AdminBarRemoval" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.NoSemicolon" />
+		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
+		<exclude name="WordPress.PHP.YodaConditions" />
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
 	<rule ref="WordPress-Core">
-		<exclude name="WordPress.WP.PreparedSQL.NotPrepared" /><!-- TEMPORARY -->
-		<exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict" />
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase"/>
 		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores"/>
@@ -88,6 +101,7 @@
 	<exclude-pattern>coverage/*</exclude-pattern>
 	<exclude-pattern>tests/phpunit/includes/speed-trap-listener.php</exclude-pattern>
 	<exclude-pattern>js/*.min.js</exclude-pattern>
+	<exclude-pattern>css/*.min.css</exclude-pattern>
 
 	<!-- Specific to Polylang -->
 	<exclude-pattern>install/plugin-updater.php</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,6 +14,7 @@
 		<exclude name="Squiz.PHP.EmbeddedPhp.NoSemicolon" />
 		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
 		<exclude name="WordPress.PHP.YodaConditions" />
+	    <exclude name="WordPress.PHP.StrictInArray"/>
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
@@ -105,5 +106,4 @@
 
 	<!-- Specific to Polylang -->
 	<exclude-pattern>install/plugin-updater.php</exclude-pattern>
-	<exclude-pattern>include/widget-calendar.php</exclude-pattern>
 </ruleset>

--- a/settings/flags.php
+++ b/settings/flags.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * the key is the flag file name (without the extension)
  * the value is the Country name
  */
-$flags = array(
+$flags = [
 	'ad' => __( 'Andorra', 'polylang' ),
 	'ae' => __( 'United Arab Emirates', 'polylang' ),
 	'af' => __( 'Afghanistan', 'polylang' ),
@@ -261,7 +261,7 @@ $flags = array(
 	'za' => __( 'South Africa', 'polylang' ),
 	'zm' => __( 'Zambia', 'polylang' ),
 	'zw' => __( 'Zimbabwe', 'polylang' ),
-);
+];
 
 /**
  * Filter the list of predefined flags

--- a/settings/languages.php
+++ b/settings/languages.php
@@ -38,64 +38,64 @@ if ( ! defined( 'ABSPATH' ) ) {
  * 'zu_ZA' (Zulu)
  * 'zz_TR' (Zazaki)
  */
-$languages = array(
-	'af' => array(
+$languages = [
+	'af' => [
 		'code'     => 'af',
 		'locale'   => 'af',
 		'name'     => 'Afrikaans',
 		'dir'      => 'ltr',
 		'flag'     => 'za',
 		'facebook' => 'af_ZA',
-	),
-	'ak' => array(
+	],
+	'ak' => [
 		'facebook' => 'ak_GH',
-	),
-	'am' => array(
+	],
+	'am' => [
 		'facebook' => 'am_ET',
-	),
-	'ar' => array(
+	],
+	'ar' => [
 		'code'     => 'ar',
 		'locale'   => 'ar',
 		'name'     => 'العربية',
 		'dir'      => 'rtl',
 		'flag'     => 'arab',
 		'facebook' => 'ar_AR',
-	),
-	'arq' => array(
+	],
+	'arq' => [
 		'facebook' => 'ar_AR',
-	),
-	'ary' => array(
+	],
+	'ary' => [
 		'code'     => 'ar',
 		'locale'   => 'ary',
 		'name'     => 'العربية المغربية',
 		'dir'      => 'rtl',
 		'flag'     => 'ma',
 		'facebook' => 'ar_AR',
-	),
-	'as' => array(
+	],
+	'as' => [
 		'code'     => 'as',
 		'locale'   => 'as',
 		'name'     => 'অসমীয়া',
 		'dir'      => 'ltr',
 		'flag'     => 'in',
 		'facebook' => 'as_IN',
-	),
-	'az' => array(
+	],
+	'az' => [
 		'code'     => 'az',
 		'locale'   => 'az',
 		'name'     => 'Azərbaycan',
 		'dir'      => 'ltr',
 		'flag'     => 'az',
 		'facebook' => 'az_AZ',
-	),
-	'azb' => array(
+	],
+	'azb' => [
 		'code'     => 'az',
 		'locale'   => 'azb',
 		'name'     => 'گؤنئی آذربایجان',
 		'dir'      => 'rtl',
 		'flag'     => 'az',
-	),
-	'bel' => array(
+	],
+	'bel' => [
 		'code'     => 'be',
 		'locale'   => 'bel',
 		'name'     => 'Беларуская мова',
@@ -103,102 +103,102 @@ $languages = array(
 		'flag'     => 'by',
 		'w3c'      => 'be',
 		'facebook' => 'be_BY',
-	),
-	'bg_BG' => array(
+	],
+	'bg_BG' => [
 		'code'     => 'bg',
 		'locale'   => 'bg_BG',
 		'name'     => 'български',
 		'dir'      => 'ltr',
 		'flag'     => 'bg',
 		'facebook' => 'bg_BG',
-	),
-	'bn_BD' => array(
+	],
+	'bn_BD' => [
 		'code'     => 'bn',
 		'locale'   => 'bn_BD',
 		'name'     => 'বাংলা',
 		'dir'      => 'ltr',
 		'flag'     => 'bd',
 		'facebook' => 'bn_IN',
-	),
-	'bo' => array(
+	],
+	'bo' => [
 		'code'     => 'bo',
 		'locale'   => 'bo',
 		'name'     => 'བོད་ཡིག',
 		'dir'      => 'ltr',
 		'flag'     => 'tibet',
-	),
-	'bre' => array(
+	],
+	'bre' => [
 		'w3c'      => 'br',
 		'facebook' => 'br_FR',
-	),
-	'bs_BA' => array(
+	],
+	'bs_BA' => [
 		'code'     => 'bs',
 		'locale'   => 'bs_BA',
 		'name'     => 'Bosanski',
 		'dir'      => 'ltr',
 		'flag'     => 'ba',
 		'facebook' => 'bs_BA',
-	),
-	'ca' => array(
+	],
+	'ca' => [
 		'code'     => 'ca',
 		'locale'   => 'ca',
 		'name'     => 'Català',
 		'dir'      => 'ltr',
 		'flag'     => 'catalonia',
 		'facebook' => 'ca_ES',
-	),
-	'ceb' => array(
+	],
+	'ceb' => [
 		'code'     => 'ceb',
 		'locale'   => 'ceb',
 		'name'     => 'Cebuano',
 		'dir'      => 'ltr',
 		'flag'     => 'ph',
 		'facebook' => 'cx_PH',
-	),
-	'ckb' => array(
+	],
+	'ckb' => [
 		'code'     => 'ku',
 		'locale'   => 'ckb',
 		'name'     => 'کوردی',
 		'dir'      => 'rtl',
 		'flag'     => 'kurdistan',
 		'facebook' => 'cb_IQ',
-	),
-	'co' => array(
+	],
+	'co' => [
 		'facebook' => 'co_FR',
-	),
-	'cs_CZ' => array(
+	],
+	'cs_CZ' => [
 		'code'     => 'cs',
 		'locale'   => 'cs_CZ',
 		'name'     => 'Čeština',
 		'dir'      => 'ltr',
 		'flag'     => 'cz',
 		'facebook' => 'cs_CZ',
-	),
-	'cy' => array(
+	],
+	'cy' => [
 		'code'     => 'cy',
 		'locale'   => 'cy',
 		'name'     => 'Cymraeg',
 		'dir'      => 'ltr',
 		'flag'     => 'wales',
 		'facebook' => 'cy_GB',
-	),
-	'da_DK' => array(
+	],
+	'da_DK' => [
 		'code'     => 'da',
 		'locale'   => 'da_DK',
 		'name'     => 'Dansk',
 		'dir'      => 'ltr',
 		'flag'     => 'dk',
 		'facebook' => 'da_DK',
-	),
-	'de_CH' => array(
+	],
+	'de_CH' => [
 		'code'     => 'de',
 		'locale'   => 'de_CH',
 		'name'     => 'Deutsch',
 		'dir'      => 'ltr',
 		'flag'     => 'ch',
 		'facebook' => 'de_DE',
-	),
-	'de_CH_informal' => array(
+	],
+	'de_CH_informal' => [
 		'code'     => 'de',
 		'locale'   => 'de_CH_informal',
 		'name'     => 'Deutsch',
@@ -206,16 +206,16 @@ $languages = array(
 		'flag'     => 'ch',
 		'w3c'      => 'de-CH',
 		'facebook' => 'de_DE',
-	),
-	'de_DE' => array(
+	],
+	'de_DE' => [
 		'code'     => 'de',
 		'locale'   => 'de_DE',
 		'name'     => 'Deutsch',
 		'dir'      => 'ltr',
 		'flag'     => 'de',
 		'facebook' => 'de_DE',
-	),
-	'de_DE_formal' => array(
+	],
+	'de_DE_formal' => [
 		'code'     => 'de',
 		'locale'   => 'de_DE_formal',
 		'name'     => 'Deutsch',
@@ -223,539 +223,539 @@ $languages = array(
 		'flag'     => 'de',
 		'w3c'      => 'de-DE',
 		'facebook' => 'de_DE',
-	),
-	'dzo' => array(
+	],
+	'dzo' => [
 		'code'     => 'dz',
 		'locale'   => 'dzo',
 		'name'     => 'རྫོང་ཁ',
 		'dir'      => 'ltr',
 		'flag'     => 'bt',
 		'w3c'      => 'dz',
-	),
-	'el' => array(
+	],
+	'el' => [
 		'code'     => 'el',
 		'locale'   => 'el',
 		'name'     => 'Ελληνικά',
 		'dir'      => 'ltr',
 		'flag'     => 'gr',
 		'facebook' => 'el_GR',
-	),
-	'en_AU' => array(
+	],
+	'en_AU' => [
 		'code'     => 'en',
 		'locale'   => 'en_AU',
 		'name'     => 'English',
 		'dir'      => 'ltr',
 		'flag'     => 'au',
 		'facebook' => 'en_US',
-	),
-	'en_CA' => array(
+	],
+	'en_CA' => [
 		'code'     => 'en',
 		'locale'   => 'en_CA',
 		'name'     => 'English',
 		'dir'      => 'ltr',
 		'flag'     => 'ca',
 		'facebook' => 'en_US',
-	),
-	'en_GB' => array(
+	],
+	'en_GB' => [
 		'code'     => 'en',
 		'locale'   => 'en_GB',
 		'name'     => 'English',
 		'dir'      => 'ltr',
 		'flag'     => 'gb',
 		'facebook' => 'en_GB',
-	),
-	'en_NZ' => array(
+	],
+	'en_NZ' => [
 		'code'     => 'en',
 		'locale'   => 'en_NZ',
 		'name'     => 'English',
 		'dir'      => 'ltr',
 		'flag'     => 'nz',
 		'facebook' => 'en_US',
-	),
-	'en_US' => array(
+	],
+	'en_US' => [
 		'code'     => 'en',
 		'locale'   => 'en_US',
 		'name'     => 'English',
 		'dir'      => 'ltr',
 		'flag'     => 'us',
 		'facebook' => 'en_US',
-	),
-	'en_ZA' => array(
+	],
+	'en_ZA' => [
 		'code'     => 'en',
 		'locale'   => 'en_ZA',
 		'name'     => 'English',
 		'dir'      => 'ltr',
 		'flag'     => 'za',
 		'facebook' => 'en_US',
-	),
-	'eo' => array(
+	],
+	'eo' => [
 		'code'     => 'eo',
 		'locale'   => 'eo',
 		'name'     => 'Esperanto',
 		'dir'      => 'ltr',
 		'flag'     => 'esperanto',
 		'facebook' => 'eo_EO',
-	),
-	'es_AR' => array(
+	],
+	'es_AR' => [
 		'code'     => 'es',
 		'locale'   => 'es_AR',
 		'name'     => 'Español',
 		'dir'      => 'ltr',
 		'flag'     => 'ar',
 		'facebook' => 'es_LA',
-	),
-	'es_CL' => array(
+	],
+	'es_CL' => [
 		'code'     => 'es',
 		'locale'   => 'es_CL',
 		'name'     => 'Español',
 		'dir'      => 'ltr',
 		'flag'     => 'cl',
 		'facebook' => 'es_CL',
-	),
-	'es_CO' => array(
+	],
+	'es_CO' => [
 		'code'     => 'es',
 		'locale'   => 'es_CO',
 		'name'     => 'Español',
 		'dir'      => 'ltr',
 		'flag'     => 'co',
 		'facebook' => 'es_CO',
-	),
-	'es_CR' => array(
+	],
+	'es_CR' => [
 		'code'     => 'es',
 		'locale'   => 'es_CR',
 		'name'     => 'Español',
 		'dir'      => 'ltr',
 		'flag'     => 'cr',
 		'facebook' => 'es_LA',
-	),
-	'es_ES' => array(
+	],
+	'es_ES' => [
 		'code'     => 'es',
 		'locale'   => 'es_ES',
 		'name'     => 'Español',
 		'dir'      => 'ltr',
 		'flag'     => 'es',
 		'facebook' => 'es_ES',
-	),
-	'es_GT' => array(
+	],
+	'es_GT' => [
 		'code'     => 'es',
 		'locale'   => 'es_GT',
 		'name'     => 'Español',
 		'dir'      => 'ltr',
 		'flag'     => 'gt',
 		'facebook' => 'es_LA',
-	),
-	'es_MX' => array(
+	],
+	'es_MX' => [
 		'code'     => 'es',
 		'locale'   => 'es_MX',
 		'name'     => 'Español',
 		'dir'      => 'ltr',
 		'flag'     => 'mx',
 		'facebook' => 'es_MX',
-	),
-	'es_PE' => array(
+	],
+	'es_PE' => [
 		'code'     => 'es',
 		'locale'   => 'es_PE',
 		'name'     => 'Español',
 		'dir'      => 'ltr',
 		'flag'     => 'pe',
 		'facebook' => 'es_LA',
-	),
-	'es_VE' => array(
+	],
+	'es_VE' => [
 		'code'     => 'es',
 		'locale'   => 'es_VE',
 		'name'     => 'Español',
 		'dir'      => 'ltr',
 		'flag'     => 've',
 		'facebook' => 'es_VE',
-	),
-	'et' => array(
+	],
+	'et' => [
 		'code'     => 'et',
 		'locale'   => 'et',
 		'name'     => 'Eesti',
 		'dir'      => 'ltr',
 		'flag'     => 'ee',
 		'facebook' => 'et_EE',
-	),
-	'eu' => array(
+	],
+	'eu' => [
 		'code'     => 'eu',
 		'locale'   => 'eu',
 		'name'     => 'Euskara',
 		'dir'      => 'ltr',
 		'flag'     => 'basque',
 		'facebook' => 'eu_ES',
-	),
-	'fa_AF' => array(
+	],
+	'fa_AF' => [
 		'code'     => 'fa',
 		'locale'   => 'fa_AF',
 		'name'     => 'فارسی',
 		'dir'      => 'rtl',
 		'flag'     => 'af',
 		'facebook' => 'fa_IR',
-	),
-	'fa_IR' => array(
+	],
+	'fa_IR' => [
 		'code'     => 'fa',
 		'locale'   => 'fa_IR',
 		'name'     => 'فارسی',
 		'dir'      => 'rtl',
 		'flag'     => 'ir',
 		'facebook' => 'fa_IR',
-	),
-	'fi' => array(
+	],
+	'fi' => [
 		'code'     => 'fi',
 		'locale'   => 'fi',
 		'name'     => 'Suomi',
 		'dir'      => 'ltr',
 		'flag'     => 'fi',
 		'facebook' => 'fi_FI',
-	),
-	'fo' => array(
+	],
+	'fo' => [
 		'code'     => 'fo',
 		'locale'   => 'fo',
 		'name'     => 'Føroyskt',
 		'dir'      => 'ltr',
 		'flag'     => 'fo',
 		'facebook' => 'fo_FO',
-	),
-	'fr_BE' => array(
+	],
+	'fr_BE' => [
 		'code'     => 'fr',
 		'locale'   => 'fr_BE',
 		'name'     => 'Français',
 		'dir'      => 'ltr',
 		'flag'     => 'be',
 		'facebook' => 'fr_FR',
-	),
-	'fr_CA' => array(
+	],
+	'fr_CA' => [
 		'code'     => 'fr',
 		'locale'   => 'fr_CA',
 		'name'     => 'Français',
 		'dir'      => 'ltr',
 		'flag'     => 'quebec',
 		'facebook' => 'fr_CA',
-	),
-	'fr_FR' => array(
+	],
+	'fr_FR' => [
 		'code'     => 'fr',
 		'locale'   => 'fr_FR',
 		'name'     => 'Français',
 		'dir'      => 'ltr',
 		'flag'     => 'fr',
 		'facebook' => 'fr_FR',
-	),
-	'fuc' => array(
+	],
+	'fuc' => [
 		'facebook' => 'ff_NG',
-	),
-	'fur' => array(
+	],
+	'fur' => [
 		'code'     => 'fur',
 		'locale'   => 'fur',
 		'name'     => 'Furlan',
 		'dir'      => 'ltr',
 		'flag'     => 'it',
-	),
-	'fy' => array(
+	],
+	'fy' => [
 		'code'     => 'fy',
 		'locale'   => 'fy',
 		'name'     => 'Frysk',
 		'dir'      => 'ltr',
 		'flag'     => 'nl',
 		'facebook' => 'fy_NL',
-	),
-	'ga' => array(
+	],
+	'ga' => [
 		'facebook' => 'ga_IE',
-	),
-	'gd' => array(
+	],
+	'gd' => [
 		'code'     => 'gd',
 		'locale'   => 'gd',
 		'name'     => 'Gàidhlig',
 		'dir'      => 'ltr',
 		'flag'     => 'scotland',
-	),
-	'gl_ES' => array(
+	],
+	'gl_ES' => [
 		'code'     => 'gl',
 		'locale'   => 'gl_ES',
 		'name'     => 'Galego',
 		'dir'      => 'ltr',
 		'flag'     => 'galicia',
 		'facebook' => 'gl_ES',
-	),
-	'gn' => array(
+	],
+	'gn' => [
 		'facebook' => 'gn_PY',
-	),
-	'gu' => array(
+	],
+	'gu' => [
 		'code'     => 'gu',
 		'locale'   => 'gu',
 		'name'     => 'ગુજરાતી',
 		'dir'      => 'ltr',
 		'flag'     => 'in',
 		'facebook' => 'gu_IN',
-	),
-	'hau' => array(
+	],
+	'hau' => [
 		'facebook' => 'ha_NG',
-	),
-	'haz' => array(
+	],
+	'haz' => [
 		'code'     => 'haz',
 		'locale'   => 'haz',
 		'name'     => 'هزاره گی',
 		'dir'      => 'rtl',
 		'flag'     => 'af',
-	),
-	'he_IL' => array(
+	],
+	'he_IL' => [
 		'code'     => 'he',
 		'locale'   => 'he_IL',
 		'name'     => 'עברית',
 		'dir'      => 'rtl',
 		'flag'     => 'il',
 		'facebook' => 'he_IL',
-	),
-	'hi_IN' => array(
+	],
+	'hi_IN' => [
 		'code'     => 'hi',
 		'locale'   => 'hi_IN',
 		'name'     => 'हिन्दी',
 		'dir'      => 'ltr',
 		'flag'     => 'in',
 		'facebook' => 'hi_IN',
-	),
-	'hr' => array(
+	],
+	'hr' => [
 		'code'     => 'hr',
 		'locale'   => 'hr',
 		'name'     => 'Hrvatski',
 		'dir'      => 'ltr',
 		'flag'     => 'hr',
 		'facebook' => 'hr_HR',
-	),
-	'hu_HU' => array(
+	],
+	'hu_HU' => [
 		'code'     => 'hu',
 		'locale'   => 'hu_HU',
 		'name'     => 'Magyar',
 		'dir'      => 'ltr',
 		'flag'     => 'hu',
 		'facebook' => 'hu_HU',
-	),
-	'hy' => array(
+	],
+	'hy' => [
 		'code'     => 'hy',
 		'locale'   => 'hy',
 		'name'     => 'Հայերեն',
 		'dir'      => 'ltr',
 		'flag'     => 'am',
 		'facebook' => 'hy_AM',
-	),
-	'id_ID' => array(
+	],
+	'id_ID' => [
 		'code'     => 'id',
 		'locale'   => 'id_ID',
 		'name'     => 'Bahasa Indonesia',
 		'dir'      => 'ltr',
 		'flag'     => 'id',
 		'facebook' => 'id_ID',
-	),
-	'ido' => array(
+	],
+	'ido' => [
 		'w3c'      => 'io',
-	),
-	'is_IS' => array(
+	],
+	'is_IS' => [
 		'code'     => 'is',
 		'locale'   => 'is_IS',
 		'name'     => 'Íslenska',
 		'dir'      => 'ltr',
 		'flag'     => 'is',
 		'facebook' => 'is_IS',
-	),
-	'it_IT' => array(
+	],
+	'it_IT' => [
 		'code'     => 'it',
 		'locale'   => 'it_IT',
 		'name'     => 'Italiano',
 		'dir'      => 'ltr',
 		'flag'     => 'it',
 		'facebook' => 'it_IT',
-	),
-	'ja' => array(
+	],
+	'ja' => [
 		'code'     => 'ja',
 		'locale'   => 'ja',
 		'name'     => '日本語',
 		'dir'      => 'ltr',
 		'flag'     => 'jp',
 		'facebook' => 'ja_JP',
-	),
-	'jv_ID' => array(
+	],
+	'jv_ID' => [
 		'code'     => 'jv',
 		'locale'   => 'jv_ID',
 		'name'     => 'Basa Jawa',
 		'dir'      => 'ltr',
 		'flag'     => 'id',
 		'facebook' => 'jv_ID',
-	),
-	'ka_GE' => array(
+	],
+	'ka_GE' => [
 		'code'     => 'ka',
 		'locale'   => 'ka_GE',
 		'name'     => 'ქართული',
 		'dir'      => 'ltr',
 		'flag'     => 'ge',
 		'facebook' => 'ka_GE',
-	),
-	'kab' => array(
+	],
+	'kab' => [
 		'code'     => 'kab',
 		'locale'   => 'kab',
 		'name'     => 'Taqbaylit',
 		'dir'      => 'ltr',
 		'flag'     => 'dz',
-	),
-	'kin' => array(
+	],
+	'kin' => [
 		'w3c'      => 'rw',
 		'facebook' => 'rw_RW',
-	),
-	'kk' => array(
+	],
+	'kk' => [
 		'code'     => 'kk',
 		'locale'   => 'kk',
 		'name'     => 'Қазақ тілі',
 		'dir'      => 'ltr',
 		'flag'     => 'kz',
 		'facebook' => 'kk_KZ',
-	),
-	'km' => array(
+	],
+	'km' => [
 		'code'     => 'km',
 		'locale'   => 'km',
 		'name'     => 'ភាសាខ្មែរ',
 		'dir'      => 'ltr',
 		'flag'     => 'kh',
 		'facebook' => 'km_KH',
-	),
-	'kn' => array(
+	],
+	'kn' => [
 		'facebook' => 'kn_IN',
-	),
-	'ko_KR' => array(
+	],
+	'ko_KR' => [
 		'code'     => 'ko',
 		'locale'   => 'ko_KR',
 		'name'     => '한국어',
 		'dir'      => 'ltr',
 		'flag'     => 'kr',
 		'facebook' => 'ko_KR',
-	),
-	'ku' => array(
+	],
+	'ku' => [
 		'facebook' => 'ku_TR',
-	),
-	'ky_KY' => array(
+	],
+	'ky_KY' => [
 		'facebook' => 'ky_KG',
-	),
-	'la' => array(
+	],
+	'la' => [
 		'facebook' => 'la_VA',
-	),
-	'li' => array(
+	],
+	'li' => [
 		'facebook' => 'li_NL',
-	),
-	'lin' => array(
+	],
+	'lin' => [
 		'facebook' => 'ln_CD',
-	),
-	'lo' => array(
+	],
+	'lo' => [
 		'code'     => 'lo',
 		'locale'   => 'lo',
 		'name'     => 'ພາສາລາວ',
 		'dir'      => 'ltr',
 		'flag'     => 'la',
 		'facebook' => 'lo_LA',
-	),
-	'lt_LT' => array(
+	],
+	'lt_LT' => [
 		'code'     => 'lt',
 		'locale'   => 'lt_LT',
 		'name'     => 'Lietuviškai',
 		'dir'      => 'ltr',
 		'flag'     => 'lt',
 		'facebook' => 'lt_LT',
-	),
-	'lv' => array(
+	],
+	'lv' => [
 		'code'     => 'lv',
 		'locale'   => 'lv',
 		'name'     => 'Latviešu valoda',
 		'dir'      => 'ltr',
 		'flag'     => 'lv',
 		'facebook' => 'lv_LV',
-	),
-	'mg_MG' => array(
+	],
+	'mg_MG' => [
 		'facebook' => 'mg_MG',
-	),
-	'mk_MK' => array(
+	],
+	'mk_MK' => [
 		'code'     => 'mk',
 		'locale'   => 'mk_MK',
 		'name'     => 'македонски јазик',
 		'dir'      => 'ltr',
 		'flag'     => 'mk',
 		'facebook' => 'mk_MK',
-	),
-	'ml_IN' => array(
+	],
+	'ml_IN' => [
 		'code'     => 'ml',
 		'locale'   => 'ml_IN',
 		'name'     => 'മലയാളം',
 		'dir'      => 'ltr',
 		'flag'     => 'in',
 		'facebook' => 'ml_IN',
-	),
-	'mlt' => array(
+	],
+	'mlt' => [
 		'facebook' => 'mt_MT',
-	),
-	'mn' => array(
+	],
+	'mn' => [
 		'code'     => 'mn',
 		'locale'   => 'mn',
 		'name'     => 'Монгол хэл',
 		'dir'      => 'ltr',
 		'flag'     => 'mn',
 		'facebook' => 'mn_MN',
-	),
-	'mr' => array(
+	],
+	'mr' => [
 		'code'     => 'mr',
 		'locale'   => 'mr',
 		'name'     => 'मराठी',
 		'dir'      => 'ltr',
 		'flag'     => 'in',
 		'facebook' => 'mr_IN',
-	),
-	'mri' => array(
+	],
+	'mri' => [
 		'w3c'      => 'mi',
 		'facebook' => 'mi_NZ',
-	),
-	'ms_MY' => array(
+	],
+	'ms_MY' => [
 		'code'     => 'ms',
 		'locale'   => 'ms_MY',
 		'name'     => 'Bahasa Melayu',
 		'dir'      => 'ltr',
 		'flag'     => 'my',
 		'facebook' => 'ms_MY',
-	),
-	'my_MM' => array(
+	],
+	'my_MM' => [
 		'code'     => 'my',
 		'locale'   => 'my_MM',
 		'name'     => 'ဗမာစာ',
 		'dir'      => 'ltr',
 		'flag'     => 'mm',
 		'facebook' => 'my_MM',
-	),
-	'nb_NO' => array(
+	],
+	'nb_NO' => [
 		'code'     => 'nb',
 		'locale'   => 'nb_NO',
 		'name'     => 'Norsk Bokmål',
 		'dir'      => 'ltr',
 		'flag'     => 'no',
 		'facebook' => 'nb_NO',
-	),
-	'ne_NP' => array(
+	],
+	'ne_NP' => [
 		'code'     => 'ne',
 		'locale'   => 'ne_NP',
 		'name'     => 'नेपाली',
 		'dir'      => 'ltr',
 		'flag'     => 'np',
 		'facebook' => 'ne_NP',
-	),
-	'nl_BE' => array(
+	],
+	'nl_BE' => [
 		'code'     => 'nl',
 		'locale'   => 'nl_BE',
 		'name'     => 'Nederlands',
 		'dir'      => 'ltr',
 		'flag'     => 'be',
 		'facebook' => 'nl_BE',
-	),
-	'nl_NL' => array(
+	],
+	'nl_NL' => [
 		'code'     => 'nl',
 		'locale'   => 'nl_NL',
 		'name'     => 'Nederlands',
 		'dir'      => 'ltr',
 		'flag'     => 'nl',
 		'facebook' => 'nl_NL',
-	),
-	'nl_NL_formal' => array(
+	],
+	'nl_NL_formal' => [
 		'code'     => 'nl',
 		'locale'   => 'nl_NL_formal',
 		'name'     => 'Nederlands',
@@ -763,342 +763,342 @@ $languages = array(
 		'flag'     => 'nl',
 		'w3c'      => 'nl-NL',
 		'facebook' => 'nl_NL',
-	),
-	'nn_NO' => array(
+	],
+	'nn_NO' => [
 		'code'     => 'nn',
 		'locale'   => 'nn_NO',
 		'name'     => 'Norsk Nynorsk',
 		'dir'      => 'ltr',
 		'flag'     => 'no',
 		'facebook' => 'nn_NO',
-	),
-	'oci' => array(
+	],
+	'oci' => [
 		'code'     => 'oc',
 		'locale'   => 'oci',
 		'name'     => 'Occitan',
 		'dir'      => 'ltr',
 		'flag'     => 'occitania',
 		'w3c'      => 'oc',
-	),
-	'ory' => array(
+	],
+	'ory' => [
 		'facebook' => 'or_IN',
-	),
-	'pa_IN' => array(
+	],
+	'pa_IN' => [
 		'code'     => 'pa',
 		'locale'   => 'pa_IN',
 		'name'     => 'ਪੰਜਾਬੀ',
 		'dir'      => 'ltr',
 		'flag'     => 'in',
 		'facebook' => 'pa_IN',
-	),
-	'pl_PL' => array(
+	],
+	'pl_PL' => [
 		'code'     => 'pl',
 		'locale'   => 'pl_PL',
 		'name'     => 'Polski',
 		'dir'      => 'ltr',
 		'flag'     => 'pl',
 		'facebook' => 'pl_PL',
-	),
-	'ps' => array(
+	],
+	'ps' => [
 		'code'     => 'ps',
 		'locale'   => 'ps',
 		'name'     => 'پښتو',
 		'dir'      => 'rtl',
 		'flag'     => 'af',
 		'facebook' => 'ps_AF',
-	),
-	'pt_BR' => array(
+	],
+	'pt_BR' => [
 		'code'     => 'pt',
 		'locale'   => 'pt_BR',
 		'name'     => 'Português',
 		'dir'      => 'ltr',
 		'flag'     => 'br',
 		'facebook' => 'pt_BR',
-	),
-	'pt_PT' => array(
+	],
+	'pt_PT' => [
 		'code'     => 'pt',
 		'locale'   => 'pt_PT',
 		'name'     => 'Português',
 		'dir'      => 'ltr',
 		'flag'     => 'pt',
 		'facebook' => 'pt_PT',
-	),
-	'pt_PT_ao90' => array(
+	],
+	'pt_PT_ao90' => [
 		'code'     => 'pt',
 		'locale'   => 'pt_PT_ao90',
 		'name'     => 'Português',
 		'dir'      => 'ltr',
 		'flag'     => 'pt',
 		'facebook' => 'pt_PT',
-	),
-	'rhg' => array(
+	],
+	'rhg' => [
 		'code'     => 'rhg',
 		'locale'   => 'rhg',
 		'name'     => 'Ruáinga',
 		'dir'      => 'ltr',
 		'flag'     => 'mm',
-	),
-	'ro_RO' => array(
+	],
+	'ro_RO' => [
 		'code'     => 'ro',
 		'locale'   => 'ro_RO',
 		'name'     => 'Română',
 		'dir'      => 'ltr',
 		'flag'     => 'ro',
 		'facebook' => 'ro_RO',
-	),
-	'roh' => array(
+	],
+	'roh' => [
 		'w3c'      => 'rm',
 		'facebook' => 'rm_CH',
-	),
-	'ru_RU' => array(
+	],
+	'ru_RU' => [
 		'code'     => 'ru',
 		'locale'   => 'ru_RU',
 		'name'     => 'Русский',
 		'dir'      => 'ltr',
 		'flag'     => 'ru',
 		'facebook' => 'ru_RU',
-	),
-	'sa_IN' => array(
+	],
+	'sa_IN' => [
 		'facebook' => 'sa_IN',
-	),
-	'sah' => array(
+	],
+	'sah' => [
 		'code'     => 'sah',
 		'locale'   => 'sah',
 		'name'     => 'Сахалыы',
 		'dir'      => 'ltr',
 		'flag'     => 'ru',
-	),
-	'si_LK' => array(
+	],
+	'si_LK' => [
 		'code'     => 'si',
 		'locale'   => 'si_LK',
 		'name'     => 'සිංහල',
 		'dir'      => 'ltr',
 		'flag'     => 'lk',
 		'facebook' => 'si_LK',
-	),
-	'sk_SK' => array(
+	],
+	'sk_SK' => [
 		'code'     => 'sk',
 		'locale'   => 'sk_SK',
 		'name'     => 'Slovenčina',
 		'dir'      => 'ltr',
 		'flag'     => 'sk',
 		'facebook' => 'sk_SK',
-	),
-	'sl_SI' => array(
+	],
+	'sl_SI' => [
 		'code'     => 'sl',
 		'locale'   => 'sl_SI',
 		'name'     => 'Slovenščina',
 		'dir'      => 'ltr',
 		'flag'     => 'si',
 		'facebook' => 'sl_SI',
-	),
-	'sna' => array(
+	],
+	'sna' => [
 		'facebook' => 'sn_ZW',
-	),
-	'so_SO' => array(
+	],
+	'so_SO' => [
 		'code'     => 'so',
 		'locale'   => 'so_SO',
 		'name'     => 'Af-Soomaali',
 		'dir'      => 'ltr',
 		'flag'     => 'so',
 		'facebook' => 'so_SO',
-	),
-	'sq' => array(
+	],
+	'sq' => [
 		'code'     => 'sq',
 		'locale'   => 'sq',
 		'name'     => 'Shqip',
 		'dir'      => 'ltr',
 		'flag'     => 'al',
 		'facebook' => 'sq_AL',
-	),
-	'sr_RS' => array(
+	],
+	'sr_RS' => [
 		'code'     => 'sr',
 		'locale'   => 'sr_RS',
 		'name'     => 'Српски језик',
 		'dir'      => 'ltr',
 		'flag'     => 'rs',
 		'facebook' => 'sr_RS',
-	),
-	'srd' => array(
+	],
+	'srd' => [
 		'w3c'      => 'sc',
 		'facebook' => 'sc_IT',
-	),
-	'su_ID' => array(
+	],
+	'su_ID' => [
 		'code'     => 'su',
 		'locale'   => 'su_ID',
 		'name'     => 'Basa Sunda',
 		'dir'      => 'ltr',
 		'flag'     => 'id',
-	),
-	'sv_SE' => array(
+	],
+	'sv_SE' => [
 		'code'     => 'sv',
 		'locale'   => 'sv_SE',
 		'name'     => 'Svenska',
 		'dir'      => 'ltr',
 		'flag'     => 'se',
 		'facebook' => 'sv_SE',
-	),
-	'sw' => array(
+	],
+	'sw' => [
 		'facebook' => 'sw_KE',
-	),
-	'syr' => array(
+	],
+	'syr' => [
 		'facebook' => 'sy_SY',
-	),
-	'szl' => array(
+	],
+	'szl' => [
 		'code'     => 'szl',
 		'locale'   => 'szl',
 		'name'     => 'Ślōnskŏ gŏdka',
 		'dir'      => 'ltr',
 		'flag'     => 'pl',
 		'facebook' => 'sz_PL',
-	),
-	'ta_IN' => array(
+	],
+	'ta_IN' => [
 		'code'     => 'ta',
 		'locale'   => 'ta_IN',
 		'name'     => 'தமிழ்',
 		'dir'      => 'ltr',
 		'flag'     => 'in',
 		'facebook' => 'ta_IN',
-	),
-	'ta_LK' => array(
+	],
+	'ta_LK' => [
 		'code'     => 'ta',
 		'locale'   => 'ta_LK',
 		'name'     => 'தமிழ்',
 		'dir'      => 'ltr',
 		'flag'     => 'lk',
 		'facebook' => 'ta_IN',
-	),
-	'tah' => array(
+	],
+	'tah' => [
 		'code'     => 'ty',
 		'locale'   => 'tah',
 		'name'     => 'Reo Tahiti',
 		'dir'      => 'ltr',
 		'flag'     => 'pf',
-	),
-	'te' => array(
+	],
+	'te' => [
 		'code'     => 'te',
 		'locale'   => 'te',
 		'name'     => 'తెలుగు',
 		'dir'      => 'ltr',
 		'flag'     => 'in',
 		'facebook' => 'te_IN',
-	),
-	'tg' => array(
+	],
+	'tg' => [
 		'facebook' => 'tg_TJ',
-	),
-	'th' => array(
+	],
+	'th' => [
 		'code'     => 'th',
 		'locale'   => 'th',
 		'name'     => 'ไทย',
 		'dir'      => 'ltr',
 		'flag'     => 'th',
 		'facebook' => 'th_TH',
-	),
-	'tl' => array(
+	],
+	'tl' => [
 		'code'     => 'tl',
 		'locale'   => 'tl',
 		'name'     => 'Tagalog',
 		'dir'      => 'ltr',
 		'flag'     => 'ph',
 		'facebook' => 'tl_PH',
-	),
-	'tr_TR' => array(
+	],
+	'tr_TR' => [
 		'code'     => 'tr',
 		'locale'   => 'tr_TR',
 		'name'     => 'Türkçe',
 		'dir'      => 'ltr',
 		'flag'     => 'tr',
 		'facebook' => 'tr_TR',
-	),
-	'tt_RU' => array(
+	],
+	'tt_RU' => [
 		'code'     => 'tt',
 		'locale'   => 'tt_RU',
 		'name'     => 'Татар теле',
 		'dir'      => 'ltr',
 		'flag'     => 'ru',
 		'facebook' => 'tt_RU',
-	),
-	'tuk' => array(
+	],
+	'tuk' => [
 		'w3c'      => 'tk',
 		'facebook' => 'tk_TM',
-	),
-	'tzm' => array(
+	],
+	'tzm' => [
 		'facebook' => 'tz_MA',
-	),
-	'ug_CN' => array(
+	],
+	'ug_CN' => [
 		'code'     => 'ug',
 		'locale'   => 'ug_CN',
 		'name'     => 'Uyƣurqə',
 		'dir'      => 'ltr',
 		'flag'     => 'cn',
-	),
-	'uk' => array(
+	],
+	'uk' => [
 		'code'     => 'uk',
 		'locale'   => 'uk',
 		'name'     => 'Українська',
 		'dir'      => 'ltr',
 		'flag'     => 'ua',
 		'facebook' => 'uk_UA',
-	),
-	'ur' => array(
+	],
+	'ur' => [
 		'code'     => 'ur',
 		'locale'   => 'ur',
 		'name'     => 'اردو',
 		'dir'      => 'rtl',
 		'flag'     => 'pk',
 		'facebook' => 'ur_PK',
-	),
-	'uz_UZ' => array(
+	],
+	'uz_UZ' => [
 		'code'     => 'uz',
 		'locale'   => 'uz_UZ',
 		'name'     => 'Oʻzbek',
 		'dir'      => 'ltr',
 		'flag'     => 'uz',
 		'facebook' => 'uz_UZ',
-	),
-	'vec' => array(
+	],
+	'vec' => [
 		'code'     => 'vec',
 		'locale'   => 'vec',
 		'name'     => 'Vèneto',
 		'dir'      => 'ltr',
 		'flag'     => 'veneto',
-	),
-	'vi' => array(
+	],
+	'vi' => [
 		'code'     => 'vi',
 		'locale'   => 'vi',
 		'name'     => 'Tiếng Việt',
 		'dir'      => 'ltr',
 		'flag'     => 'vn',
 		'facebook' => 'vi_VN',
-	),
-	'xho' => array(
+	],
+	'xho' => [
 		'facebook' => 'xh_ZA',
-	),
-	'yor' => array(
+	],
+	'yor' => [
 		'facebook' => 'yo_NG',
-	),
-	'zh_CN' => array(
+	],
+	'zh_CN' => [
 		'code'     => 'zh',
 		'locale'   => 'zh_CN',
 		'name'     => '中文 (中国)',
 		'dir'      => 'ltr',
 		'flag'     => 'cn',
 		'facebook' => 'zh_CN',
-	),
-	'zh_HK' => array(
+	],
+	'zh_HK' => [
 		'code'     => 'zh',
 		'locale'   => 'zh_HK',
 		'name'     => '中文 (香港)',
 		'dir'      => 'ltr',
 		'flag'     => 'hk',
 		'facebook' => 'zh_HK',
-	),
-	'zh_TW' => array(
+	],
+	'zh_TW' => [
 		'code'     => 'zh',
 		'locale'   => 'zh_TW',
 		'name'     => '中文 (台灣)',
 		'dir'      => 'ltr',
 		'flag'     => 'tw',
 		'facebook' => 'zh_TW',
-	),
-);
+	],
+];

--- a/settings/settings-browser.php
+++ b/settings/settings-browser.php
@@ -15,15 +15,17 @@ class PLL_Settings_Browser extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'        => 'browser',
-			'title'         => __( 'Detect browser language', 'polylang' ),
-			'description'   => __( 'When the front page is visited, set the language according to the browser preference', 'polylang' ),
-			'active_option' => $this->is_available() ? 'browser' : false,
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'        => 'browser',
+				'title'         => __( 'Detect browser language', 'polylang' ),
+				'description'   => __( 'When the front page is visited, set the language according to the browser preference', 'polylang' ),
+				'active_option' => $this->is_available() ? 'browser' : false,
+			]
+		);
 
 		if ( ! class_exists( 'PLL_Xdata_Domain', true ) ) {
-			add_action( 'admin_print_footer_scripts', array( $this, 'print_js' ) );
+			add_action( 'admin_print_footer_scripts', [ $this, 'print_js' ] );
 		}
 	}
 
@@ -61,8 +63,7 @@ class PLL_Settings_Browser extends PLL_Settings_Module {
 		if ( parent::is_active() && 3 > $this->options['force_lang'] ) {
 			$func = 'removeClass( "inactive" ).addClass( "active" )';
 			$link = sprintf( '<span class="deactivate">%s</span>', $this->action_links['deactivate'] );
-		}
-		else {
+		} else {
 			$func = 'removeClass( "active" ).addClass( "inactive" )';
 			$link = sprintf( '<span class="activate">%s</span>', $this->action_links['activate'] );
 		}

--- a/settings/settings-cpt.php
+++ b/settings/settings-cpt.php
@@ -76,11 +76,11 @@ class PLL_Settings_CPT extends PLL_Settings_Module {
 				foreach ( $this->post_types as $post_type ) {
 					$pt = get_post_type_object( $post_type );
 					if ( ! empty( $pt ) ) {
-						$disabled = in_array( $post_type, $this->disabled_post_types );
+						$disabled = in_array( $post_type, $this->disabled_post_types, true );
 						printf(
 							'<li><label><input name="post_types[%s]" type="checkbox" value="1" %s %s/> %s</label></li>',
 							esc_attr( $post_type ),
-							in_array( $post_type, $this->options['post_types'] ) || $disabled ? 'checked="checked"' : '',
+							in_array( $post_type, $this->options['post_types'], true ) || $disabled ? 'checked="checked"' : '',
 							$disabled ? 'disabled="disabled"' : '',
 							esc_html( $pt->labels->name )
 						);
@@ -100,11 +100,11 @@ class PLL_Settings_CPT extends PLL_Settings_Module {
 				foreach ( $this->taxonomies as $taxonomy ) {
 					$tax = get_taxonomy( $taxonomy );
 					if ( ! empty( $tax ) ) {
-						$disabled = in_array( $taxonomy, $this->disabled_taxonomies );
+						$disabled = in_array( $taxonomy, $this->disabled_taxonomies, true );
 						printf(
 							'<li><label><input name="taxonomies[%s]" type="checkbox" value="1" %s %s/> %s</label></li>',
 							esc_attr( $taxonomy ),
-							in_array( $taxonomy, $this->options['taxonomies'] ) || $disabled ? 'checked="checked"' : '',
+							in_array( $taxonomy, $this->options['taxonomies'], true ) || $disabled ? 'checked="checked"' : '',
 							$disabled ? 'disabled="disabled"' : '',
 							esc_html( $tax->labels->name )
 						);

--- a/settings/settings-cpt.php
+++ b/settings/settings-cpt.php
@@ -16,26 +16,38 @@ class PLL_Settings_CPT extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'      => 'cpt',
-			'title'       => __( 'Custom post types and Taxonomies', 'polylang' ),
-			'description' => __( 'Activate the languages and translations management for the custom post types and taxonomies.', 'polylang' ),
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'      => 'cpt',
+				'title'       => __( 'Custom post types and Taxonomies', 'polylang' ),
+				'description' => __( 'Activate the languages and translations management for the custom post types and taxonomies.', 'polylang' ),
+			]
+		);
 
-		$public_post_types = get_post_types( array( 'public' => true, '_builtin' => false ) );
+		$public_post_types = get_post_types(
+			[
+				'public' => true,
+				'_builtin' => false,
+			]
+		);
 		/** This filter is documented in include/model.php */
 		$this->post_types = array_unique( apply_filters( 'pll_get_post_types', $public_post_types, true ) );
 
-		$programmatically_active_post_types = array_unique( apply_filters( 'pll_get_post_types', array(), false ) );
+		$programmatically_active_post_types = array_unique( apply_filters( 'pll_get_post_types', [], false ) );
 		/** This filter is documented in include/model.php */
 		$this->disabled_post_types = array_intersect( $programmatically_active_post_types, $this->post_types );
 
-		$public_taxonomies = get_taxonomies( array( 'public' => true, '_builtin' => false ) );
-		$public_taxonomies = array_diff( $public_taxonomies, get_taxonomies( array( '_pll' => true ) ) );
+		$public_taxonomies = get_taxonomies(
+			[
+				'public' => true,
+				'_builtin' => false,
+			]
+		);
+		$public_taxonomies = array_diff( $public_taxonomies, get_taxonomies( [ '_pll' => true ] ) );
 		/** This filter is documented in include/model.php */
 		$this->taxonomies = array_unique( apply_filters( 'pll_get_taxonomies', $public_taxonomies, true ) );
 
-		$programmatically_active_taxonomies = array_unique( apply_filters( 'pll_get_taxonomies', array(), false ) );
+		$programmatically_active_taxonomies = array_unique( apply_filters( 'pll_get_taxonomies', [], false ) );
 		/** This filter is documented in include/model.php */
 		$this->disabled_taxonomies = array_intersect( $programmatically_active_taxonomies, $this->taxonomies );
 	}
@@ -113,8 +125,8 @@ class PLL_Settings_CPT extends PLL_Settings_Module {
 	 * @param array $options
 	 */
 	protected function update( $options ) {
-		foreach ( array( 'post_types', 'taxonomies' ) as $key ) {
-			$newoptions[ $key ] = empty( $options[ $key ] ) ? array() : array_keys( $options[ $key ], 1 );
+		foreach ( [ 'post_types', 'taxonomies' ] as $key ) {
+			$newoptions[ $key ] = empty( $options[ $key ] ) ? [] : array_keys( $options[ $key ], 1 );
 		}
 		return $newoptions; // Take care to return only validated options
 	}

--- a/settings/settings-licenses.php
+++ b/settings/settings-licenses.php
@@ -16,17 +16,19 @@ class PLL_Settings_Licenses extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'        => 'licenses',
-			'title'         => __( 'License keys', 'polylang' ),
-			'description'   => __( 'Manage licenses for Polylang Pro or addons.', 'polylang' ),
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'        => 'licenses',
+				'title'         => __( 'License keys', 'polylang' ),
+				'description'   => __( 'Manage licenses for Polylang Pro or addons.', 'polylang' ),
+			]
+		);
 
 		$this->buttons['cancel'] = sprintf( '<button type="button" class="button button-secondary cancel">%s</button>', __( 'Close' ) );
 
-		$this->items = apply_filters( 'pll_settings_licenses', array() );
+		$this->items = apply_filters( 'pll_settings_licenses', [] );
 
-		add_action( 'wp_ajax_pll_deactivate_license', array( $this, 'deactivate_license' ) );
+		add_action( 'wp_ajax_pll_deactivate_license', [ $this, 'deactivate_license' ] );
 	}
 
 	/**
@@ -80,13 +82,13 @@ class PLL_Settings_Licenses extends PLL_Settings_Module {
 		);
 
 		if ( ! empty( $license ) && is_object( $license ) ) {
-			$now = current_time( 'timestamp' );
+			$now        = current_time( 'timestamp' );
 			$expiration = strtotime( $license->expires, $now );
 
 			// Special case: the license expired after the last check
 			if ( $license->success && $expiration < $now ) {
 				$license->success = false;
-				$license->error = 'expired';
+				$license->error   = 'expired';
 			}
 
 			if ( false === $license->success ) {
@@ -145,7 +147,7 @@ class PLL_Settings_Licenses extends PLL_Settings_Module {
 				if ( 'lifetime' === $license->expires ) {
 					$message = __( 'The license key never expires.', 'polylang' );
 				} elseif ( $expiration > $now && $expiration - $now < ( DAY_IN_SECONDS * 30 ) ) {
-					$class = 'notice-warning notice-alt';
+					$class   = 'notice-warning notice-alt';
 					$message = sprintf(
 						/* translators: %1$s is a date, %2$s is link start tag, %3$s is link end tag. */
 						__( 'Your license key expires soon! It expires on %1$s. %2$sRenew your license key%3$s.', 'polylang' ),
@@ -186,14 +188,25 @@ class PLL_Settings_Licenses extends PLL_Settings_Module {
 			$x = new WP_Ajax_Response();
 			foreach ( $this->items as $item ) {
 				$updated_item = $item->activate_license( sanitize_text_field( $_POST['licenses'][ $item->id ] ) );
-				$x->Add( array( 'what' => 'license-update', 'data' => $item->id, 'supplemental' => array( 'html' => $this->get_row( $updated_item ) ) ) );
+				$x->Add(
+					[
+						'what' => 'license-update',
+						'data' => $item->id,
+						'supplemental' => [ 'html' => $this->get_row( $updated_item ) ],
+					]
+				);
 			}
 
 			// Updated message
 			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'updated' );
 			ob_start();
 			settings_errors();
-			$x->Add( array( 'what' => 'success', 'data' => ob_get_clean() ) );
+			$x->Add(
+				[
+					'what' => 'success',
+					'data' => ob_get_clean(),
+				]
+			);
 			$x->send();
 		}
 	}
@@ -211,9 +224,11 @@ class PLL_Settings_Licenses extends PLL_Settings_Module {
 		}
 
 		$id = sanitize_text_field( substr( $_POST['id'], 11 ) );
-		wp_send_json( array(
-			'id' => $id,
-			'html' => $this->get_row( $this->items[ $id ]->deactivate_license() ),
-		) );
+		wp_send_json(
+			[
+				'id' => $id,
+				'html' => $this->get_row( $this->items[ $id ]->deactivate_license() ),
+			]
+		);
 	}
 }

--- a/settings/settings-media.php
+++ b/settings/settings-media.php
@@ -15,11 +15,13 @@ class PLL_Settings_Media extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'        => 'media',
-			'title'         => __( 'Media' ),
-			'description'   => __( 'Activate languages and translations for media', 'polylang' ),
-			'active_option' => 'media_support',
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'        => 'media',
+				'title'         => __( 'Media' ),
+				'description'   => __( 'Activate languages and translations for media', 'polylang' ),
+				'active_option' => 'media_support',
+			]
+		);
 	}
 }

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -158,7 +158,7 @@ class PLL_Settings_Module {
 			wp_die( -1 );
 		}
 
-		if ( $this->module == $_POST['module'] ) {
+		if ( $this->module === $_POST['module'] ) {
 			// It's up to the child class to decide which options are saved, whether there are errors or not
 			$post          = array_diff_key( $_POST, array_flip( [ 'action', 'module', 'pll_ajax_backend', '_pll_nonce' ] ) );
 			$options       = $this->update( $post );

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -20,22 +20,24 @@ class PLL_Settings_Module {
 	 * @param array  $args
 	 */
 	public function __construct( &$polylang, $args ) {
-		$this->options = &$polylang->options;
-		$this->model = &$polylang->model;
+		$this->options     = &$polylang->options;
+		$this->model       = &$polylang->model;
 		$this->links_model = &$polylang->links_model;
 
-		$args = wp_parse_args( $args, array(
-			'title' => '',
-			'description' => '',
-			'active_option' => false,
-		) );
+		$args = wp_parse_args(
+			$args, [
+				'title' => '',
+				'description' => '',
+				'active_option' => false,
+			]
+		);
 
 		foreach ( $args as $prop => $value ) {
 			$this->$prop = $value;
 		}
 
 		// All possible action links, even if not always a link ;-)
-		$this->action_links = array(
+		$this->action_links = [
 			'configure' => sprintf(
 				'<a title="%s" href="%s">%s</a>',
 				esc_attr__( 'Configure this module', 'polylang' ),
@@ -60,15 +62,15 @@ class PLL_Settings_Module {
 			'activated' => esc_html__( 'Activated', 'polylang' ),
 
 			'deactivated' => esc_html__( 'Deactivated', 'polylang' ),
-		);
+		];
 
-		$this->buttons = array(
+		$this->buttons = [
 			'cancel' => sprintf( '<button type="button" class="button button-secondary cancel">%s</button>', esc_html__( 'Cancel' ) ),
 			'save'   => sprintf( '<button type="button" class="button button-primary save">%s</button>', esc_html__( 'Save Changes' ) ),
-		);
+		];
 
 		// Ajax action to save options
-		add_action( 'wp_ajax_pll_save_options', array( $this, 'save_options' ) );
+		add_action( 'wp_ajax_pll_save_options', [ $this, 'save_options' ] );
 	}
 
 	/**
@@ -142,7 +144,7 @@ class PLL_Settings_Module {
 	 * @return array Options
 	 */
 	protected function update( $options ) {
-		return array(); // It's responsibility of the child class to decide what is saved
+		return []; // It's responsibility of the child class to decide what is saved
 	}
 
 	/**
@@ -158,8 +160,8 @@ class PLL_Settings_Module {
 
 		if ( $this->module == $_POST['module'] ) {
 			// It's up to the child class to decide which options are saved, whether there are errors or not
-			$post = array_diff_key( $_POST, array_flip( array( 'action', 'module', 'pll_ajax_backend', '_pll_nonce' ) ) );
-			$options = $this->update( $post );
+			$post          = array_diff_key( $_POST, array_flip( [ 'action', 'module', 'pll_ajax_backend', '_pll_nonce' ] ) );
+			$options       = $this->update( $post );
 			$this->options = array_merge( $this->options, $options );
 			update_option( 'polylang', $this->options );
 
@@ -176,12 +178,22 @@ class PLL_Settings_Module {
 				// Send update message
 				add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'updated' );
 				settings_errors();
-				$x = new WP_Ajax_Response( array( 'what' => 'success', 'data' => ob_get_clean() ) );
+				$x = new WP_Ajax_Response(
+					[
+						'what' => 'success',
+						'data' => ob_get_clean(),
+					]
+				);
 				$x->send();
 			} else {
 				// Send error messages
 				settings_errors();
-				$x = new WP_Ajax_Response( array( 'what' => 'error', 'data' => ob_get_clean() ) );
+				$x = new WP_Ajax_Response(
+					[
+						'what' => 'error',
+						'data' => ob_get_clean(),
+					]
+				);
 				$x->send();
 			}
 		}

--- a/settings/settings-tools.php
+++ b/settings/settings-tools.php
@@ -15,11 +15,13 @@ class PLL_Settings_Tools extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'        => 'tools',
-			'title'         => __( 'Tools', 'polylang' ),
-			'description'   => __( 'Decide whether to remove all data when deleting Polylang.', 'polylang' ),
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'        => 'tools',
+				'title'         => __( 'Tools', 'polylang' ),
+				'description'   => __( 'Decide whether to remove all data when deleting Polylang.', 'polylang' ),
+			]
+		);
 	}
 
 	/**

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -48,7 +48,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			<?php
 			printf(
 				'<input name="force_lang" type="radio" value="1" %s/> %s',
-				1 == $this->options['force_lang'] ? 'checked="checked"' : '',
+				1 === $this->options['force_lang'] ? 'checked="checked"' : '',
 				$this->links_model->using_permalinks ? esc_html__( 'The language is set from the directory name in pretty permalinks', 'polylang' ) : esc_html__( 'The language is set from the code in the URL', 'polylang' )
 			);
 			?>
@@ -59,7 +59,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			printf(
 				'<input name="force_lang" type="radio" value="2" %s %s/> %s',
 				$this->links_model->using_permalinks ? '' : 'disabled="disabled"',
-				2 == $this->options['force_lang'] ? 'checked="checked"' : '',
+				2 === $this->options['force_lang'] ? 'checked="checked"' : '',
 				esc_html__( 'The language is set from the subdomain name in pretty permalinks', 'polylang' )
 			);
 			?>
@@ -70,12 +70,12 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			printf(
 				'<input name="force_lang" type="radio" value="3" %s %s/> %s',
 				$this->links_model->using_permalinks ? '' : 'disabled="disabled"',
-				3 == $this->options['force_lang'] ? 'checked="checked"' : '',
+				3 === $this->options['force_lang'] ? 'checked="checked"' : '',
 				esc_html__( 'The language is set from different domains', 'polylang' )
 			);
 			?>
 		</label>
-		<table id="pll-domains-table" class="form-table" <?php echo 3 == $this->options['force_lang'] ? '' : 'style="display: none;"'; ?>>
+		<table id="pll-domains-table" class="form-table" <?php echo 3 === $this->options['force_lang'] ? '' : 'style="display: none;"'; ?>>
 			<?php
 			foreach ( $this->model->get_languages_list() as  $lg ) {
 				printf(
@@ -83,7 +83,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 					'<td><input name="domains[%1$s]" id="pll-domain[%1$s]" type="text" value="%3$s" class="regular-text code" aria-required="true" /></td></tr>',
 					esc_attr( $lg->slug ),
 					esc_attr( $lg->name ),
-					esc_url( isset( $this->options['domains'][ $lg->slug ] ) ? $this->options['domains'][ $lg->slug ] : ( $lg->slug == $this->options['default_lang'] ? $this->links_model->home : '' ) )
+					esc_url( isset( $this->options['domains'][ $lg->slug ] ) ? $this->options['domains'][ $lg->slug ] : ( $lg->slug === $this->options['default_lang'] ? $this->links_model->home : '' ) )
 				);
 			}
 			?>
@@ -224,7 +224,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			$newoptions[ $key ] = isset( $options[ $key ] ) ? (int) $options[ $key ] : 0;
 		}
 
-		if ( 3 == $options['force_lang'] && isset( $options['domains'] ) && is_array( $options['domains'] ) ) {
+		if ( 3 === $options['force_lang'] && isset( $options['domains'] ) && is_array( $options['domains'] ) ) {
 			foreach ( $options['domains'] as $key => $domain ) {
 				if ( empty( $domain ) ) {
 					$lang = $this->model->get_language( $key );
@@ -246,7 +246,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			$newoptions[ $key ] = isset( $options[ $key ] ) ? 1 : 0;
 		}
 
-		if ( 3 == $options['force_lang'] ) {
+		if ( 3 === $options['force_lang'] ) {
 			if ( ! class_exists( 'PLL_Xdata_Domain', true ) ) {
 				$newoptions['browser'] = 0;
 			}
@@ -278,7 +278,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			$response      = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( esc_url_raw( $url ) ) : wp_remote_get( esc_url_raw( $url ) );
 			$response_code = wp_remote_retrieve_response_code( $response );
 
-			if ( 200 != $response_code ) {
+			if ( 200 !== $response_code ) {
 				add_settings_error(
 					'general', 'pll_invalid_domain', esc_html(
 						sprintf(

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -15,14 +15,16 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
-		parent::__construct( $polylang, array(
-			'module'      => 'url',
-			'title'       => __( 'URL modifications', 'polylang' ),
-			'description' => __( 'Decide how your URLs will look like.', 'polylang' ),
-			'configure'   => true,
-		) );
+		parent::__construct(
+			$polylang, [
+				'module'      => 'url',
+				'title'       => __( 'URL modifications', 'polylang' ),
+				'description' => __( 'Decide how your URLs will look like.', 'polylang' ),
+				'configure'   => true,
+			]
+		);
 
-		$this->links_model = &$polylang->links_model;
+		$this->links_model   = &$polylang->links_model;
 		$this->page_on_front = &$polylang->static_pages->page_on_front;
 	}
 
@@ -62,7 +64,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			);
 			?>
 		</label>
-		<p class="description"><?php echo esc_html__( 'Example:', 'polylang' ) . ' <code>' . esc_html( str_replace( array( '://', 'www.' ), array( '://en.', '' ), home_url( 'my-post/' ) ) ) . '</code>'; ?></p>
+		<p class="description"><?php echo esc_html__( 'Example:', 'polylang' ) . ' <code>' . esc_html( str_replace( [ '://', 'www.' ], [ '://en.', '' ], home_url( 'my-post/' ) ) ) . '</code>'; ?></p>
 		<label>
 			<?php
 			printf(
@@ -218,7 +220,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @param array $options
 	 */
 	protected function update( $options ) {
-		foreach ( array( 'force_lang', 'rewrite' ) as $key ) {
+		foreach ( [ 'force_lang', 'rewrite' ] as $key ) {
 			$newoptions[ $key ] = isset( $options[ $key ] ) ? (int) $options[ $key ] : 0;
 		}
 
@@ -226,18 +228,21 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			foreach ( $options['domains'] as $key => $domain ) {
 				if ( empty( $domain ) ) {
 					$lang = $this->model->get_language( $key );
-					add_settings_error( 'general', 'pll_invalid_domain', esc_html( sprintf(
-						/* translators: %s is a native language name */
-						__( 'Please enter a valid URL for %s.', 'polylang' ), $lang->name
-					) ) );
-				}
-				else {
+					add_settings_error(
+						'general', 'pll_invalid_domain', esc_html(
+							sprintf(
+								/* translators: %s is a native language name */
+								__( 'Please enter a valid URL for %s.', 'polylang' ), $lang->name
+							)
+						)
+					);
+				} else {
 					$newoptions['domains'][ $key ] = esc_url_raw( trim( $domain ) );
 				}
 			}
 		}
 
-		foreach ( array( 'hide_default', 'redirect_lang' ) as $key ) {
+		foreach ( [ 'hide_default', 'redirect_lang' ] as $key ) {
 			$newoptions[ $key ] = isset( $options[ $key ] ) ? 1 : 0;
 		}
 
@@ -264,20 +269,24 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @param array $options new set of options to test
 	 */
 	protected function check_domains( $options ) {
-		$options = array_merge( $this->options, $options );
-		$model = new PLL_Model( $options );
+		$options     = array_merge( $this->options, $options );
+		$model       = new PLL_Model( $options );
 		$links_model = $model->get_links_model();
 		foreach ( $this->model->get_languages_list() as $lang ) {
 			$url = add_query_arg( 'deactivate-polylang', 1, $links_model->home_url( $lang ) );
 			// Don't redefine vip_safe_wp_remote_get() as it has not the same signature as wp_remote_get()
-			$response = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( esc_url_raw( $url ) ) : wp_remote_get( esc_url_raw( $url ) );
+			$response      = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( esc_url_raw( $url ) ) : wp_remote_get( esc_url_raw( $url ) );
 			$response_code = wp_remote_retrieve_response_code( $response );
 
 			if ( 200 != $response_code ) {
-				add_settings_error( 'general', 'pll_invalid_domain', esc_html( sprintf(
-					/* translators: %s is an url */
-					__( 'Polylang was unable to access the URL %s. Please check that the URL is valid.', 'polylang' ), $url
-				) ) );
+				add_settings_error(
+					'general', 'pll_invalid_domain', esc_html(
+						sprintf(
+							/* translators: %s is an url */
+							__( 'Polylang was unable to access the URL %s. Please check that the URL is valid.', 'polylang' ), $url
+						)
+					)
+				);
 			}
 		}
 	}

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -36,14 +36,14 @@ class PLL_Settings extends PLL_Admin_Base {
 		PLL_Admin_Strings::init();
 
 		// FIXME put this as late as possible
-		add_action( 'admin_init', array( $this, 'register_settings_modules' ) );
+		add_action( 'admin_init', [ $this, 'register_settings_modules' ] );
 
 		// Adds screen options and the about box in the languages admin panel
-		add_action( 'load-toplevel_page_mlang', array( $this, 'load_page' ) );
-		add_action( 'load-languages_page_mlang_strings', array( $this, 'load_page_strings' ) );
+		add_action( 'load-toplevel_page_mlang', [ $this, 'load_page' ] );
+		add_action( 'load-languages_page_mlang_strings', [ $this, 'load_page_strings' ] );
 
 		// Saves per-page value in screen option
-		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );
+		add_filter( 'set-screen-option', [ $this, 'set_screen_option' ], 10, 3 );
 	}
 
 	/**
@@ -52,22 +52,24 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @since 1.8
 	 */
 	public function register_settings_modules() {
-		$modules = array(
+		$modules = [
 			'PLL_Settings_Tools',
 			'PLL_Settings_Licenses',
-		);
+		];
 
 		if ( $this->model->get_languages_list() ) {
-			$modules = array_merge( array(
-				'PLL_Settings_Url',
-				'PLL_Settings_Browser',
-				'PLL_Settings_Media',
-				'PLL_Settings_CPT',
-				'PLL_Settings_Sync',
-				'PLL_Settings_WPML',
-				'PLL_Settings_Share_Slug',
-				'PLL_Settings_Translate_Slugs',
-			), $modules );
+			$modules = array_merge(
+				[
+					'PLL_Settings_Url',
+					'PLL_Settings_Browser',
+					'PLL_Settings_Media',
+					'PLL_Settings_CPT',
+					'PLL_Settings_Sync',
+					'PLL_Settings_WPML',
+					'PLL_Settings_Share_Slug',
+					'PLL_Settings_Translate_Slugs',
+				], $modules
+			);
 		}
 
 		/**
@@ -80,7 +82,7 @@ class PLL_Settings extends PLL_Admin_Base {
 		$modules = apply_filters( 'pll_settings_modules', $modules );
 
 		foreach ( $modules as $key => $class ) {
-			$key = is_numeric( $key ) ? strtolower( str_replace( 'PLL_Settings_', '', $class ) ) : $key;
+			$key                   = is_numeric( $key ) ? strtolower( str_replace( 'PLL_Settings_', '', $class ) ) : $key;
 			$this->modules[ $key ] = new $class( $this );
 		}
 	}
@@ -104,19 +106,21 @@ class PLL_Settings extends PLL_Admin_Base {
 			add_meta_box(
 				'pll-about-box',
 				__( 'About Polylang', 'polylang' ),
-				array( $this, 'metabox_about' ),
+				[ $this, 'metabox_about' ],
 				'settings_page_mlang', // FIXME not shown in screen options
 				'normal'
 			);
 		}
 
-		add_screen_option( 'per_page', array(
-			'label'   => __( 'Languages', 'polylang' ),
-			'default' => 10,
-			'option'  => 'pll_lang_per_page',
-		) );
+		add_screen_option(
+			'per_page', [
+				'label'   => __( 'Languages', 'polylang' ),
+				'default' => 10,
+				'option'  => 'pll_lang_per_page',
+			]
+		);
 
-		add_action( 'admin_notices', array( $this, 'notice_objects_with_no_lang' ) );
+		add_action( 'admin_notices', [ $this, 'notice_objects_with_no_lang' ] );
 	}
 
 	/**
@@ -125,11 +129,13 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @since 2.1
 	 */
 	public function load_page_strings() {
-		add_screen_option( 'per_page', array(
-			'label'   => __( 'Strings translations', 'polylang' ),
-			'default' => 10,
-			'option'  => 'pll_strings_per_page',
-		) );
+		add_screen_option(
+			'per_page', [
+				'label'   => __( 'Strings translations', 'polylang' ),
+				'default' => 10,
+				'option'  => 'pll_strings_per_page',
+			]
+		);
 	}
 
 	/**
@@ -277,10 +283,10 @@ class PLL_Settings extends PLL_Admin_Base {
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		wp_enqueue_script( 'pll_admin', plugins_url( '/js/admin' . $suffix . '.js', POLYLANG_FILE ), array( 'jquery', 'wp-ajax-response', 'postbox', 'jquery-ui-selectmenu' ), POLYLANG_VERSION );
+		wp_enqueue_script( 'pll_admin', plugins_url( '/js/admin' . $suffix . '.js', POLYLANG_FILE ), [ 'jquery', 'wp-ajax-response', 'postbox', 'jquery-ui-selectmenu' ], POLYLANG_VERSION );
 		wp_localize_script( 'pll_admin', 'pll_flag_base_url', plugins_url( '/flags/', POLYLANG_FILE ) );
 
-		wp_enqueue_style( 'pll_selectmenu', plugins_url( '/css/selectmenu' . $suffix . '.css', POLYLANG_FILE ), array(), POLYLANG_VERSION );
+		wp_enqueue_style( 'pll_selectmenu', plugins_url( '/css/selectmenu' . $suffix . '.css', POLYLANG_FILE ), [], POLYLANG_VERSION );
 	}
 
 	/**
@@ -307,13 +313,13 @@ class PLL_Settings extends PLL_Admin_Base {
 	 *
 	 * @param array $args query arguments to add to the url
 	 */
-	static public function redirect( $args = array() ) {
+	static public function redirect( $args = [] ) {
 		if ( $errors = get_settings_errors() ) {
 			set_transient( 'settings_errors', $errors, 30 );
 			$args['settings-updated'] = 1;
 		}
 		// Remove possible 'pll_action' and 'lang' query args from the referer before redirecting
-		wp_safe_redirect( add_query_arg( $args, remove_query_arg( array( 'pll_action', 'lang' ), wp_get_referer() ) ) );
+		wp_safe_redirect( add_query_arg( $args, remove_query_arg( [ 'pll_action', 'lang' ], wp_get_referer() ) ) );
 		exit;
 	}
 
@@ -327,9 +333,9 @@ class PLL_Settings extends PLL_Admin_Base {
 		include PLL_SETTINGS_INC . '/languages.php';
 
 		// Keep only languages with existing WP language pack
-		$translations = wp_get_available_translations();
+		$translations          = wp_get_available_translations();
 		$translations['en_US'] = ''; // Languages packs don't include en_US
-		$languages = array_intersect_key( $languages, $translations );
+		$languages             = array_intersect_key( $languages, $translations );
 
 		/**
 		 * Filter the list of predefined languages

--- a/settings/table-languages.php
+++ b/settings/table-languages.php
@@ -102,7 +102,7 @@ class PLL_Table_Languages extends WP_List_Table {
 	function column_default_lang( $item ) {
 		$options = get_option( 'polylang' );
 
-		if ( $options['default_lang'] != $item->slug ) {
+		if ( $options['default_lang'] !== $item->slug ) {
 			$s = sprintf(
 				'
 				<div class="row-actions"><span class="default-lang">
@@ -244,7 +244,7 @@ class PLL_Table_Languages extends WP_List_Table {
 			$result = strcmp( $a->$orderby, $b->$orderby );
 		}
 		// Send final sort direction to usort
-		return ( empty( $_GET['order'] ) || 'asc' == $_GET['order'] ) ? $result : -$result;
+		return ( empty( $_GET['order'] ) || 'asc' === $_GET['order'] ) ? $result : -$result;
 	}
 
 	/**

--- a/settings/table-languages.php
+++ b/settings/table-languages.php
@@ -18,10 +18,12 @@ class PLL_Table_Languages extends WP_List_Table {
 	 * @since 0.1
 	 */
 	function __construct() {
-		parent::__construct( array(
-			'plural' => 'Languages', // Do not translate ( used for css class )
-			'ajax'   => false,
-		) );
+		parent::__construct(
+			[
+				'plural' => 'Languages', // Do not translate ( used for css class )
+				'ajax'   => false,
+			]
+		);
 	}
 
 	/**
@@ -40,7 +42,7 @@ class PLL_Table_Languages extends WP_List_Table {
 		 * @param array  $classes list of class names
 		 * @param object $item    the current item
 		 */
-		$classes = apply_filters( 'pll_languages_row_classes', array(), $item );
+		$classes = apply_filters( 'pll_languages_row_classes', [], $item );
 		echo '<tr' . ( empty( $classes ) ? '>' : ' class="' . esc_attr( implode( ' ', $classes ) ) . '">' );
 		$this->single_row_columns( $item );
 		echo '</tr>';
@@ -101,7 +103,8 @@ class PLL_Table_Languages extends WP_List_Table {
 		$options = get_option( 'polylang' );
 
 		if ( $options['default_lang'] != $item->slug ) {
-			$s = sprintf('
+			$s = sprintf(
+				'
 				<div class="row-actions"><span class="default-lang">
 				<a class="icon-default-lang" title="%1$s" href="%2$s"><span class="screen-reader-text">%3$s</span></a>
 				</span></div>',
@@ -126,7 +129,7 @@ class PLL_Table_Languages extends WP_List_Table {
 				/* translators: accessibility text */
 				esc_html__( 'Default language', 'polylang' )
 			);
-			$actions = array();
+			$actions = [];
 		}
 
 		return $s;
@@ -140,7 +143,7 @@ class PLL_Table_Languages extends WP_List_Table {
 	 * @return array the list of column titles
 	 */
 	function get_columns() {
-		return array(
+		return [
 			'name'         => esc_html__( 'Full name', 'polylang' ),
 			'locale'       => esc_html__( 'Locale', 'polylang' ),
 			'slug'         => esc_html__( 'Code', 'polylang' ),
@@ -148,7 +151,7 @@ class PLL_Table_Languages extends WP_List_Table {
 			'term_group'   => esc_html__( 'Order', 'polylang' ),
 			'flag'         => esc_html__( 'Flag', 'polylang' ),
 			'count'        => esc_html__( 'Posts', 'polylang' ),
-		);
+		];
 	}
 
 	/**
@@ -159,13 +162,13 @@ class PLL_Table_Languages extends WP_List_Table {
 	 * @return array
 	 */
 	function get_sortable_columns() {
-		return array(
-			'name'       => array( 'name', true ), // sorted by name by default
-			'locale'     => array( 'locale', false ),
-			'slug'       => array( 'slug', false ),
-			'term_group' => array( 'term_group', false ),
-			'count'      => array( 'count', false ),
-		);
+		return [
+			'name'       => [ 'name', true ], // sorted by name by default
+			'locale'     => [ 'locale', false ],
+			'slug'       => [ 'slug', false ],
+			'term_group' => [ 'term_group', false ],
+			'count'      => [ 'count', false ],
+		];
 	}
 
 	/**
@@ -194,7 +197,7 @@ class PLL_Table_Languages extends WP_List_Table {
 			return '';
 		}
 
-		$actions = array(
+		$actions = [
 			'edit'   => sprintf(
 				'<a title="%s" href="%s">%s</a>',
 				esc_attr__( 'Edit this language', 'polylang' ),
@@ -208,7 +211,7 @@ class PLL_Table_Languages extends WP_List_Table {
 				esc_js( __( 'You are about to permanently delete this language. Are you sure?', 'polylang' ) ),
 				esc_html__( 'Delete', 'polylang' )
 			),
-		);
+		];
 
 		/**
 		 * Filter the list of row actions in the languages list table
@@ -251,19 +254,21 @@ class PLL_Table_Languages extends WP_List_Table {
 	 *
 	 * @param array $data
 	 */
-	function prepare_items( $data = array() ) {
-		$per_page = $this->get_items_per_page( 'pll_lang_per_page' );
-		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns() );
+	function prepare_items( $data = [] ) {
+		$per_page              = $this->get_items_per_page( 'pll_lang_per_page' );
+		$this->_column_headers = [ $this->get_columns(), [], $this->get_sortable_columns() ];
 
-		usort( $data, array( $this, 'usort_reorder' ) );
+		usort( $data, [ $this, 'usort_reorder' ] );
 
 		$total_items = count( $data );
 		$this->items = array_slice( $data, ( $this->get_pagenum() - 1 ) * $per_page, $per_page );
 
-		$this->set_pagination_args( array(
-			'total_items' => $total_items,
-			'per_page'    => $per_page,
-			'total_pages' => ceil( $total_items / $per_page ),
-		) );
+		$this->set_pagination_args(
+			[
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+				'total_pages' => ceil( $total_items / $per_page ),
+			]
+		);
 	}
 }

--- a/settings/table-settings.php
+++ b/settings/table-settings.php
@@ -104,11 +104,11 @@ class PLL_Table_Settings extends WP_List_Table {
 				$classes .= ' column-primary';
 			}
 
-			if ( in_array( $column_name, $hidden ) ) {
+			if ( in_array( $column_name, $hidden, true ) ) {
 				$classes .= ' hidden';
 			}
 
-			if ( 'cb' == $column_name ) {
+			if ( 'cb' === $column_name ) {
 				echo '<th scope="row" class="check-column">';
 				echo $this->column_cb( $item );
 				echo '</th>';
@@ -130,7 +130,7 @@ class PLL_Table_Settings extends WP_List_Table {
 	 * @return string
 	 */
 	protected function column_default( $item, $column_name ) {
-		if ( 'plugin-title' == $column_name ) {
+		if ( 'plugin-title' === $column_name ) {
 			return sprintf( '<strong>%s</strong>', esc_html( $item->title ) ) . $this->row_actions( $item->get_action_links(), true /*always visible*/ );
 		}
 		return $item->$column_name;

--- a/settings/table-settings.php
+++ b/settings/table-settings.php
@@ -17,10 +17,12 @@ class PLL_Table_Settings extends WP_List_Table {
 	 * @since 1.8
 	 */
 	function __construct() {
-		parent::__construct( array(
-			'plural' => 'Settings', // Do not translate ( used for css class )
-			'ajax'   => false,
-		) );
+		parent::__construct(
+			[
+				'plural' => 'Settings', // Do not translate ( used for css class )
+				'ajax'   => false,
+			]
+		);
 	}
 
 	/**
@@ -29,7 +31,7 @@ class PLL_Table_Settings extends WP_List_Table {
 	 * @since 1.8
 	 */
 	protected function get_table_classes() {
-		return array( 'wp-list-table', 'widefat', 'plugins', 'pll-settings' ); // get the style of the plugins list table + one specific class
+		return [ 'wp-list-table', 'widefat', 'plugins', 'pll-settings' ]; // get the style of the plugins list table + one specific class
 	}
 
 	/**
@@ -53,7 +55,8 @@ class PLL_Table_Settings extends WP_List_Table {
 
 		// Display an upgrade message if there is any, reusing css from the plugins updates
 		if ( $message = $item->get_upgrade_message() ) {
-			printf( '
+			printf(
+				'
 				<tr class="plugin-update-tr">
 					<td colspan="3" class="plugin-update colspanchange">%s</td>
 				</tr>',
@@ -69,7 +72,8 @@ class PLL_Table_Settings extends WP_List_Table {
 		// The settings if there are
 		// "inactive" class to reuse css from the plugins list table
 		if ( $form = $item->get_form() ) {
-			printf( '
+			printf(
+				'
 				<tr id="pll-configure-%s" class="pll-configure inactive inline-edit-row" style="display: none;">
 					<td colspan="3">
 						<legend>%s</legend>
@@ -108,8 +112,7 @@ class PLL_Table_Settings extends WP_List_Table {
 				echo '<th scope="row" class="check-column">';
 				echo $this->column_cb( $item );
 				echo '</th>';
-			}
-			else {
+			} else {
 				printf( '<td class="%s">', esc_attr( $classes ) );
 				echo $this->column_default( $item, $column_name );
 				echo '</td>';
@@ -141,11 +144,11 @@ class PLL_Table_Settings extends WP_List_Table {
 	 * @return array the list of column titles
 	 */
 	public function get_columns() {
-		return array(
+		return [
 			'cb'           => '', // For the 4px border inherited from plugins when the module is activated
 			'plugin-title' => esc_html__( 'Module', 'polylang' ), // plugin-title for styling
 			'description'  => esc_html__( 'Description', 'polylang' ),
-		);
+		];
 	}
 
 	/**
@@ -166,9 +169,9 @@ class PLL_Table_Settings extends WP_List_Table {
 	 *
 	 * @param array $items
 	 */
-	public function prepare_items( $items = array() ) {
-		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns(), $this->get_primary_column_name() );
-		$this->items = $items;
+	public function prepare_items( $items = [] ) {
+		$this->_column_headers = [ $this->get_columns(), [], $this->get_sortable_columns(), $this->get_primary_column_name() ];
+		$this->items           = $items;
 	}
 
 	/**

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -21,17 +21,19 @@ class PLL_Table_String extends WP_List_Table {
 	 * @param array $languages list of languages
 	 */
 	function __construct( $languages ) {
-		parent::__construct( array(
-			'plural' => 'Strings translations', // Do not translate ( used for css class )
-			'ajax'   => false,
-		) );
+		parent::__construct(
+			[
+				'plural' => 'Strings translations', // Do not translate ( used for css class )
+				'ajax'   => false,
+			]
+		);
 
-		$this->languages = $languages;
-		$this->strings = PLL_Admin_Strings::get_strings();
-		$this->groups = array_unique( wp_list_pluck( $this->strings, 'context' ) );
+		$this->languages      = $languages;
+		$this->strings        = PLL_Admin_Strings::get_strings();
+		$this->groups         = array_unique( wp_list_pluck( $this->strings, 'context' ) );
 		$this->selected_group = empty( $_GET['group'] ) || ! in_array( $_GET['group'], $this->groups ) ? -1 : $_GET['group'];
 
-		add_action( 'mlang_action_string-translation', array( $this, 'save_translations' ) );
+		add_action( 'mlang_action_string-translation', [ $this, 'save_translations' ] );
 	}
 
 	/**
@@ -87,17 +89,19 @@ class PLL_Table_String extends WP_List_Table {
 	 */
 	function column_translations( $item ) {
 		$languages = array_combine( wp_list_pluck( $this->languages, 'slug' ), wp_list_pluck( $this->languages, 'name' ) );
-		$out = '';
+		$out       = '';
 
 		foreach ( $item['translations'] as $key => $translation ) {
 			$input_type = $item['multiline'] ?
 				'<textarea name="translation[%1$s][%2$s]" id="%1$s-%2$s">%4$s</textarea>' :
 				'<input type="text" name="translation[%1$s][%2$s]" id="%1$s-%2$s" value="%4$s" />';
-			$out .= sprintf( '<div class="translation"><label for="%1$s-%2$s">%3$s</label>' . $input_type . '</div>' . "\n",
+			$out       .= sprintf(
+				'<div class="translation"><label for="%1$s-%2$s">%3$s</label>' . $input_type . '</div>' . "\n",
 				esc_attr( $key ),
 				esc_attr( $item['row'] ),
 				esc_html( $languages[ $key ] ),
-			format_to_edit( $translation ) ); // Don't interpret special chars
+				format_to_edit( $translation )
+			); // Don't interpret special chars
 		}
 
 		return $out;
@@ -111,13 +115,13 @@ class PLL_Table_String extends WP_List_Table {
 	 * @return array the list of column titles
 	 */
 	function get_columns() {
-		return array(
+		return [
 			'cb'           => '<input type="checkbox" />', // Checkbox
 			'string'       => esc_html__( 'String', 'polylang' ),
 			'name'         => esc_html__( 'Name', 'polylang' ),
 			'context'      => esc_html__( 'Group', 'polylang' ),
 			'translations' => esc_html__( 'Translations', 'polylang' ),
-		);
+		];
 	}
 
 	/**
@@ -128,11 +132,11 @@ class PLL_Table_String extends WP_List_Table {
 	 * @return array
 	 */
 	function get_sortable_columns() {
-		return array(
-			'string'  => array( 'string', false ),
-			'name'    => array( 'name', false ),
-			'context' => array( 'context', false ),
-		);
+		return [
+			'string'  => [ 'string', false ],
+			'name'    => [ 'name', false ],
+			'context' => [ 'context', false ],
+		];
 	}
 
 	/**
@@ -187,25 +191,27 @@ class PLL_Table_String extends WP_List_Table {
 			$mo->import_from_db( $language );
 			foreach ( $data as $key => $row ) {
 				$data[ $key ]['translations'][ $language->slug ] = $mo->translate( $row['string'] );
-				$data[ $key ]['row'] = $key; // Store the row number for convenience
+				$data[ $key ]['row']                             = $key; // Store the row number for convenience
 			}
 		}
 
-		$per_page = $this->get_items_per_page( 'pll_strings_per_page' );
-		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns() );
+		$per_page              = $this->get_items_per_page( 'pll_strings_per_page' );
+		$this->_column_headers = [ $this->get_columns(), [], $this->get_sortable_columns() ];
 
 		if ( ! empty( $_GET['orderby'] ) ) { // No sort by default
-			usort( $data, array( $this, 'usort_reorder' ) );
+			usort( $data, [ $this, 'usort_reorder' ] );
 		}
 
 		$total_items = count( $data );
 		$this->items = array_slice( $data, ( $this->get_pagenum() - 1 ) * $per_page, $per_page );
 
-		$this->set_pagination_args( array(
-			'total_items' => $total_items,
-			'per_page'    => $per_page,
-			'total_pages' => ceil( $total_items / $per_page ),
-		) );
+		$this->set_pagination_args(
+			[
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+				'total_pages' => ceil( $total_items / $per_page ),
+			]
+		);
 	}
 
 	/**
@@ -216,7 +222,7 @@ class PLL_Table_String extends WP_List_Table {
 	 * @return array
 	 */
 	function get_bulk_actions() {
-		return array( 'delete' => __( 'Delete', 'polylang' ) );
+		return [ 'delete' => __( 'Delete', 'polylang' ) ];
 	}
 
 	/**
@@ -266,7 +272,7 @@ class PLL_Table_String extends WP_List_Table {
 		}
 		echo '</select>' . "\n";
 
-		submit_button( __( 'Filter' ), 'button', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
+		submit_button( __( 'Filter' ), 'button', 'filter_action', false, [ 'id' => 'post-query-submit' ] );
 		echo '</div>';
 	}
 
@@ -333,7 +339,7 @@ class PLL_Table_String extends WP_List_Table {
 		}
 
 		// To refresh the page ( possible thanks to the $_GET['noheader']=true )
-		$args = array_intersect_key( $_REQUEST, array_flip( array( 's', 'paged', 'group' ) ) );
+		$args = array_intersect_key( $_REQUEST, array_flip( [ 's', 'paged', 'group' ] ) );
 		if ( ! empty( $_GET['paged'] ) && ! empty( $_POST['submit'] ) ) {
 			$args['paged'] = (int) $_GET['paged']; // Don't rely on $_REQUEST['paged'] or $_POST['paged']. See #14
 		}

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -31,7 +31,7 @@ class PLL_Table_String extends WP_List_Table {
 		$this->languages      = $languages;
 		$this->strings        = PLL_Admin_Strings::get_strings();
 		$this->groups         = array_unique( wp_list_pluck( $this->strings, 'context' ) );
-		$this->selected_group = empty( $_GET['group'] ) || ! in_array( $_GET['group'], $this->groups ) ? -1 : $_GET['group'];
+		$this->selected_group = empty( $_GET['group'] ) || ! in_array( $_GET['group'], $this->groups, true ) ? -1 : $_GET['group'];
 
 		add_action( 'mlang_action_string-translation', [ $this, 'save_translations' ] );
 	}

--- a/settings/view-tab-lang.php
+++ b/settings/view-tab-lang.php
@@ -58,7 +58,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								'<option value="%1$s:%2$s:%3$s:%4$s">%5$s - %2$s</option>' . "\n",
 								esc_attr( $lg['code'] ),
 								esc_attr( $lg['locale'] ),
-								'rtl' == $lg['dir'] ? '1' : '0',
+								'rtl' === $lg['dir'] ? '1' : '0',
 								esc_attr( $lg['flag'] ),
 								esc_html( $lg['name'] )
 							);
@@ -128,7 +128,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							printf(
 								'<option value="%1$s"%2$s>%3$s</option>' . "\n",
 								esc_attr( $code ),
-								isset( $edit_lang->flag_code ) && $edit_lang->flag_code == $code ? ' selected="selected"' : '',
+								isset( $edit_lang->flag_code ) && $edit_lang->flag_code === $code ? ' selected="selected"' : '',
 								esc_html( $label )
 							);
 						}

--- a/settings/view-tab-lang.php
+++ b/settings/view-tab-lang.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<div class="metabox-holder">
 				<?php
 				wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce', false );
-				do_meta_boxes( 'settings_page_mlang', 'normal', array() );
+				do_meta_boxes( 'settings_page_mlang', 'normal', [] );
 				?>
 			</div>
 		</div><!-- col-wrap -->
@@ -37,16 +37,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php
 					wp_nonce_field( 'add-lang', '_wpnonce_add-lang' );
 
-				if ( ! empty( $edit_lang ) ) {
-					?>
-					<input type="hidden" name="pll_action" value="update" />
-					<input type="hidden" name="lang_id" value="<?php echo esc_attr( $edit_lang->term_id ); ?>" />
+					if ( ! empty( $edit_lang ) ) {
+						?>
+						<input type="hidden" name="pll_action" value="update" />
+						<input type="hidden" name="lang_id" value="<?php echo esc_attr( $edit_lang->term_id ); ?>" />
 					<?php
-				} else {
-					?>
-					<input type="hidden" name="pll_action" value="add" />
-					<?php
-				}
+					} else {
+						?>
+						<input type="hidden" name="pll_action" value="add" />
+						<?php
+					}
 				?>
 				<div class="form-field">
 					<label for="lang_list"><?php esc_html_e( 'Choose a language', 'polylang' ); ?></label>

--- a/tests/phpunit/includes/speed-trap-listener.php
+++ b/tests/phpunit/includes/speed-trap-listener.php
@@ -267,7 +267,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener {
 	 */
 	protected function renderFooter() {
 		if ( $hidden = $this->getHiddenCount( $this->slow ) ) {
-			echo sprintf( '...and there %s %s more above your threshold hidden from view', $hidden == 1 ? 'is' : 'are', $hidden );
+			echo sprintf( '...and there %s %s more above your threshold hidden from view', $hidden === 1 ? 'is' : 'are', $hidden );
 		}
 	}
 

--- a/tests/phpunit/includes/speed-trap-listener.php
+++ b/tests/phpunit/includes/speed-trap-listener.php
@@ -4,323 +4,302 @@
  * A PHPUnit TestListener that exposes your slowest running tests by outputting
  * results directly to the console.
  */
-class SpeedTrapListener implements PHPUnit_Framework_TestListener
-{
-    /**
-     * Internal tracking for test suites.
-     *
-     * Increments as more suites are run, then decremented as they finish. All
-     * suites have been run when returns to 0.
-     *
-     * @var integer
-     */
-    protected $suites = 0;
+class SpeedTrapListener implements PHPUnit_Framework_TestListener {
 
-    /**
-     * Time in milliseconds at which a test will be considered "slow" and be
-     * reported by this listener.
-     *
-     * @var int
-     */
-    protected $slowThreshold;
+	/**
+	 * Internal tracking for test suites.
+	 *
+	 * Increments as more suites are run, then decremented as they finish. All
+	 * suites have been run when returns to 0.
+	 *
+	 * @var integer
+	 */
+	protected $suites = 0;
 
-    /**
-     * Number of tests to report on for slowness.
-     *
-     * @var int
-     */
-    protected $reportLength;
+	/**
+	 * Time in milliseconds at which a test will be considered "slow" and be
+	 * reported by this listener.
+	 *
+	 * @var int
+	 */
+	protected $slowThreshold;
 
-    /**
-     * Collection of slow tests.
-     *
-     * @var array
-     */
-    protected $slow = array();
+	/**
+	 * Number of tests to report on for slowness.
+	 *
+	 * @var int
+	 */
+	protected $reportLength;
 
-    /**
-     * Construct a new instance.
-     *
-     * @param array $options
-     */
-    public function __construct(array $options = array())
-    {
-        $this->loadOptions($options);
-    }
+	/**
+	 * Collection of slow tests.
+	 *
+	 * @var array
+	 */
+	protected $slow = [];
 
-    /**
-     * An error occurred.
-     *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                   $time
-     */
-    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
-    }
+	/**
+	 * Construct a new instance.
+	 *
+	 * @param array $options
+	 */
+	public function __construct( array $options = [] ) {
+		$this->loadOptions( $options );
+	}
 
-    /**
-     * A warning occurred.
-     *
-     * @param PHPUnit_Framework_Test    $test
-     * @param PHPUnit_Framework_Warning $e
-     * @param float                     $time
-     * @since Method available since Release 5.1.0
-     */
-    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_Warning $e, $time)
-    {
-    }
+	/**
+	 * An error occurred.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param Exception              $e
+	 * @param float                   $time
+	 */
+	public function addError( PHPUnit_Framework_Test $test, Exception $e, $time ) {
+	}
 
-    /**
-     * A failure occurred.
-     *
-     * @param PHPUnit_Framework_Test                 $test
-     * @param PHPUnit_Framework_AssertionFailedError $e
-     * @param float                                   $time
-     */
-    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
-    {
-    }
+	/**
+	 * A warning occurred.
+	 *
+	 * @param PHPUnit_Framework_Test    $test
+	 * @param PHPUnit_Framework_Warning $e
+	 * @param float                     $time
+	 * @since Method available since Release 5.1.0
+	 */
+	public function addWarning( PHPUnit_Framework_Test $test, PHPUnit_Framework_Warning $e, $time ) {
+	}
 
-    /**
-     * Incomplete test.
-     *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                   $time
-     */
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
-    }
+	/**
+	 * A failure occurred.
+	 *
+	 * @param PHPUnit_Framework_Test                 $test
+	 * @param PHPUnit_Framework_AssertionFailedError $e
+	 * @param float                                   $time
+	 */
+	public function addFailure( PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time ) {
+	}
 
-    /**
-     * Risky test.
-     *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                   $time
-     * @since  Method available since Release 4.0.0
-     */
-    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
-    }
+	/**
+	 * Incomplete test.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param Exception              $e
+	 * @param float                   $time
+	 */
+	public function addIncompleteTest( PHPUnit_Framework_Test $test, Exception $e, $time ) {
+	}
 
-    /**
-     * Skipped test.
-     *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                   $time
-     */
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
-    }
+	/**
+	 * Risky test.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param Exception              $e
+	 * @param float                   $time
+	 * @since  Method available since Release 4.0.0
+	 */
+	public function addRiskyTest( PHPUnit_Framework_Test $test, Exception $e, $time ) {
+	}
 
-    /**
-     * A test started.
-     *
-     * @param PHPUnit_Framework_Test $test
-     */
-    public function startTest(PHPUnit_Framework_Test $test)
-    {
-    }
+	/**
+	 * Skipped test.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param Exception              $e
+	 * @param float                   $time
+	 */
+	public function addSkippedTest( PHPUnit_Framework_Test $test, Exception $e, $time ) {
+	}
 
-    /**
-     * A test ended.
-     *
-     * @param PHPUnit_Framework_Test $test
-     * @param float                   $time
-     */
-    public function endTest(PHPUnit_Framework_Test $test, $time)
-    {
-        if (!$test instanceof PHPUnit_Framework_TestCase) return;
+	/**
+	 * A test started.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 */
+	public function startTest( PHPUnit_Framework_Test $test ) {
+	}
 
-        $time = $this->toMilliseconds($time);
-        $threshold = $this->getSlowThreshold($test);
+	/**
+	 * A test ended.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param float                   $time
+	 */
+	public function endTest( PHPUnit_Framework_Test $test, $time ) {
+		if ( ! $test instanceof PHPUnit_Framework_TestCase ) {
+			return;
+		}
 
-        if ($this->isSlow($time, $threshold)) {
-            $this->addSlowTest($test, $time);
-        }
-    }
+		$time      = $this->toMilliseconds( $time );
+		$threshold = $this->getSlowThreshold( $test );
 
-    /**
-     * A test suite started.
-     *
-     * @param PHPUnit_Framework_TestSuite $suite
-     */
-    public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
-    {
-        $this->suites++;
-    }
+		if ( $this->isSlow( $time, $threshold ) ) {
+			$this->addSlowTest( $test, $time );
+		}
+	}
 
-    /**
-     * A test suite ended.
-     *
-     * @param PHPUnit_Framework_TestSuite $suite
-     */
-    public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
-    {
-        $this->suites--;
+	/**
+	 * A test suite started.
+	 *
+	 * @param PHPUnit_Framework_TestSuite $suite
+	 */
+	public function startTestSuite( PHPUnit_Framework_TestSuite $suite ) {
+		$this->suites++;
+	}
 
-        if (0 === $this->suites && $this->hasSlowTests()) {
-            arsort($this->slow); // Sort longest running tests to the top
+	/**
+	 * A test suite ended.
+	 *
+	 * @param PHPUnit_Framework_TestSuite $suite
+	 */
+	public function endTestSuite( PHPUnit_Framework_TestSuite $suite ) {
+		$this->suites--;
 
-            $this->renderHeader();
-            $this->renderBody();
-            $this->renderFooter();
-        }
-    }
+		if ( 0 === $this->suites && $this->hasSlowTests() ) {
+			arsort( $this->slow ); // Sort longest running tests to the top
 
-    /**
-     * Whether the given test execution time is considered slow.
-     *
-     * @param int $time          Test execution time in milliseconds
-     * @param int $slowThreshold Test execution time at which a test should be considered slow (milliseconds)
-     * @return bool
-     */
-    protected function isSlow($time, $slowThreshold)
-    {
-        return $time >= $slowThreshold;
-    }
+			$this->renderHeader();
+			$this->renderBody();
+			$this->renderFooter();
+		}
+	}
 
-    /**
-     * Stores a test as slow.
-     *
-     * @param PHPUnit_Framework_TestCase $test
-     * @param int                         $time Test execution time in milliseconds
-     */
-    protected function addSlowTest(PHPUnit_Framework_TestCase $test, $time)
-    {
-        $label = $this->makeLabel($test);
+	/**
+	 * Whether the given test execution time is considered slow.
+	 *
+	 * @param int $time          Test execution time in milliseconds
+	 * @param int $slowThreshold Test execution time at which a test should be considered slow (milliseconds)
+	 * @return bool
+	 */
+	protected function isSlow( $time, $slowThreshold ) {
+		return $time >= $slowThreshold;
+	}
 
-        $this->slow[$label] = $time;
-    }
+	/**
+	 * Stores a test as slow.
+	 *
+	 * @param PHPUnit_Framework_TestCase $test
+	 * @param int                         $time Test execution time in milliseconds
+	 */
+	protected function addSlowTest( PHPUnit_Framework_TestCase $test, $time ) {
+		$label = $this->makeLabel( $test );
 
-    /**
-     * Whether at least one test has been considered slow.
-     *
-     * @return bool
-     */
-    protected function hasSlowTests()
-    {
-        return !empty($this->slow);
-    }
+		$this->slow[ $label ] = $time;
+	}
 
-    /**
-     * Convert PHPUnit's reported test time (microseconds) to milliseconds.
-     *
-     * @param float $time
-     * @return int
-     */
-    protected function toMilliseconds($time)
-    {
-        return (int) round($time * 1000);
-    }
+	/**
+	 * Whether at least one test has been considered slow.
+	 *
+	 * @return bool
+	 */
+	protected function hasSlowTests() {
+		return ! empty( $this->slow );
+	}
 
-    /**
-     * Label for describing a test.
-     *
-     * @param PHPUnit_Framework_TestCase $test
-     * @return string
-     */
-    protected function makeLabel(PHPUnit_Framework_TestCase $test)
-    {
-        return sprintf('%s:%s', get_class($test), $test->getName());
-    }
+	/**
+	 * Convert PHPUnit's reported test time (microseconds) to milliseconds.
+	 *
+	 * @param float $time
+	 * @return int
+	 */
+	protected function toMilliseconds( $time ) {
+		return (int) round( $time * 1000 );
+	}
 
-    /**
-     * Calculate number of slow tests to report about.
-     *
-     * @return int
-     */
-    protected function getReportLength()
-    {
-        return min(count($this->slow), $this->reportLength);
-    }
+	/**
+	 * Label for describing a test.
+	 *
+	 * @param PHPUnit_Framework_TestCase $test
+	 * @return string
+	 */
+	protected function makeLabel( PHPUnit_Framework_TestCase $test ) {
+		return sprintf( '%s:%s', get_class( $test ), $test->getName() );
+	}
 
-    /**
-     * Find how many slow tests occurred that won't be shown due to list length.
-     *
-     * @return int Number of hidden slow tests
-     */
-    protected function getHiddenCount()
-    {
-        $total = count($this->slow);
-        $showing = $this->getReportLength($this->slow);
+	/**
+	 * Calculate number of slow tests to report about.
+	 *
+	 * @return int
+	 */
+	protected function getReportLength() {
+		return min( count( $this->slow ), $this->reportLength );
+	}
 
-        $hidden = 0;
-        if ($total > $showing) {
-            $hidden = $total - $showing;
-        }
+	/**
+	 * Find how many slow tests occurred that won't be shown due to list length.
+	 *
+	 * @return int Number of hidden slow tests
+	 */
+	protected function getHiddenCount() {
+		$total   = count( $this->slow );
+		$showing = $this->getReportLength( $this->slow );
 
-        return $hidden;
-    }
+		$hidden = 0;
+		if ( $total > $showing ) {
+			$hidden = $total - $showing;
+		}
 
-    /**
-     * Renders slow test report header.
-     */
-    protected function renderHeader()
-    {
-        echo sprintf("\n\nYou should really fix these slow tests (>%sms)...\n", $this->slowThreshold);
-    }
+		return $hidden;
+	}
 
-    /**
-     * Renders slow test report body.
-     */
-    protected function renderBody()
-    {
-        $slowTests = $this->slow;
+	/**
+	 * Renders slow test report header.
+	 */
+	protected function renderHeader() {
+		echo sprintf( "\n\nYou should really fix these slow tests (>%sms)...\n", $this->slowThreshold );
+	}
 
-        $length = $this->getReportLength($slowTests);
-        for ($i = 1; $i <= $length; ++$i) {
-            $label = key($slowTests);
-            $time = array_shift($slowTests);
+	/**
+	 * Renders slow test report body.
+	 */
+	protected function renderBody() {
+		$slowTests = $this->slow;
 
-            echo sprintf(" %s. %sms to run %s\n", $i, $time, $label);
-        }
-    }
+		$length = $this->getReportLength( $slowTests );
+		for ( $i = 1; $i <= $length; ++$i ) {
+			$label = key( $slowTests );
+			$time  = array_shift( $slowTests );
 
-    /**
-     * Renders slow test report footer.
-     */
-    protected function renderFooter()
-    {
-        if ($hidden = $this->getHiddenCount($this->slow)) {
-            echo sprintf("...and there %s %s more above your threshold hidden from view", $hidden == 1 ? 'is' : 'are', $hidden);
-        }
-    }
+			echo sprintf( " %s. %sms to run %s\n", $i, $time, $label );
+		}
+	}
 
-    /**
-     * Populate options into class internals.
-     *
-     * @param array $options
-     */
-    protected function loadOptions(array $options)
-    {
-        $this->slowThreshold = isset($options['slowThreshold']) ? $options['slowThreshold'] : 500;
-        $this->reportLength = isset($options['reportLength']) ? $options['reportLength'] : 10;
-    }
+	/**
+	 * Renders slow test report footer.
+	 */
+	protected function renderFooter() {
+		if ( $hidden = $this->getHiddenCount( $this->slow ) ) {
+			echo sprintf( '...and there %s %s more above your threshold hidden from view', $hidden == 1 ? 'is' : 'are', $hidden );
+		}
+	}
 
-    /**
-     * Get slow test threshold for given test. A TestCase can override the
-     * suite-wide slow threshold by using the annotation @slowThreshold with
-     * the threshold value in milliseconds.
-     *
-     * The following test will only be considered slow when its execution time
-     * reaches 5000ms (5 seconds):
-     *
-     * <code>
-     * @slowThreshold 5000
-     * public function testLongRunningProcess() {}
-     * </code>
-     *
-     * @param PHPUnit_Framework_TestCase $test
-     * @return int
-     */
-    protected function getSlowThreshold(PHPUnit_Framework_TestCase $test)
-    {
-        $ann = $test->getAnnotations();
+	/**
+	 * Populate options into class internals.
+	 *
+	 * @param array $options
+	 */
+	protected function loadOptions( array $options ) {
+		$this->slowThreshold = isset( $options['slowThreshold'] ) ? $options['slowThreshold'] : 500;
+		$this->reportLength  = isset( $options['reportLength'] ) ? $options['reportLength'] : 10;
+	}
 
-        return isset($ann['method']['slowThreshold'][0]) ? $ann['method']['slowThreshold'][0] : $this->slowThreshold;
-    }
+	/**
+	 * Get slow test threshold for given test. A TestCase can override the
+	 * suite-wide slow threshold by using the annotation @slowThreshold with
+	 * the threshold value in milliseconds.
+	 *
+	 * The following test will only be considered slow when its execution time
+	 * reaches 5000ms (5 seconds):
+	 *
+	 * <code>
+	 * @slowThreshold 5000
+	 * public function testLongRunningProcess() {}
+	 * </code>
+	 *
+	 * @param PHPUnit_Framework_TestCase $test
+	 * @return int
+	 */
+	protected function getSlowThreshold( PHPUnit_Framework_TestCase $test ) {
+		$ann = $test->getAnnotations();
+
+		return isset( $ann['method']['slowThreshold'][0] ) ? $ann['method']['slowThreshold'][0] : $this->slowThreshold;
+	}
 }

--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -8,10 +8,10 @@ class PLL_Ajax_UnitTestCase extends WP_Ajax_UnitTestCase {
 	static function wpSetUpBeforeClass() {
 		self::$polylang = new StdClass();
 
-		self::$polylang->options = PLL_Install::get_default_options();
+		self::$polylang->options                 = PLL_Install::get_default_options();
 		self::$polylang->options['hide_default'] = 0; // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis
-		self::$polylang->model = new PLL_Admin_Model( self::$polylang->options );
-		self::$polylang->links_model = self::$polylang->model->get_links_model(); // We always need a links model due to PLL_Language::set_home_url()
+		self::$polylang->model                   = new PLL_Admin_Model( self::$polylang->options );
+		self::$polylang->links_model             = self::$polylang->model->get_links_model(); // We always need a links model due to PLL_Language::set_home_url()
 	}
 
 	static function wpTearDownAfterClass() {
@@ -25,12 +25,12 @@ class PLL_Ajax_UnitTestCase extends WP_Ajax_UnitTestCase {
 		parent::tearDown();
 	}
 
-	static function create_language( $locale, $args = array() ) {
+	static function create_language( $locale, $args = [] ) {
 		include PLL_SETTINGS_INC . '/languages.php';
 		$values = $languages[ $locale ];
 
-		$values['slug'] = $values['code'];
-		$values['rtl'] = (int) ( 'rtl' === $values['dir'] );
+		$values['slug']       = $values['code'];
+		$values['rtl']        = (int) ( 'rtl' === $values['dir'] );
 		$values['term_group'] = 0; // default term_group
 
 		$args = array_merge( $values, $args );
@@ -46,8 +46,8 @@ class PLL_Ajax_UnitTestCase extends WP_Ajax_UnitTestCase {
 				// Delete the default category first
 				if ( $default_cat = self::$polylang->model->term->get_translation( get_option( 'default_category' ), $lang ) ) {
 					// For some reason wp_delete_term doesn't work :/
-					$wpdb->delete( $wpdb->terms, array( 'term_id' => $default_cat ) );
-					$wpdb->delete( $wpdb->term_taxonomy, array( 'term_id' => $default_cat ) );
+					$wpdb->delete( $wpdb->terms, [ 'term_id' => $default_cat ] );
+					$wpdb->delete( $wpdb->term_taxonomy, [ 'term_id' => $default_cat ] );
 				}
 				self::$polylang->model->delete_language( $lang->term_id );
 				unset( $GLOBALS['wp_settings_errors'] );

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -5,9 +5,9 @@ class PLL_Canonical_UnitTestCase extends PLL_UnitTestCase {
 	// mainly copy paste from WP_Canonical_UnitTestCase::assertCanonical
 	public function assertCanonical( $test_url, $expected ) {
 		if ( is_string( $expected ) ) {
-			$expected = array( 'url' => $expected );
+			$expected = [ 'url' => $expected ];
 		} elseif ( is_array( $expected ) && ! isset( $expected['url'] ) && ! isset( $expected['qv'] ) ) {
-			$expected = array( 'qv' => $expected );
+			$expected = [ 'qv' => $expected ];
 		}
 
 		if ( ! isset( $expected['url'] ) && ! isset( $expected['qv'] ) ) {
@@ -17,7 +17,7 @@ class PLL_Canonical_UnitTestCase extends PLL_UnitTestCase {
 		$this->go_to( home_url( $test_url ) );
 
 		// Does the redirect match what's expected?
-		$can_url = self::$polylang->filters_links->check_canonical_url( home_url( $test_url ), false ); // FIXME TODO define links ( need $curlang )
+		$can_url        = self::$polylang->filters_links->check_canonical_url( home_url( $test_url ), false ); // FIXME TODO define links ( need $curlang )
 		$parsed_can_url = parse_url( $can_url );
 
 		// Just test the Path and Query if present
@@ -40,7 +40,7 @@ class PLL_Canonical_UnitTestCase extends PLL_UnitTestCase {
 			parse_str( $parsed_can_url['query'], $_qv );
 
 			// $_qv should not contain any elements which are set in $query_vars already ( ie. $_GET vars should not be present in the Rewrite )
-			$this->assertEquals( array(), array_intersect( $query_vars, $_qv ) );
+			$this->assertEquals( [], array_intersect( $query_vars, $_qv ) );
 
 			$query_vars = array_merge( $query_vars, $_qv );
 		}

--- a/tests/phpunit/includes/testcase-domain.php
+++ b/tests/phpunit/includes/testcase-domain.php
@@ -55,9 +55,9 @@ class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 
 	function test_get_language_from_url() {
 		// hack $_SERVER
-		$server = $_SERVER;
+		$server                 = $_SERVER;
 		$_SERVER['REQUEST_URI'] = '/test/';
-		$_SERVER['HTTP_HOST'] = parse_url( $this->hosts['fr'], PHP_URL_HOST );
+		$_SERVER['HTTP_HOST']   = parse_url( $this->hosts['fr'], PHP_URL_HOST );
 		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
 
 		// clean up
@@ -71,15 +71,15 @@ class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 
 	function test_allowed_redirect_hosts() {
 		$hosts = str_replace( 'http://', '', array_values( $this->hosts ) );
-		$this->assertEquals( $hosts, self::$polylang->links_model->allowed_redirect_hosts( array() ) );
+		$this->assertEquals( $hosts, self::$polylang->links_model->allowed_redirect_hosts( [] ) );
 		$this->assertEquals( $this->hosts['fr'], wp_validate_redirect( $this->hosts['fr'] ) );
 	}
 
 	function test_upload_dir() {
 		// hack $_SERVER
-		$server = $_SERVER;
+		$server                 = $_SERVER;
 		$_SERVER['REQUEST_URI'] = '/test/';
-		$_SERVER['HTTP_HOST'] = parse_url( $this->hosts['fr'], PHP_URL_HOST );
+		$_SERVER['HTTP_HOST']   = parse_url( $this->hosts['fr'], PHP_URL_HOST );
 		if ( function_exists( 'wp_get_upload_dir' ) ) {
 			$uploads = wp_get_upload_dir(); // Since WP 4.5
 		} else {

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -7,10 +7,10 @@ class PLL_UnitTestCase extends WP_UnitTestCase {
 	static function wpSetUpBeforeClass() {
 		self::$polylang = new StdClass();
 
-		self::$polylang->options = PLL_Install::get_default_options();
+		self::$polylang->options                 = PLL_Install::get_default_options();
 		self::$polylang->options['hide_default'] = 0; // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis
-		self::$polylang->model = new PLL_Admin_Model( self::$polylang->options );
-		self::$polylang->links_model = self::$polylang->model->get_links_model(); // We always need a links model due to PLL_Language::set_home_url()
+		self::$polylang->model                   = new PLL_Admin_Model( self::$polylang->options );
+		self::$polylang->links_model             = self::$polylang->model->get_links_model(); // We always need a links model due to PLL_Language::set_home_url()
 
 		$_SERVER['SCRIPT_FILENAME'] = '/index.php'; // To pass the test in PLL_Choose_Lang::init() by default
 	}
@@ -32,12 +32,12 @@ class PLL_UnitTestCase extends WP_UnitTestCase {
 		parent::tearDown();
 	}
 
-	static function create_language( $locale, $args = array() ) {
+	static function create_language( $locale, $args = [] ) {
 		include PLL_SETTINGS_INC . '/languages.php';
 		$values = $languages[ $locale ];
 
-		$values['slug'] = $values['code'];
-		$values['rtl'] = (int) ( 'rtl' === $values['dir'] );
+		$values['slug']       = $values['code'];
+		$values['rtl']        = (int) ( 'rtl' === $values['dir'] );
 		$values['term_group'] = 0; // default term_group
 
 		$args = array_merge( $values, $args );
@@ -49,7 +49,7 @@ class PLL_UnitTestCase extends WP_UnitTestCase {
 		$languages = self::$polylang->model->get_languages_list();
 		if ( is_array( $languages ) ) {
 			// Delete the default categories first
-			$tt = wp_get_object_terms( get_option( 'default_category' ), 'term_translations' );
+			$tt    = wp_get_object_terms( get_option( 'default_category' ), 'term_translations' );
 			$terms = self::$polylang->model->term->get_translations( get_option( 'default_category' ) );
 
 			wp_delete_term( $tt, 'term_translations' );

--- a/tests/phpunit/tests/admin/test-admin.php
+++ b/tests/phpunit/tests/admin/test-admin.php
@@ -53,20 +53,20 @@ class Admin_Test extends PLL_UnitTestCase {
 		$footer = ob_get_clean();
 
 		$test = strpos( $footer, 'pll_ajax_backend' );
-		in_array( 'pll_ajax_backend', $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
+		in_array( 'pll_ajax_backend', $scripts, true ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 
 		foreach ( [ 'media', 'term' ] as $key ) {
 			$test = strpos( $footer, plugins_url( "/js/$key.min.js", POLYLANG_FILE ) );
-			in_array( $key, $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
+			in_array( $key, $scripts, true ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 		}
 
 		foreach ( [ 'post', 'user' ] as $key ) {
 			$test = strpos( $head, plugins_url( "/js/$key.min.js", POLYLANG_FILE ) );
-			in_array( $key, $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
+			in_array( $key, $scripts, true ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 		}
 
 		$test = strpos( $footer, 'polylang_admin-css' );
-		in_array( 'css', $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
+		in_array( 'css', $scripts, true ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 
 		unset( $GLOBALS['hook_suffix'], $GLOBALS['current_screen'], $GLOBALS['wp_scripts'], $GLOBALS['wp_styles'] );
 	}

--- a/tests/phpunit/tests/admin/test-admin.php
+++ b/tests/phpunit/tests/admin/test-admin.php
@@ -19,7 +19,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		self::$polylang->init();
 
 		_wp_admin_bar_init();
-		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
+		do_action_ref_array( 'admin_bar_menu', [ &$wp_admin_bar ] );
 
 		$languages = $wp_admin_bar->get_node( 'languages' );
 		$this->assertEmpty( $languages->parent );
@@ -35,10 +35,10 @@ class Admin_Test extends PLL_UnitTestCase {
 	}
 
 	function _test_scripts( $scripts ) {
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
+		self::$polylang        = new PLL_Admin( self::$polylang->links_model );
 		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
 
-		$GLOBALS['wp_styles'] = new WP_Styles();
+		$GLOBALS['wp_styles']  = new WP_Styles();
 		$GLOBALS['wp_scripts'] = new WP_Scripts();
 		wp_default_scripts( $GLOBALS['wp_scripts'] );
 
@@ -55,12 +55,12 @@ class Admin_Test extends PLL_UnitTestCase {
 		$test = strpos( $footer, 'pll_ajax_backend' );
 		in_array( 'pll_ajax_backend', $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 
-		foreach ( array( 'media', 'term' ) as $key ) {
+		foreach ( [ 'media', 'term' ] as $key ) {
 			$test = strpos( $footer, plugins_url( "/js/$key.min.js", POLYLANG_FILE ) );
 			in_array( $key, $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 		}
 
-		foreach ( array( 'post', 'user' ) as $key ) {
+		foreach ( [ 'post', 'user' ] as $key ) {
 			$test = strpos( $head, plugins_url( "/js/$key.min.js", POLYLANG_FILE ) );
 			in_array( $key, $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 		}
@@ -75,7 +75,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'edit.php';
 		set_current_screen( 'edit' );
 
-		$scripts = array( 'pll_ajax_backend', 'post', 'css' );
+		$scripts = [ 'pll_ajax_backend', 'post', 'css' ];
 		$this->_test_scripts( $scripts );
 	}
 
@@ -83,7 +83,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'post.php';
 		set_current_screen( 'post' );
 
-		$scripts = array( 'pll_ajax_backend', 'post', 'css' );
+		$scripts = [ 'pll_ajax_backend', 'post', 'css' ];
 		$this->_test_scripts( $scripts );
 	}
 
@@ -91,7 +91,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'upload.php';
 		set_current_screen( 'upload' );
 
-		$scripts = array( 'pll_ajax_backend', 'media', 'css' );
+		$scripts = [ 'pll_ajax_backend', 'media', 'css' ];
 		$this->_test_scripts( $scripts );
 	}
 
@@ -99,7 +99,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';
 		set_current_screen( 'edit-tags' );
 
-		$scripts = array( 'pll_ajax_backend', 'term', 'css' );
+		$scripts = [ 'pll_ajax_backend', 'term', 'css' ];
 		$this->_test_scripts( $scripts );
 	}
 
@@ -107,7 +107,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'term.php';
 		set_current_screen( 'term' );
 
-		$scripts = array( 'pll_ajax_backend', 'term', 'css' );
+		$scripts = [ 'pll_ajax_backend', 'term', 'css' ];
 		$this->_test_scripts( $scripts );
 	}
 
@@ -115,7 +115,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'profile.php';
 		set_current_screen( 'profile' );
 
-		$scripts = array( 'pll_ajax_backend', 'user', 'css' );
+		$scripts = [ 'pll_ajax_backend', 'user', 'css' ];
 		$this->_test_scripts( $scripts );
 	}
 }

--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -8,56 +8,56 @@ if ( ! $_tests_dir ) {
 
 if ( file_exists( $_tests_dir . '../jetpack/jetpack.php' ) ) {
 
-require_once $_tests_dir . '../jetpack/functions.opengraph.php';
+	require_once $_tests_dir . '../jetpack/functions.opengraph.php';
 
-class Jetpack_Test extends PLL_UnitTestCase {
+	class Jetpack_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+		static function wpSetUpBeforeClass() {
+			parent::wpSetUpBeforeClass();
 
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
+			self::create_language( 'en_US' );
+			self::create_language( 'fr_FR' );
+		}
+
+		function setUp() {
+			parent::setUp();
+
+			global $_tests_dir;
+			require_once PLL_INC . '/api.php'; // usually loaded only if an instance of Polylang exists
+			require_once $_tests_dir . '../jetpack/jetpack.php';
+
+			$GLOBALS['polylang'] = &self::$polylang; // we still use the global $polylang
+			self::$polylang      = new PLL_Frontend( self::$polylang->links_model );
+			self::$polylang->init();
+		}
+
+		function tearDown() {
+			parent::tearDown();
+
+			unset( $GLOBALS['polylang'] );
+		}
+
+		function test_opengraph() {
+			// create posts to get something  on home page
+			$en = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $en, 'en' );
+
+			$fr = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $fr, 'fr' );
+
+			$this->go_to( home_url( '/?lang=fr' ) );
+			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+
+			do_action_ref_array( 'pll_init', [ &self::$polylang ] );
+
+			ob_start();
+			jetpack_og_tags();
+			$output = ob_get_clean();
+
+			$this->assertNotFalse( strpos( $output, '<meta property="og:locale" content="fr_FR" />' ) );
+			$this->assertFalse( strpos( $output, '<meta property="og:locale:alternate" content="fr_FR" />' ) ); // only for alternate languages
+			$this->assertNotFalse( strpos( $output, '<meta property="og:locale:alternate" content="en_US" />' ) );
+		}
 	}
-
-	function setUp() {
-		parent::setUp();
-
-		global $_tests_dir;
-		require_once PLL_INC . '/api.php'; // usually loaded only if an instance of Polylang exists
-		require_once $_tests_dir . '../jetpack/jetpack.php';
-
-		$GLOBALS['polylang'] = &self::$polylang; // we still use the global $polylang
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
-	}
-
-	function tearDown() {
-		parent::tearDown();
-
-		unset( $GLOBALS['polylang'] );
-	}
-
-	function test_opengraph() {
-		// create posts to get something  on home page
-		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
-
-		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-
-		$this->go_to( home_url( '/?lang=fr' ) );
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-
-		do_action_ref_array( 'pll_init', array( &self::$polylang ) );
-
-		ob_start();
-		jetpack_og_tags();
-		$output = ob_get_clean();
-
-		$this->assertNotFalse( strpos( $output, '<meta property="og:locale" content="fr_FR" />' ) );
-		$this->assertFalse( strpos( $output, '<meta property="og:locale:alternate" content="fr_FR" />' ) ); // only for alternate languages
-		$this->assertNotFalse( strpos( $output, '<meta property="og:locale:alternate" content="en_US" />' ) );
-	}
-}
 
 } // file_exists

--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -8,102 +8,126 @@ if ( ! $_tests_dir ) {
 
 if ( file_exists( $_tests_dir . '/../wordpress-importer/wordpress-importer.php' ) ) {
 
-class WP_Importer_Test extends PLL_UnitTestCase {
+	class WP_Importer_Test extends PLL_UnitTestCase {
 
-	function setUp() {
-		parent::setUp();
+		function setUp() {
+			parent::setUp();
 
-		require_once PLL_INC . '/api.php';
-		$GLOBALS['polylang'] = &self::$polylang; // we still use the global $polylang
-		self::$polylang->options['hide_default'] = 0;
-		update_option( 'polylang', self::$polylang->options ); // make sure we have options in DB ( needed by PLL_WP_Import )
+			require_once PLL_INC . '/api.php';
+			$GLOBALS['polylang']                     = &self::$polylang; // we still use the global $polylang
+			self::$polylang->options['hide_default'] = 0;
+			update_option( 'polylang', self::$polylang->options ); // make sure we have options in DB ( needed by PLL_WP_Import )
 
-		if ( ! defined( 'WP_IMPORTING' ) ) {
-			define( 'WP_IMPORTING', true );
-		}
-
-		if ( ! defined( 'WP_LOAD_IMPORTERS' ) ) {
-			define( 'WP_LOAD_IMPORTERS', true );
-		}
-
-		global $_tests_dir;
-		require_once $_tests_dir . '/../wordpress-importer/wordpress-importer.php';
-
-		global $wpdb;
-		// crude but effective: make sure there's no residual data in the main tables
-		foreach ( array( 'posts', 'postmeta', 'comments', 'terms', 'term_taxonomy', 'term_relationships', 'users', 'usermeta' ) as $table ) {
-			$wpdb->query( "DELETE FROM {$wpdb->$table}" );
-		}
-	}
-
-	function tearDown() {
-		self::delete_all_languages();
-
-		parent::tearDown();
-	}
-
-	// mostly copied from WP_Import_UnitTestCase
-	protected function _import_wp( $filename, $users = array(), $fetch_files = true ) {
-		$importer = new PLL_WP_Import(); // Change to our importer
-		$file = realpath( $filename );
-		assert( '!empty( $file )' );
-		assert( 'is_file( $file )' );
-
-		$authors = $mapping = $new = array();
-		$i = 0;
-
-		// each user is either mapped to a given ID, mapped to a new user
-		// with given login or imported using details in WXR file
-		foreach ( $users as $user => $map ) {
-			$authors[ $i ] = $user;
-			if ( is_int( $map ) ) {
-				$mapping[ $i ] = $map;
-			} elseif ( is_string( $map ) ) {
-				$new[ $i ] = $map;
+			if ( ! defined( 'WP_IMPORTING' ) ) {
+				define( 'WP_IMPORTING', true );
 			}
 
-			$i++;
+			if ( ! defined( 'WP_LOAD_IMPORTERS' ) ) {
+				define( 'WP_LOAD_IMPORTERS', true );
+			}
+
+			global $_tests_dir;
+			require_once $_tests_dir . '/../wordpress-importer/wordpress-importer.php';
+
+			global $wpdb;
+			// crude but effective: make sure there's no residual data in the main tables
+			foreach ( [ 'posts', 'postmeta', 'comments', 'terms', 'term_taxonomy', 'term_relationships', 'users', 'usermeta' ] as $table ) {
+				$wpdb->query( "DELETE FROM {$wpdb->$table}" );
+			}
 		}
 
-		$_POST = array( 'imported_authors' => $authors, 'user_map' => $mapping, 'user_new' => $new );
+		function tearDown() {
+			self::delete_all_languages();
 
-		ob_start();
-		$importer->fetch_attachments = $fetch_files;
-		$importer->import( $file );
-		ob_end_clean();
+			parent::tearDown();
+		}
 
-		self::$polylang->options = get_option( 'polylang' );
-		$_POST = array();
+		// mostly copied from WP_Import_UnitTestCase
+		protected function _import_wp( $filename, $users = [], $fetch_files = true ) {
+			$importer = new PLL_WP_Import(); // Change to our importer
+			$file     = realpath( $filename );
+			assert( '!empty( $file )' );
+			assert( 'is_file( $file )' );
+
+			$authors = $mapping = $new = [];
+			$i       = 0;
+
+			// each user is either mapped to a given ID, mapped to a new user
+			// with given login or imported using details in WXR file
+			foreach ( $users as $user => $map ) {
+				$authors[ $i ] = $user;
+				if ( is_int( $map ) ) {
+					$mapping[ $i ] = $map;
+				} elseif ( is_string( $map ) ) {
+					$new[ $i ] = $map;
+				}
+
+				$i++;
+			}
+
+			$_POST = [
+				'imported_authors' => $authors,
+				'user_map' => $mapping,
+				'user_new' => $new,
+			];
+
+			ob_start();
+			$importer->fetch_attachments = $fetch_files;
+			$importer->import( $file );
+			ob_end_clean();
+
+			self::$polylang->options = get_option( 'polylang' );
+			$_POST                   = [];
+		}
+
+		function test_simple_import() {
+			$this->_import_wp( dirname( __FILE__ ) . '/../../data/test-import.xml' );
+
+			// languages
+			$this->assertEqualSets( [ 'en', 'fr' ], self::$polylang->model->get_languages_list( [ 'fields' => 'slug' ] ) );
+
+			// posts
+			$en = get_posts(
+				[
+					's' => 'Test',
+					'lang' => 'en',
+				]
+			);
+			$en = reset( $en );
+
+			$fr = get_posts(
+				[
+					's' => 'Essai',
+					'lang' => 'fr',
+				]
+			);
+			$fr = reset( $fr );
+
+			$this->assertEquals( 'en', self::$polylang->model->post->get_language( $en->ID )->slug );
+			$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $fr->ID )->slug );
+			$this->assertEqualSetsWithIndex(
+				[
+					'en' => $en->ID,
+					'fr' => $fr->ID,
+				], self::$polylang->model->post->get_translations( $en->ID )
+			);
+
+			// categories
+			$en = get_term_by( 'name', 'Test', 'category' );
+			$this->assertEquals( 'en', self::$polylang->model->term->get_language( $en->term_id )->slug );
+
+			$fr = get_term_by( 'name', 'Essai', 'category' );
+			$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr->term_id )->slug );
+
+			$this->assertEquals( 'en', self::$polylang->model->term->get_language( $en->term_id )->slug );
+			$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr->term_id )->slug );
+			$this->assertEqualSetsWithIndex(
+				[
+					'en' => $en->term_id,
+					'fr' => $fr->term_id,
+				], self::$polylang->model->term->get_translations( $en->term_id )
+			);
+		}
 	}
-
-	function test_simple_import() {
-		$this->_import_wp( dirname( __FILE__ ) . '/../../data/test-import.xml' );
-
-		// languages
-		$this->assertEqualSets( array( 'en', 'fr' ), self::$polylang->model->get_languages_list( array( 'fields' => 'slug' ) ) );
-
-		// posts
-		$en = get_posts( array( 's' => 'Test', 'lang' => 'en' ) );
-		$en = reset( $en );
-
-		$fr = get_posts( array( 's' => 'Essai', 'lang' => 'fr' ) );
-		$fr = reset( $fr );
-
-		$this->assertEquals( 'en', self::$polylang->model->post->get_language( $en->ID )->slug );
-		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $fr->ID )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $en->ID, 'fr' => $fr->ID ), self::$polylang->model->post->get_translations( $en->ID ) );
-
-		// categories
-		$en = get_term_by( 'name', 'Test', 'category' );
-		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $en->term_id )->slug );
-
-		$fr = get_term_by( 'name', 'Essai', 'category' );
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr->term_id )->slug );
-
-		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $en->term_id )->slug );
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr->term_id )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $en->term_id, 'fr' => $fr->term_id ), self::$polylang->model->term->get_translations( $en->term_id ) );
-	}
-}
 
 } // file_exists

--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -32,6 +32,7 @@ if ( file_exists( $_tests_dir . '/../wordpress-importer/wordpress-importer.php' 
 			global $wpdb;
 			// crude but effective: make sure there's no residual data in the main tables
 			foreach ( [ 'posts', 'postmeta', 'comments', 'terms', 'term_taxonomy', 'term_relationships', 'users', 'usermeta' ] as $table ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "DELETE FROM {$wpdb->$table}" );
 			}
 		}

--- a/tests/phpunit/tests/plugins/test-wpseo.php
+++ b/tests/phpunit/tests/plugins/test-wpseo.php
@@ -11,19 +11,19 @@ if ( file_exists( $_tests_dir . '/../wordpress-seo/wp-seo.php' ) ) {
 	require_once $_tests_dir . '/../wordpress-seo/inc/sitemaps/class-sitemaps.php';
 
 	/**
-     * copied from WPSEO unit tests
-     */
+	 * copied from WPSEO unit tests
+	 */
 	class WPSEO_Sitemaps_Double extends WPSEO_Sitemaps {
 		/**
-	     * Overwrite sitemap_close() so we don't die on outputting the sitemap
-	     */
+		 * Overwrite sitemap_close() so we don't die on outputting the sitemap
+		 */
 		function sitemap_close() {
 			remove_all_actions( 'wp_footer' );
 		}
 
 		/**
-	     * Cleans out the sitemap variable
-	     */
+		 * Cleans out the sitemap variable
+		 */
 		public function reset() {
 			$this->sitemap     = false;
 			$this->bad_sitemap = false;

--- a/tests/phpunit/tests/plugins/test-wpseo.php
+++ b/tests/phpunit/tests/plugins/test-wpseo.php
@@ -11,19 +11,19 @@ if ( file_exists( $_tests_dir . '/../wordpress-seo/wp-seo.php' ) ) {
 	require_once $_tests_dir . '/../wordpress-seo/inc/sitemaps/class-sitemaps.php';
 
 	/**
- * copied from WPSEO unit tests
- */
+     * copied from WPSEO unit tests
+     */
 	class WPSEO_Sitemaps_Double extends WPSEO_Sitemaps {
 		/**
-	 * Overwrite sitemap_close() so we don't die on outputting the sitemap
-	 */
+	     * Overwrite sitemap_close() so we don't die on outputting the sitemap
+	     */
 		function sitemap_close() {
 			remove_all_actions( 'wp_footer' );
 		}
 
 		/**
-	 * Cleans out the sitemap variable
-	 */
+	     * Cleans out the sitemap variable
+	     */
 		public function reset() {
 			$this->sitemap     = false;
 			$this->bad_sitemap = false;

--- a/tests/phpunit/tests/plugins/test-wpseo.php
+++ b/tests/phpunit/tests/plugins/test-wpseo.php
@@ -8,209 +8,209 @@ if ( ! $_tests_dir ) {
 
 if ( file_exists( $_tests_dir . '/../wordpress-seo/wp-seo.php' ) ) {
 
-require_once $_tests_dir . '/../wordpress-seo/inc/sitemaps/class-sitemaps.php';
+	require_once $_tests_dir . '/../wordpress-seo/inc/sitemaps/class-sitemaps.php';
 
-/**
+	/**
  * copied from WPSEO unit tests
  */
-class WPSEO_Sitemaps_Double extends WPSEO_Sitemaps {
-	/**
+	class WPSEO_Sitemaps_Double extends WPSEO_Sitemaps {
+		/**
 	 * Overwrite sitemap_close() so we don't die on outputting the sitemap
 	 */
-	function sitemap_close() {
-		remove_all_actions( 'wp_footer' );
-	}
+		function sitemap_close() {
+			remove_all_actions( 'wp_footer' );
+		}
 
-	/**
+		/**
 	 * Cleans out the sitemap variable
 	 */
-	public function reset() {
-		$this->sitemap     = false;
-		$this->bad_sitemap = false;
-	}
-}
-
-class WPSEO_Test extends PLL_UnitTestCase {
-	protected $structure = '/%postname%/';
-	protected $hosts;
-
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
-
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
-
-		$_SERVER['SERVER_NAME'] = 'example.org';
+		public function reset() {
+			$this->sitemap     = false;
+			$this->bad_sitemap = false;
+		}
 	}
 
-	function setUp() {
-		parent::setUp();
+	class WPSEO_Test extends PLL_UnitTestCase {
+		protected $structure = '/%postname%/';
+		protected $hosts;
 
-		global $_tests_dir;
-		require_once $_tests_dir . '/../wordpress-seo/wp-seo.php';
+		static function wpSetUpBeforeClass() {
+			parent::wpSetUpBeforeClass();
 
-		require_once PLL_INC . '/api.php';
-		$GLOBALS['polylang'] = &self::$polylang; // we still use the global $polylang
+			self::create_language( 'en_US' );
+			self::create_language( 'fr_FR' );
 
-		self::$polylang->options['hide_default'] = 0;
+			$_SERVER['SERVER_NAME'] = 'example.org';
+		}
 
-		_wpseo_activate();
-		$GLOBALS['wpseo_sitemaps'] = new WPSEO_Sitemaps;
-		add_action( 'pll_language_defined', array( new PLL_WPSEO(), 'init' ) ); // Load the compatibility layer
+		function setUp() {
+			parent::setUp();
 
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
+			global $_tests_dir;
+			require_once $_tests_dir . '/../wordpress-seo/wp-seo.php';
+
+			require_once PLL_INC . '/api.php';
+			$GLOBALS['polylang'] = &self::$polylang; // we still use the global $polylang
+
+			self::$polylang->options['hide_default'] = 0;
+
+			_wpseo_activate();
+			$GLOBALS['wpseo_sitemaps'] = new WPSEO_Sitemaps;
+			add_action( 'pll_language_defined', [ new PLL_WPSEO(), 'init' ] ); // Load the compatibility layer
+
+			self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+			self::$polylang->init();
+		}
+
+		function tearDown() {
+			parent::tearDown();
+
+			unset( $GLOBALS['polylang'] );
+		}
+
+		function test_opengraph() {
+			// create posts to get something  on home page
+			$en = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $en, 'en' );
+
+			$fr = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $fr, 'fr' );
+
+			$this->go_to( home_url( '/?lang=fr' ) );
+			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+
+			do_action( 'pll_language_defined' );
+			do_action_ref_array( 'pll_init', [ &self::$polylang ] );
+			do_action( 'template_redirect' ); // for home_url filter
+			wpseo_frontend_head_init();
+
+			ob_start();
+			do_action( 'wp_head' );
+			$output = ob_get_clean();
+
+			$this->assertNotFalse( strpos( $output, '<meta property="og:locale" content="fr_FR" />' ) ); // test WPSEO just in case
+			$this->assertFalse( strpos( $output, '<meta property="og:locale:alternate" content="fr_FR" />' ) ); // only for alternate languages
+			$this->assertNotFalse( strpos( $output, '<meta property="og:locale:alternate" content="en_US" />' ) );
+			$this->assertNotFalse( strpos( $output, '<link rel="canonical" href="http://example.org/?lang=fr" />' ) ); // covers pll_home_url_white_list
+		}
+
+		function test_post_sitemap_for_code_in_url() {
+			$en = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $en, 'en' );
+
+			$fr = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $fr, 'fr' );
+
+			$sm = new WPSEO_Sitemaps_Double();
+			set_query_var( 'sitemap', 'post' );
+
+			ob_start();
+			$sm->redirect( $GLOBALS['wp_the_query'] );
+			$output = ob_get_clean();
+
+			$en = htmlspecialchars( get_permalink( $en ) ); // WPSEO uses htmlspecialchars
+			$fr = htmlspecialchars( get_permalink( $fr ) );
+
+			// the sitemap must contain all languages
+			$this->assertNotFalse( strpos( $output, "<loc>$en</loc>" ) );
+			$this->assertNotFalse( strpos( $output, "<loc>$fr</loc>" ) );
+
+			// bug fixed in v1.9
+			// the sitemap must contain the home urls in all languages
+			$this->assertNotFalse( strpos( $output, '<loc>' . home_url( '/?lang=en' ) . '</loc>' ) );
+			$this->assertNotFalse( strpos( $output, '<loc>' . home_url( '/?lang=fr' ) . '</loc>' ) );
+		}
+
+		function test_category_sitemap_for_code_in_url() {
+			$en = $this->factory->category->create();
+			self::$polylang->model->term->set_language( $en, 'en' );
+			$post_id = $this->factory->post->create(); // by default, the sitemap hides empty categories
+			self::$polylang->model->post->set_language( $post_id, 'en' );
+			wp_set_post_terms( $post_id, [ $en ], 'category' );
+
+			$fr = $this->factory->category->create();
+			self::$polylang->model->term->set_language( $fr, 'fr' );
+			$post_id = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $post_id, 'fr' );
+			wp_set_post_terms( $post_id, [ $fr ], 'category' );
+
+			$sm = new WPSEO_Sitemaps_Double();
+			set_query_var( 'sitemap', 'category' );
+			$GLOBALS['wp_query']->query['sitemap'] = 'category'; // FIXME isn't that too hacky?
+
+			ob_start();
+			$sm->redirect( $GLOBALS['wp_the_query'] );
+			$output = ob_get_clean();
+
+			$en = htmlspecialchars( get_category_link( $en ) ); // WPSEO uses htmlspecialchars
+			$fr = htmlspecialchars( get_category_link( $fr ) );
+
+			// the sitemap must contain all languages
+			$this->assertNotFalse( strpos( $output, "<loc>$en</loc>" ) );
+			$this->assertNotFalse( strpos( $output, "<loc>$fr</loc>" ) );
+		}
+
+		function test_post_sitemap_for_subdomains() {
+			// FIXME The test works alone but static vars in Yoast SEO make it conclict with test_post_sitemap_for_code_in_url()
+			// See https://github.com/Yoast/wordpress-seo/issues/6926
+			$this->markTestSkipped();
+
+			global $wp_rewrite;
+
+			// setup subdomains
+			$this->hosts = [
+				'en' => 'http://example.org',
+				'fr' => 'http://fr.example.org',
+			];
+
+			self::$polylang->options['hide_default'] = 1;
+			self::$polylang->options['force_lang']   = 2;
+
+			// switch to pretty permalinks
+			$wp_rewrite->init();
+			$wp_rewrite->set_permalink_structure( $this->structure );
+
+			self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
+			create_initial_taxonomies();
+			self::$polylang->links_model = self::$polylang->model->get_links_model();
+
+			$wp_rewrite->flush_rules();
+
+			// init frontend
+			self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+			self::$polylang->init();
+			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+			do_action( 'pll_language_defined' );
+
+			// de-activate cache for links
+			self::$polylang->links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
+			self::$polylang->links->cache->method( 'get' )->willReturn( false );
+			self::$polylang->filters_links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
+			self::$polylang->filters_links->cache->method( 'get' )->willReturn( false );
+
+			// create posts
+			$en = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $en, 'en' );
+
+			$fr = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $fr, 'fr' );
+
+			$this->go_to( $this->hosts['fr'] . '/post-sitemap.xml' );
+			$sm = new WPSEO_Sitemaps_Double();
+			set_query_var( 'sitemap', 'post' );
+
+			ob_start();
+			$sm->redirect( $GLOBALS['wp_the_query'] );
+			$output = ob_get_clean();
+
+			$en = htmlspecialchars( get_permalink( $en ) ); // WPSEO uses htmlspecialchars
+			$fr = htmlspecialchars( get_permalink( $fr ) );
+
+			// the sitemap must contain only one language
+			$this->assertNotFalse( strpos( $output, '<loc>' . $this->hosts['fr'] . '</loc>' ) );
+			$this->assertNotFalse( strpos( $output, "<loc>$fr</loc>" ) );
+			$this->assertFalse( strpos( $output, "<loc>$en</loc>" ) );
+		}
 	}
-
-	function tearDown() {
-		parent::tearDown();
-
-		unset( $GLOBALS['polylang'] );
-	}
-
-	function test_opengraph() {
-		// create posts to get something  on home page
-		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
-
-		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-
-		$this->go_to( home_url( '/?lang=fr' ) );
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-
-		do_action( 'pll_language_defined' );
-		do_action_ref_array( 'pll_init', array( &self::$polylang ) );
-		do_action( 'template_redirect' ); // for home_url filter
-		wpseo_frontend_head_init();
-
-		ob_start();
-		do_action( 'wp_head' );
-		$output = ob_get_clean();
-
-		$this->assertNotFalse( strpos( $output, '<meta property="og:locale" content="fr_FR" />' ) ); // test WPSEO just in case
-		$this->assertFalse( strpos( $output, '<meta property="og:locale:alternate" content="fr_FR" />' ) ); // only for alternate languages
-		$this->assertNotFalse( strpos( $output, '<meta property="og:locale:alternate" content="en_US" />' ) );
-		$this->assertNotFalse( strpos( $output, '<link rel="canonical" href="http://example.org/?lang=fr" />' ) ); // covers pll_home_url_white_list
-	}
-
-	function test_post_sitemap_for_code_in_url() {
-		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
-
-		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-
-		$sm = new WPSEO_Sitemaps_Double();
-		set_query_var( 'sitemap', 'post' );
-
-		ob_start();
-		$sm->redirect( $GLOBALS['wp_the_query'] );
-		$output = ob_get_clean();
-
-		$en = htmlspecialchars( get_permalink( $en ) ); // WPSEO uses htmlspecialchars
-		$fr = htmlspecialchars( get_permalink( $fr ) );
-
-		// the sitemap must contain all languages
-		$this->assertNotFalse( strpos( $output, "<loc>$en</loc>" ) );
-		$this->assertNotFalse( strpos( $output, "<loc>$fr</loc>" ) );
-
-		// bug fixed in v1.9
-		// the sitemap must contain the home urls in all languages
-		$this->assertNotFalse( strpos( $output, '<loc>' . home_url( '/?lang=en' ) . '</loc>' ) );
-		$this->assertNotFalse( strpos( $output, '<loc>' . home_url( '/?lang=fr' ) . '</loc>' ) );
-	}
-
-	function test_category_sitemap_for_code_in_url() {
-		$en = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $en, 'en' );
-		$post_id = $this->factory->post->create(); // by default, the sitemap hides empty categories
-		self::$polylang->model->post->set_language( $post_id, 'en' );
-		wp_set_post_terms( $post_id, array( $en ), 'category' );
-
-		$fr = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $fr, 'fr' );
-		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
-		wp_set_post_terms( $post_id, array( $fr ), 'category' );
-
-		$sm = new WPSEO_Sitemaps_Double();
-		set_query_var( 'sitemap', 'category' );
-		$GLOBALS['wp_query']->query['sitemap'] = 'category'; // FIXME isn't that too hacky?
-
-		ob_start();
-		$sm->redirect( $GLOBALS['wp_the_query'] );
-		$output = ob_get_clean();
-
-		$en = htmlspecialchars( get_category_link( $en ) ); // WPSEO uses htmlspecialchars
-		$fr = htmlspecialchars( get_category_link( $fr ) );
-
-		// the sitemap must contain all languages
-		$this->assertNotFalse( strpos( $output, "<loc>$en</loc>" ) );
-		$this->assertNotFalse( strpos( $output, "<loc>$fr</loc>" ) );
-	}
-
-	function test_post_sitemap_for_subdomains() {
-		// FIXME The test works alone but static vars in Yoast SEO make it conclict with test_post_sitemap_for_code_in_url()
-		// See https://github.com/Yoast/wordpress-seo/issues/6926
-		$this->markTestSkipped();
-
-		global $wp_rewrite;
-
-		// setup subdomains
-		$this->hosts = array(
-			'en' => 'http://example.org',
-			'fr' => 'http://fr.example.org',
-		);
-
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['force_lang'] = 2;
-
-		// switch to pretty permalinks
-		$wp_rewrite->init();
-		$wp_rewrite->set_permalink_structure( $this->structure );
-
-		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
-		create_initial_taxonomies();
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
-
-		$wp_rewrite->flush_rules();
-
-		// init frontend
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		do_action( 'pll_language_defined' );
-
-		// de-activate cache for links
-		self::$polylang->links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		self::$polylang->links->cache->method( 'get' )->willReturn( false );
-		self::$polylang->filters_links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		self::$polylang->filters_links->cache->method( 'get' )->willReturn( false );
-
-		// create posts
-		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
-
-		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-
-		$this->go_to( $this->hosts['fr'] . '/post-sitemap.xml' );
-		$sm = new WPSEO_Sitemaps_Double();
-		set_query_var( 'sitemap', 'post' );
-
-		ob_start();
-		$sm->redirect( $GLOBALS['wp_the_query'] );
-		$output = ob_get_clean();
-
-		$en = htmlspecialchars( get_permalink( $en ) ); // WPSEO uses htmlspecialchars
-		$fr = htmlspecialchars( get_permalink( $fr ) );
-
-		// the sitemap must contain only one language
-		$this->assertNotFalse( strpos( $output, '<loc>' . $this->hosts['fr'] . '</loc>' ) );
-		$this->assertNotFalse( strpos( $output, "<loc>$fr</loc>" ) );
-		$this->assertFalse( strpos( $output, "<loc>$en</loc>" ) );
-	}
-}
 
 } // file_exists

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -11,53 +11,53 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 		self::create_language( 'es_ES' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = self::factory()->user->create( [ 'role' => 'editor' ] );
 	}
 
 	function setUp() {
 		parent::setUp();
 
 		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang ); // To activate the fix_delete_default_category() filter
+		self::$polylang               = new PLL_Admin( self::$polylang->links_model );
+		self::$polylang->filters      = new PLL_Admin_Filters( self::$polylang ); // To activate the fix_delete_default_category() filter
 		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang );
 	}
 
 	function tearDown() {
 		parent::tearDown();
 
-		$_REQUEST = $_GET = $_POST = array();
+		$_REQUEST = $_GET = $_POST = [];
 	}
 
 	function test_default_language() {
 		// User preferred language
 		self::$polylang->pref_lang = self::$polylang->model->get_language( 'fr' );
-		$term_id = $this->factory->category->create();
+		$term_id                   = $this->factory->category->create();
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $term_id )->slug );
 
 		// Language set from parent
 		$parent = $this->factory->category->create();
 		self::$polylang->model->term->set_language( $parent, 'de' );
-		$term_id = $this->factory->category->create( array( 'parent' => $parent ) );
+		$term_id = $this->factory->category->create( [ 'parent' => $parent ] );
 		$this->assertEquals( 'de', self::$polylang->model->term->get_language( $term_id )->slug );
 	}
 
 	function test_save_term_from_edit_tags() {
-		$_REQUEST = $_POST = array(
+		$_REQUEST = $_POST = [
 			'action'           => 'add-tag',
 			'term_lang_choice' => 'en',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
-		);
-		$en = $this->factory->category->create();
+		];
+		$en       = $this->factory->category->create();
 		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $en )->slug );
 
 		// Set the language and translations
-		$_REQUEST = $_POST = array(
+		$_REQUEST = $_POST = [
 			'action'           => 'add-tag',
 			'post_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
-			'term_tr_lang'     => array( 'en' => $en ),
-		);
+			'term_tr_lang'     => [ 'en' => $en ],
+		];
 
 		$fr = $this->factory->category->create();
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr )->slug );
@@ -65,11 +65,11 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_create_term_from_categories_metabox() {
-		$_REQUEST = $_POST = array(
+		$_REQUEST = $_POST = [
 			'action'                   => 'add-category',
 			'term_lang_choice'         => 'fr',
 			'_ajax_nonce-add-category' => wp_create_nonce( 'add-category' ),
-		);
+		];
 
 		$fr = $this->factory->category->create();
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr )->slug );
@@ -89,11 +89,11 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		// Post quick edit
 		// + the language is free in the translation group
-		$_REQUEST = $_POST = array(
+		$_REQUEST = $_POST = [
 			'action'             => 'inline-save',
 			'inline_lang_choice' => 'fr',
 			'_inline_edit'       => wp_create_nonce( 'inlineeditnonce' ),
-		);
+		];
 
 		wp_update_term( $fr = $term_id, 'category' );
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $term_id )->slug );
@@ -101,16 +101,16 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		// edit-tags quick edit
 		// + the language is *not* free in the translation group
-		$_REQUEST = $_POST = array(
+		$_REQUEST = $_POST = [
 			'action'             => 'inline-save-tax',
 			'inline_lang_choice' => 'de',
 			'_inline_edit'       => wp_create_nonce( 'taxinlineeditnonce' ),
-		);
+		];
 
 		wp_update_term( $term_id, 'category' );
 		$this->assertEquals( 'de', self::$polylang->model->term->get_language( $term_id )->slug );
 		$this->assertEqualSetsWithIndex( compact( 'de', 'es' ), self::$polylang->model->term->get_translations( $es ) );
-		$this->assertEquals( array( 'de' => $term_id ), self::$polylang->model->term->get_translations( $term_id ) );
+		$this->assertEquals( [ 'de' => $term_id ], self::$polylang->model->term->get_translations( $term_id ) );
 	}
 
 	function test_create_term_from_post_bulk_edit() {
@@ -120,31 +120,31 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		self::$polylang->model->post->set_language( $posts[0], 'en' );
 		self::$polylang->model->post->set_language( $posts[1], 'fr' );
 
-		$test_tag = $this->factory->tag->create( array( 'name' => 'test_tag' ) );
+		$test_tag = $this->factory->tag->create( [ 'name' => 'test_tag' ] );
 		self::$polylang->model->term->set_language( $test_tag, 'fr' );
 
 		// First do not modify any language
-		$_REQUEST = $_GET = array(
+		$_REQUEST = $_GET = [
 			'inline_lang_choice' => -1,
 			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),
 			'bulk_edit'          => 'Update',
 			'post'               => $posts,
 			'_status'            => 'publish',
-			'tax_input'          => array( 'post_tag' => 'new_tag,test_tag' ),
-		);
+			'tax_input'          => [ 'post_tag' => 'new_tag,test_tag' ],
+		];
 		do_action( 'load-edit.php' );
 		$done = bulk_edit_posts( $_REQUEST );
 
 		$tags_en = wp_get_post_tags( $posts[0] );
-		$new_en = wp_filter_object_list( $tags_en, array( 'name' => 'new_tag' ), 'AND', 'term_id' );
-		$new_en = reset( $new_en );
-		$test_en = wp_filter_object_list( $tags_en, array( 'name' => 'test_tag' ), 'AND', 'term_id' );
+		$new_en  = wp_filter_object_list( $tags_en, [ 'name' => 'new_tag' ], 'AND', 'term_id' );
+		$new_en  = reset( $new_en );
+		$test_en = wp_filter_object_list( $tags_en, [ 'name' => 'test_tag' ], 'AND', 'term_id' );
 		$test_en = reset( $test_en );
 
 		$tags_fr = wp_get_post_tags( $posts[1] );
-		$new_fr = wp_filter_object_list( $tags_fr, array( 'name' => 'new_tag' ), 'AND', 'term_id' );
-		$new_fr = reset( $new_fr );
-		$test_fr = wp_filter_object_list( $tags_fr, array( 'name' => 'test_tag' ), 'AND', 'term_id' );
+		$new_fr  = wp_filter_object_list( $tags_fr, [ 'name' => 'new_tag' ], 'AND', 'term_id' );
+		$new_fr  = reset( $new_fr );
+		$test_fr = wp_filter_object_list( $tags_fr, [ 'name' => 'test_tag' ], 'AND', 'term_id' );
 		$test_fr = reset( $test_fr );
 
 		$this->assertEquals( $test_tag, $test_fr );
@@ -152,26 +152,36 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $test_fr )->slug );
 		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $new_en )->slug );
 		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $test_en )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $new_en, 'fr' => $new_fr ), self::$polylang->model->term->get_translations( $new_en ) );
-		$this->assertEqualSetsWithIndex( array( 'en' => $test_en, 'fr' => $test_fr ), self::$polylang->model->term->get_translations( $test_en ) );
+		$this->assertEqualSetsWithIndex(
+			[
+				'en' => $new_en,
+				'fr' => $new_fr,
+			], self::$polylang->model->term->get_translations( $new_en )
+		);
+		$this->assertEqualSetsWithIndex(
+			[
+				'en' => $test_en,
+				'fr' => $test_fr,
+			], self::$polylang->model->term->get_translations( $test_en )
+		);
 
 		// Second modify all languages
 		$_GET['inline_lang_choice'] = $_REQUEST['inline_lang_choice'] = 'fr';
-		$_GET['tax_input']  = $_REQUEST['tax_input'] = array( 'post_tag' => 'third_tag' );
+		$_GET['tax_input']          = $_REQUEST['tax_input'] = [ 'post_tag' => 'third_tag' ];
 		do_action( 'load-edit.php' );
 		$done = bulk_edit_posts( $_REQUEST );
 
-		$tags = wp_get_post_tags( $posts[0] );
-		$third = wp_filter_object_list( $tags, array( 'name' => 'third_tag' ), 'AND', 'term_id' );
+		$tags  = wp_get_post_tags( $posts[0] );
+		$third = wp_filter_object_list( $tags, [ 'name' => 'third_tag' ], 'AND', 'term_id' );
 		$third = reset( $third );
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $third )->slug );
 
 		$tags = wp_list_pluck( $tags, 'term_id' );
-		$this->assertEqualSets( array( $new_fr, $test_fr, $third ), $tags );
+		$this->assertEqualSets( [ $new_fr, $test_fr, $third ], $tags );
 
 		$tags = wp_get_post_tags( $posts[1] );
 		$tags = wp_list_pluck( $tags, 'term_id' );
-		$this->assertEqualSets( array( $new_fr, $test_fr, $third ), $tags );
+		$this->assertEqualSets( [ $new_fr, $test_fr, $third ], $tags );
 	}
 
 	function test_delete_term() {
@@ -198,11 +208,11 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	function get_edit_term_form( $tag_ID, $taxonomy ) {
 		// Prepare all needed info before loading the entire form
 		$GLOBALS['post_type'] = 'post';
-		$tax = get_taxonomy( $taxonomy );
-		$_REQUEST['tag_ID'] = $_GET['tag_ID'] = $tag_ID;
-		$tag = get_term( $tag_ID, $taxonomy, OBJECT, 'edit' );
-		$wp_http_referer = home_url( '/wp-admin/edit-tags.php?taxonomy=category' );
-		$message = '';
+		$tax                  = get_taxonomy( $taxonomy );
+		$_REQUEST['tag_ID']   = $_GET['tag_ID'] = $tag_ID;
+		$tag                  = get_term( $tag_ID, $taxonomy, OBJECT, 'edit' );
+		$wp_http_referer      = home_url( '/wp-admin/edit-tags.php?taxonomy=category' );
+		$message              = '';
 		set_current_screen( 'edit-tags' );
 		$GLOBALS['pagenow'] = 'term.php'; // WP 4.5+
 		self::$polylang->set_current_language();
@@ -213,13 +223,23 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_parent_dropdown_in_edit_tags() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$tag_ID = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$tag_ID = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $tag_ID, 'fr' );
 
 		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
@@ -230,14 +250,14 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		// The admin language filter must have no impact
 		self::$polylang->pref_lang = self::$polylang->filter_lang = self::$polylang->model->get_language( 'en' );
-		$form = $this->get_edit_term_form( $tag_ID, 'category' );
+		$form                      = $this->get_edit_term_form( $tag_ID, 'category' );
 		$this->assertFalse( strpos( $form, 'test' ) );
 		$this->assertNotFalse( strpos( $form, 'essai' ) );
 		self::$polylang->filter_lang = false;
 
 		// Even when we just activated the admin language filter
 		$_REQUEST['lang'] = $_GET['lang'] = 'en';
-		$form = $this->get_edit_term_form( $tag_ID, 'category' );
+		$form             = $this->get_edit_term_form( $tag_ID, 'category' );
 		$this->assertFalse( strpos( $form, 'test' ) );
 		$this->assertNotFalse( strpos( $form, 'essai' ) );
 
@@ -245,10 +265,20 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_language_dropdown_and_translations_in_edit_tags() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
@@ -258,7 +288,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$lang = self::$polylang->model->get_language( 'fr' );
 		$form = $this->get_edit_term_form( $fr, 'category' );
 		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
-		$doc = new DomDocument();
+		$doc  = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 
@@ -276,10 +306,10 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
 
 		$default = self::$polylang->model->term->get( get_option( 'default_category' ), 'de' );
-		$de = self::$polylang->model->get_language( 'de' );
-		$form = $this->get_edit_term_form( $default, 'category' );
-		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
-		$doc = new DomDocument();
+		$de      = self::$polylang->model->get_language( 'de' );
+		$form    = $this->get_edit_term_form( $default, 'category' );
+		$form    = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$doc     = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 
@@ -301,7 +331,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		// So let's copy paste WP 4.4 code:
 		ob_start();
-		$dropdown_args = array(
+		$dropdown_args = [
 			'hide_empty'       => 0,
 			'hide_if_empty'    => false,
 			'taxonomy'         => $taxonomy,
@@ -309,7 +339,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'orderby'          => 'name',
 			'hierarchical'     => true,
 			'show_option_none' => __( 'None' ),
-		);
+		];
 
 		// FIXME this filter is available since WP 4.2 and is worth looking at ( could simplify get_queried_language? )
 		$dropdown_args = apply_filters( 'taxonomy_parent_dropdown_args', $dropdown_args, $taxonomy, 'new' );
@@ -320,15 +350,30 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 	function test_parent_dropdown_in_new_tag() {
 		self::$polylang->pref_lang = self::$polylang->model->get_language( 'en' );
-		$_GET['taxonomy'] = 'category';
+		$_GET['taxonomy']          = 'category';
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$child = $this->factory->term->create( array( 'taxonomy' => 'category', 'parent' => $en ) );
+		$child = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'parent' => $en,
+			]
+		);
 
 		$GLOBALS['pagenow'] = 'edit-tags.php';
 		self::$polylang->set_current_language();
@@ -338,11 +383,11 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $dropdown, '<option class="level-0" value="' . $fr . '">essai</option>' ) );
 		$this->assertFalse( strpos( $dropdown, 'selected' ) );
 
-		$_GET = array(
+		$_GET = [
 			'taxonomy' => 'category',
 			'new_lang' => 'fr',
 			'from_tag' => $child,
-		);
+		];
 		self::$polylang->set_current_language();
 		$dropdown = $this->get_parent_dropdown_in_new_term_form( 'category' );
 
@@ -359,21 +404,26 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_language_dropdown_and_translations_in_new_tags() {
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
 		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
 
-		$_GET['taxonomy'] = 'category';
+		$_GET['taxonomy']     = 'category';
 		$GLOBALS['post_type'] = 'post';
-		$lang = self::$polylang->pref_lang = self::$polylang->model->get_language( 'en' );
+		$lang                 = self::$polylang->pref_lang = self::$polylang->model->get_language( 'en' );
 		self::$polylang->set_current_language();
 
 		ob_start();
 		do_action( 'category_add_form_fields' );
 		$form = ob_get_clean();
 		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
-		$doc = new DomDocument();
+		$doc  = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 
@@ -394,7 +444,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		do_action( 'category_add_form_fields' );
 		$form = ob_get_clean();
 		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
-		$doc = new DomDocument();
+		$doc  = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 
@@ -413,31 +463,46 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_new_default_category() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'new-default' ) );
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'new-default',
+			]
+		);
 		update_option( 'default_category', $term_id );
 
 		$this->assertEquals( $term_id, get_option( 'default_category' ) );
 		$translations = self::$polylang->model->term->get_translations( $term_id );
-		$this->assertEqualSets( array( 'en', 'fr', 'de', 'es' ), array_keys( $translations ) );
+		$this->assertEqualSets( [ 'en', 'fr', 'de', 'es' ], array_keys( $translations ) );
 	}
 
 	function test_post_categories_meta_box() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
 		$post = $this->factory->post->create_and_get();
 		self::$polylang->model->post->set_language( $post->ID, 'fr' );
 
-		$_GET['post'] = $post->ID;
+		$_GET['post']       = $post->ID;
 		$GLOBALS['pagenow'] = 'post.php';
 		self::$polylang->set_current_language();
 		require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
 
 		ob_start();
-		post_categories_meta_box( $post, array() );
+		post_categories_meta_box( $post, [] );
 		$out = ob_get_clean();
 
 		$this->assertFalse( strpos( $out, 'test' ) );
@@ -447,10 +512,20 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_nav_menu_item_taxonomy_meta_box() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
 		require_once ABSPATH . 'wp-admin/includes/nav-menu.php';
@@ -477,25 +552,49 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_get_terms_language_filter() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$es = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$es = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 		self::$polylang->model->term->set_language( $es, 'es' );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
-		$this->assertEqualSets( array( $en ), $terms );
+		$terms = get_terms(
+			'post_tag', [
+				'fields' => 'ids',
+				'hide_empty' => false,
+				'lang' => 'en',
+			]
+		);
+		$this->assertEqualSets( [ $en ], $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'en', 'fr' ) ) );
-		$this->assertEqualSets( array( $fr, $en ), $terms );
+		$terms = get_terms(
+			'post_tag', [
+				'fields' => 'ids',
+				'hide_empty' => false,
+				'lang' => [ 'en', 'fr' ],
+			]
+		);
+		$this->assertEqualSets( [ $fr, $en ], $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 0 ) );
-		$this->assertEqualSets( array( $en, $fr, $es ), $terms );
+		$terms = get_terms(
+			'post_tag', [
+				'fields' => 'ids',
+				'hide_empty' => false,
+				'lang' => 0,
+			]
+		);
+		$this->assertEqualSets( [ $en, $fr, $es ], $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
-		$this->assertEqualSets( array( $en, $fr ), $terms );
+		$terms = get_terms(
+			'post_tag', [
+				'fields' => 'ids',
+				'hide_empty' => false,
+				'lang' => 'en,fr',
+			]
+		);
+		$this->assertEqualSets( [ $en, $fr ], $terms );
 	}
 }

--- a/tests/phpunit/tests/test-admin-filters.php
+++ b/tests/phpunit/tests/test-admin-filters.php
@@ -33,7 +33,7 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 	}
 
 	function test_personal_options_update() {
-		$_POST['user_lang'] = 'en_US'; // Backward compatibility with WP < 4.7
+		$_POST['user_lang']      = 'en_US'; // Backward compatibility with WP < 4.7
 		$_POST['description_de'] = 'Biography in German';
 		remove_action( 'personal_options_update', 'send_confirmation_on_profile_email' );
 		do_action( 'personal_options_update', 1 );

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -10,13 +10,13 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 	}
 
 	function update_language( $lang, $args ) {
-		foreach ( array( 'name', 'slug', 'locale', 'term_group' ) as $key ) {
+		foreach ( [ 'name', 'slug', 'locale', 'term_group' ] as $key ) {
 			$defaults[ $key ] = $lang->$key;
 		}
-		$args['rtl'] = $lang->is_rtl;
-		$args['flag'] = $lang->flag_code;
+		$args['rtl']     = $lang->is_rtl;
+		$args['flag']    = $lang->flag_code;
 		$args['lang_id'] = $lang->term_id;
-		$args = wp_parse_args( $args, $defaults );
+		$args            = wp_parse_args( $args, $defaults );
 		self::$polylang->model->update_language( $args );
 		unset( $GLOBALS['wp_settings_errors'] ); // clean "errors"
 	}
@@ -30,12 +30,12 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$this->update_language( self::$polylang->model->get_language( 'en' ), array( 'slug' => 'eng' ) );
+		$this->update_language( self::$polylang->model->get_language( 'en' ), [ 'slug' => 'eng' ] );
 		$this->assertFalse( self::$polylang->model->get_language( 'en' ) );
 		$this->assertEquals( 'eng', self::$polylang->options['default_lang'] );
 		$this->assertEquals( 'eng', self::$polylang->model->post->get_language( $en )->slug );
 
-		$this->update_language( self::$polylang->model->get_language( 'fr' ), array( 'slug' => 'fra' ) );
+		$this->update_language( self::$polylang->model->get_language( 'fr' ), [ 'slug' => 'fra' ] );
 		$this->assertEquals( $fr, self::$polylang->model->post->get( $en, 'fra' ) );
 		$this->assertEquals( $en, self::$polylang->model->post->get( $fr, 'eng' ) );
 
@@ -54,27 +54,27 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		self::$polylang->model->post->set_language( $post_id, 'fr' );
 
 		// 2 posts in non translated post types
-		$this->factory->post->create( array( 'post_type' => 'nav_menu_item' ) );
-		$this->factory->post->create( array( 'post_type' => 'cpt' ) );
+		$this->factory->post->create( [ 'post_type' => 'nav_menu_item' ] );
+		$this->factory->post->create( [ 'post_type' => 'cpt' ] );
 
 		// 2 posts without language
 		$expected['posts'][] = $this->factory->post->create();
-		$expected['posts'][] = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$expected['posts'][] = $this->factory->post->create( [ 'post_type' => 'page' ] );
 
 		// 2 terms with language
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $term_id, 'en' );
 
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 		self::$polylang->model->term->set_language( $term_id, 'fr' );
 
 		// 2 terms in non translated taxonomies
-		$this->factory->term->create( array( 'taxonomy' => 'nav_menu' ) );
-		$this->factory->term->create( array( 'taxonomy' => 'tax' ) );
+		$this->factory->term->create( [ 'taxonomy' => 'nav_menu' ] );
+		$this->factory->term->create( [ 'taxonomy' => 'tax' ] );
 
 		// 2 terms without language
-		$expected['terms'][] = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		$expected['terms'][] = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$expected['terms'][] = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
+		$expected['terms'][] = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 
 		$nolang = self::$polylang->model->get_objects_with_no_lang();
 
@@ -87,20 +87,30 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 	}
 
 	function test_set_language_in_mass_for_posts() {
-		foreach ( $this->factory->post->create_many( 2, array() ) as $p ) {
+		foreach ( $this->factory->post->create_many( 2, [] ) as $p ) {
 			self::$polylang->model->post->set_language( $p, 'en' );
 		}
 
-		foreach ( $this->factory->post->create_many( 2, array() ) as $p ) {
+		foreach ( $this->factory->post->create_many( 2, [] ) as $p ) {
 			self::$polylang->model->post->set_language( $p, 'fr' );
 		}
 
 		$posts = $this->factory->post->create_many( 2 );
 		self::$polylang->model->set_language_in_mass( 'post', $posts, 'fr' );
 
-		$posts = get_posts( array( 'fields' => 'ids', 'posts_per_page' => -1 ) );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->post, 'get_language' ), $posts ), 'slug' );
-		$this->assertEquals( array( 'fr' => 4, 'en' => 2 ), array_count_values( $languages ) );
+		$posts     = get_posts(
+			[
+				'fields' => 'ids',
+				'posts_per_page' => -1,
+			]
+		);
+		$languages = wp_list_pluck( array_map( [ self::$polylang->model->post, 'get_language' ], $posts ), 'slug' );
+		$this->assertEquals(
+			[
+				'fr' => 4,
+				'en' => 2,
+			], array_count_values( $languages )
+		);
 		$this->assertEmpty( get_terms( 'post_translations' ) ); // no translation group for posts
 	}
 
@@ -116,9 +126,19 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		$tags = $this->factory->tag->create_many( 2 );
 		self::$polylang->model->set_language_in_mass( 'term', $tags, 'fr' );
 
-		$terms = get_terms( 'post_tag', array( 'hide_empty' => false, 'fields' => 'ids' ) );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->term, 'get_language' ), $terms ), 'slug' );
-		$this->assertEquals( array( 'fr' => 4, 'en' => 2 ), array_count_values( $languages ) );
+		$terms     = get_terms(
+			'post_tag', [
+				'hide_empty' => false,
+				'fields' => 'ids',
+			]
+		);
+		$languages = wp_list_pluck( array_map( [ self::$polylang->model->term, 'get_language' ], $terms ), 'slug' );
+		$this->assertEquals(
+			[
+				'fr' => 4,
+				'en' => 2,
+			], array_count_values( $languages )
+		);
 		$this->assertCount( 7, get_terms( 'term_translations' ) ); // one translation group per tag + 1 for default categories
 	}
 }

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -26,13 +26,23 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	function test_deactivate_editor_for_page_for_posts() {
-		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
+		$en = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_content' => '',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', $en );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) ); // Content must be empty to deactivate editor.
+		$fr = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_content' => '',
+			]
+		); // Content must be empty to deactivate editor.
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
@@ -49,19 +59,34 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 
 	// Bug introduced in 2.2.2 and fixed in 2.2.3
 	function test_editor_on_page() {
-		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
+		$en = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_content' => '',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', $en );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) ); // Content must be empty to deactivate editor.
+		$fr = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_content' => '',
+			]
+		); // Content must be empty to deactivate editor.
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		self::$polylang->model->clean_languages_cache();
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) ); // Content must be empty to deactivate editor.
+		$fr = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_content' => '',
+			]
+		); // Content must be empty to deactivate editor.
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );

--- a/tests/phpunit/tests/test-ajax-columns.php
+++ b/tests/phpunit/tests/test-ajax-columns.php
@@ -9,7 +9,7 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = self::factory()->user->create( [ 'role' => 'editor' ] );
 	}
 
 	function setUp() {
@@ -17,7 +17,7 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		self::$polylang->links           = new PLL_Admin_Links( self::$polylang );
 		self::$polylang->filters_columns = new PLL_Admin_Filters_Columns( self::$polylang );
 	}
 
@@ -36,14 +36,14 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$_POST = array(
+		$_POST = [
 			'action'       => 'pll_update_post_rows',
 			'post_id'      => $en,
 			'translations' => $fr,
 			'post_type'    => 'post',
 			'screen'       => 'edit-post',
 			'_pll_nonce'   => wp_create_nonce( 'inlineeditnonce', '_inline_edit' ),
-		);
+		];
 
 		try {
 			$this->_handleAjax( 'pll_update_post_rows' );
@@ -96,7 +96,7 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$_POST = array(
+		$_POST = [
 			'action'       => 'pll_update_term_rows',
 			'term_id'      => $en,
 			'translations' => $fr,
@@ -104,7 +104,7 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 			'post_type'    => 'post',
 			'screen'       => 'edit-category',
 			'_pll_nonce'   => wp_create_nonce( 'pll_language', '_pll_nonce' ),
-		);
+		];
 
 		try {
 			$this->_handleAjax( 'pll_update_term_rows' );

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -10,7 +10,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		self::create_language( 'fr_FR' );
 		self::create_language( 'es_ES' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = self::factory()->user->create( [ 'role' => 'editor' ] );
 	}
 
 	function setUp() {
@@ -18,9 +18,9 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
+		self::$polylang               = new PLL_Admin( self::$polylang->links_model );
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		self::$polylang->links        = new PLL_Admin_Links( self::$polylang );
 	}
 
 	function tearDown() {
@@ -33,25 +33,35 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang ); // we need this for categories and tags
 
 		// categories
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test cat' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test cat',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai cat' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai cat',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		// the post
 		$post_id = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
-		$_POST = array(
+		$_POST = [
 			'action'      => 'post_lang_choice',
 			'_pll_nonce'  => wp_create_nonce( 'pll_language' ),
 			'lang'        => 'fr',
 			'post_type'   => 'post',
 			'post_id'     => $post_id,
 			'pll_post_id' => $post_id,
-			'taxonomies'  => array( 'category', 'post_tag' ),
-		);
+			'taxonomies'  => [ 'category', 'post_tag' ],
+		];
 
 		$_REQUEST['lang'] = $_POST['lang'];
 		self::$polylang->set_current_language();
@@ -65,7 +75,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		// translations
 		$form = $xml->response[0]->translations->response_data;
-		$doc = new DomDocument();
+		$doc  = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 
@@ -87,24 +97,34 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang ); // we need this for the pages dropdown
 
 		// possible parents
-		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
+		$en = $this->factory->post->create(
+			[
+				'post_title' => 'test',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai', 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_title' => 'essai',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		// the post
-		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
-		$_POST = array(
+		$_POST = [
 			'action'      => 'post_lang_choice',
 			'_pll_nonce'  => wp_create_nonce( 'pll_language' ),
 			'lang'        => 'fr',
 			'post_type'   => 'page',
 			'post_id'     => $post_id,
 			'pll_post_id' => $post_id,
-		);
+		];
 
 		$_REQUEST['lang'] = $_POST['lang'];
 		self::$polylang->set_current_language();
@@ -118,7 +138,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		// translations
 		$form = $xml->response[0]->translations->response_data;
-		$doc = new DomDocument();
+		$doc  = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 
@@ -137,21 +157,21 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 	}
 
 	function test_posts_not_translated() {
-		$en = $this->factory->post->create( array( 'post_title' => 'test english' ) );
+		$en = $this->factory->post->create( [ 'post_title' => 'test english' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'test français' ) );
+		$fr = $this->factory->post->create( [ 'post_title' => 'test français' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$searched = $this->factory->post->create( array( 'post_title' => 'test searched' ) );
+		$searched = $this->factory->post->create( [ 'post_title' => 'test searched' ] );
 		self::$polylang->model->post->set_language( $searched, 'en' );
 
 		$fr = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
-		$_GET = array(
+		$_GET = [
 			'action'               => 'pll_posts_not_translated',
 			'_pll_nonce'           => wp_create_nonce( 'pll_language' ),
 			'term'                 => 'tes',
@@ -159,7 +179,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 			'translation_language' => 'en',
 			'post_type'            => 'post',
 			'pll_post_id'          => $fr,
-		);
+		];
 
 		self::$polylang->set_current_language();
 
@@ -188,7 +208,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		}
 
 		$this->assertCount( 2, $response );
-		$this->assertEqualSets( array( $searched, $en ), wp_list_pluck( $response, 'id' ) );
+		$this->assertEqualSets( [ $searched, $en ], wp_list_pluck( $response, 'id' ) );
 	}
 
 	function test_save_post_from_quick_edit() {
@@ -201,12 +221,12 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'es' ) );
 
 		// Switch to a free language in the translation group
-		$_REQUEST = $_POST = array(
+		$_REQUEST = $_POST = [
 			'action'             => 'inline-save',
 			'post_ID'            => $post_id,
 			'inline_lang_choice' => 'fr',
 			'_inline_edit'       => wp_create_nonce( 'inlineeditnonce' ),
-		);
+		];
 
 		try {
 			$this->_handleAjax( 'inline-save' );
@@ -216,8 +236,18 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $post_id )->slug );
 		$this->assertEquals( 'es', self::$polylang->model->post->get_language( $es )->slug );
-		$this->assertEqualSets( array( 'fr' => $post_id, 'es' => $es ), self::$polylang->model->post->get_translations( $post_id ) );
-		$this->assertEqualSets( array( 'fr' => $post_id, 'es' => $es ), self::$polylang->model->post->get_translations( $es ) );
+		$this->assertEqualSets(
+			[
+				'fr' => $post_id,
+				'es' => $es,
+			], self::$polylang->model->post->get_translations( $post_id )
+		);
+		$this->assertEqualSets(
+			[
+				'fr' => $post_id,
+				'es' => $es,
+			], self::$polylang->model->post->get_translations( $es )
+		);
 
 		// Switch to a *non* free language in the translation group
 		$_REQUEST['inline_lang_choice'] = $_POST['inline_lang_choice'] = 'es';
@@ -230,13 +260,13 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		$this->assertEquals( 'es', self::$polylang->model->post->get_language( $post_id )->slug );
 		$this->assertEquals( 'es', self::$polylang->model->post->get_language( $es )->slug );
-		$this->assertEquals( array( 'es' => $post_id ), self::$polylang->model->post->get_translations( $post_id ) );
+		$this->assertEquals( [ 'es' => $post_id ], self::$polylang->model->post->get_translations( $post_id ) );
 
 		// For some reason the last assertion does not work in WP < 4.6
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
 			$this->markTestIncomplete();
 		}
 
-		$this->assertEquals( array( 'es' => $es ), self::$polylang->model->post->get_translations( $es ) );
+		$this->assertEquals( [ 'es' => $es ], self::$polylang->model->post->get_translations( $es ) );
 	}
 }

--- a/tests/phpunit/tests/test-ajax-filters-term.php
+++ b/tests/phpunit/tests/test-ajax-filters-term.php
@@ -9,7 +9,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = self::factory()->user->create( [ 'role' => 'editor' ] );
 	}
 
 	function setUp() {
@@ -17,9 +17,9 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
+		self::$polylang               = new PLL_Admin( self::$polylang->links_model );
 		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang );
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		self::$polylang->links        = new PLL_Admin_Links( self::$polylang );
 	}
 
 	function tearDown() {
@@ -30,23 +30,33 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 	function test_term_lang_choice_in_edit_category() {
 		// possible parents
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test cat' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test cat',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai cat' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai cat',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		// the category
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 
-		$_POST = array(
+		$_POST = [
 			'action'     => 'term_lang_choice',
 			'_pll_nonce' => wp_create_nonce( 'pll_language' ),
 			'lang'       => 'fr',
 			'post_type'  => 'post',
 			'taxonomy'   => 'category',
 			'term_id'    => $term_id,
-		);
+		];
 
 		$_REQUEST['lang'] = $_POST['lang'];
 		self::$polylang->set_current_language();
@@ -60,7 +70,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 		// translations
 		$form = $xml->response[0]->translations->response_data;
-		$doc = new DomDocument();
+		$doc  = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 
@@ -78,26 +88,36 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 	function test_term_lang_choice_in_new_tag() {
 		// possible parents
-		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		// we need posts for the tag cloud
-		$this->factory->post->create( array( 'tags_input' => 'test' ) );
-		$this->factory->post->create( array( 'tags_input' => 'essai' ) );
+		$this->factory->post->create( [ 'tags_input' => 'test' ] );
+		$this->factory->post->create( [ 'tags_input' => 'essai' ] );
 
 		// the post_tag
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 
-		$_POST = array(
+		$_POST = [
 			'action'     => 'term_lang_choice',
 			'_pll_nonce' => wp_create_nonce( 'pll_language' ),
 			'lang'       => 'fr',
 			'post_type'  => 'post',
 			'taxonomy'   => 'post_tag',
-		);
+		];
 
 		$_REQUEST['lang'] = $_POST['lang'];
 		self::$polylang->set_current_language();
@@ -111,7 +131,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 		// translations
 		$form = $xml->response[0]->translations->response_data;
-		$doc = new DomDocument();
+		$doc  = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 
@@ -130,21 +150,36 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 
 	function test_terms_not_translated() {
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test cat' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test cat',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai cat' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai cat',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$searched = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test searched' ) );
+		$searched = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test searched',
+			]
+		);
 		self::$polylang->model->term->set_language( $searched, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$_GET = array(
+		$_GET = [
 			'action'               => 'pll_terms_not_translated',
 			'_pll_nonce'           => wp_create_nonce( 'pll_language' ),
 			'term'                 => 'tes',
@@ -153,7 +188,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 			'post_type'            => 'post',
 			'taxonomy'             => 'category',
 			'term_id'              => $fr,
-		);
+		];
 
 		self::$polylang->set_current_language();
 
@@ -168,7 +203,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertEquals( $searched, $response[0]['id'] );
 
 		// translate the current term
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
@@ -182,6 +217,6 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		}
 
 		$this->assertCount( 2, $response );
-		$this->assertEqualSets( array( $searched, $en ), wp_list_pluck( $response, 'id' ) );
+		$this->assertEqualSets( [ $searched, $en ], wp_list_pluck( $response, 'id' ) );
 	}
 }

--- a/tests/phpunit/tests/test-ajax-on-front.php
+++ b/tests/phpunit/tests/test-ajax-on-front.php
@@ -38,7 +38,7 @@ class Ajax_On_Front_Test extends PLL_Ajax_UnitTestCase {
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 		new PLL_Frontend_Filters( self::$polylang );
 
-		add_action( 'wp_ajax_test_locale', array( $this, '_ajax_test_locale' ) );
+		add_action( 'wp_ajax_test_locale', [ $this, '_ajax_test_locale' ] );
 
 		$_REQUEST['action'] = 'test_locale';
 

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -12,19 +12,24 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		self::$polylang->options['post_types'] = array(
+		self::$polylang->options['post_types'] = [
 			'trcpt' => 'trcpt',
-		);
-		self::$polylang->options['taxonomies'] = array(
+		];
+		self::$polylang->options['taxonomies'] = [
 			'trtax' => 'trtax',
-		);
+		];
 
-		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // translated custom post type with archives
+		register_post_type(
+			'trcpt', [
+				'public' => true,
+				'has_archive' => true,
+			]
+		); // translated custom post type with archives
 		register_taxonomy( 'trtax', 'trcpt' ); // translated custom tax
 
 		self::$polylang->auto_translate = new PLL_Frontend_Auto_Translate( self::$polylang );
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		self::$polylang->filters = new PLL_Frontend_Filters( self::$polylang );
+		self::$polylang->curlang        = self::$polylang->model->get_language( 'fr' );
+		self::$polylang->filters        = new PLL_Frontend_Filters( self::$polylang );
 	}
 
 	function tearDown() {
@@ -35,128 +40,209 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 	}
 
 	function test_category() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$post_fr = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $post_fr, 'fr' );
-		wp_set_post_terms( $post_fr, array( $fr ), 'category' );
+		wp_set_post_terms( $post_fr, [ $fr ], 'category' );
 
 		$post_en = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $post_en, 'en' );
-		wp_set_post_terms( $post_en, array( $en ), 'category' );
+		wp_set_post_terms( $post_en, [ $en ], 'category' );
 
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'cat' => $en ) ) );
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'category_name' => 'test' ) ) );
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'category__in' => array( $en ) ) ) );
+		$this->assertEquals( [ get_post( $post_fr ) ], get_posts( [ 'cat' => $en ] ) );
+		$this->assertEquals( [ get_post( $post_fr ) ], get_posts( [ 'category_name' => 'test' ] ) );
+		$this->assertEquals( [ get_post( $post_fr ) ], get_posts( [ 'category__in' => [ $en ] ] ) );
 	}
 
 	function test_tag() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai2' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'essai2',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test2' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'test2',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$post_fr = $this->factory->post->create( array( 'tags_input' => array( 'essai', 'essai2' ) ) );
+		$post_fr = $this->factory->post->create( [ 'tags_input' => [ 'essai', 'essai2' ] ] );
 		self::$polylang->model->post->set_language( $post_fr, 'fr' );
 
-		$post_en = $this->factory->post->create( array( 'tags_input' => array( 'test', 'test2' ) ) );
+		$post_en = $this->factory->post->create( [ 'tags_input' => [ 'test', 'test2' ] ] );
 		self::$polylang->model->post->set_language( $post_en, 'en' );
 
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag_id' => $en ) ) );
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag' => 'test' ) ) );
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag' => 'test,test2' ) ) );
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag' => 'test+test2' ) ) );
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag_slug__in' => array( 'test' ) ) ) );
+		$this->assertEquals( [ get_post( $post_fr ) ], get_posts( [ 'tag_id' => $en ] ) );
+		$this->assertEquals( [ get_post( $post_fr ) ], get_posts( [ 'tag' => 'test' ] ) );
+		$this->assertEquals( [ get_post( $post_fr ) ], get_posts( [ 'tag' => 'test,test2' ] ) );
+		$this->assertEquals( [ get_post( $post_fr ) ], get_posts( [ 'tag' => 'test+test2' ] ) );
+		$this->assertEquals( [ get_post( $post_fr ) ], get_posts( [ 'tag_slug__in' => [ 'test' ] ] ) );
 	}
 
 	function test_custom_tax() {
-		$term_fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'essai' ) );
+		$term_fr = $fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'trtax',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$term_en = $en = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'test' ) );
+		$term_en = $en = $this->factory->term->create(
+			[
+				'taxonomy' => 'trtax',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'essai2' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'trtax',
+				'name' => 'essai2',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'test2' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'trtax',
+				'name' => 'test2',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'essai3' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'trtax',
+				'name' => 'essai3',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'test3' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'trtax',
+				'name' => 'test3',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$post_fr = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		wp_set_post_terms( $post_fr, array( 'essai', 'essai2' ), 'trtax' ); // don't use 'tax_input' above as we don't pass current_user_can test in wp_insert_post
+		$post_fr = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
+		wp_set_post_terms( $post_fr, [ 'essai', 'essai2' ], 'trtax' ); // don't use 'tax_input' above as we don't pass current_user_can test in wp_insert_post
 		self::$polylang->model->post->set_language( $post_fr, 'fr' );
 
-		$post_en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		wp_set_post_terms( $post_en, array( 'test', 'test2' ), 'trtax' ); // don't use 'tax_input' above as we don't pass current_user_can test in wp_insert_post
+		$post_en = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
+		wp_set_post_terms( $post_en, [ 'test', 'test2' ], 'trtax' ); // don't use 'tax_input' above as we don't pass current_user_can test in wp_insert_post
 		self::$polylang->model->post->set_language( $post_en, 'en' );
 
 		// old way
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'post_type' => 'trcpt', 'trtax' => 'test' ) ) );
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'post_type' => 'trcpt', 'trtax' => 'test,test2' ) ) );
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'post_type' => 'trcpt', 'trtax' => 'test+test2' ) ) );
+		$this->assertEquals(
+			[ get_post( $post_fr ) ], get_posts(
+				[
+					'post_type' => 'trcpt',
+					'trtax' => 'test',
+				]
+			)
+		);
+		$this->assertEquals(
+			[ get_post( $post_fr ) ], get_posts(
+				[
+					'post_type' => 'trcpt',
+					'trtax' => 'test,test2',
+				]
+			)
+		);
+		$this->assertEquals(
+			[ get_post( $post_fr ) ], get_posts(
+				[
+					'post_type' => 'trcpt',
+					'trtax' => 'test+test2',
+				]
+			)
+		);
 
 		// tax query
-		$args = array(
+		$args = [
 			'post_type' => 'trcpt',
-			'tax_query' => array(
-				array(
+			'tax_query' => [
+				[
 					'taxonomy' => 'trtax',
 					'terms'    => 'test',
 					'field'    => 'slug',
-				),
-			),
-		);
+				],
+			],
+		];
 
-		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( $args ) );
+		$this->assertEquals( [ get_post( $post_fr ) ], get_posts( $args ) );
 
 		// Nested tax query
-		$args = array(
+		$args  = [
 			'post_type' => 'trcpt',
-			'tax_query' => array(
+			'tax_query' => [
 				'relation' => 'OR',
-				array(
+				[
 					'taxonomy' => 'trtax',
 					'field'    => 'term_id',
-					'terms'    => array( $en ),
-				),
-				array(
+					'terms'    => [ $en ],
+				],
+				[
 					'relation' => 'AND',
-					array(
+					[
 						'taxonomy' => 'trtax',
 						'field'    => 'term_id',
-						'terms'    => array( $term_en ),
-					),
-					array(
+						'terms'    => [ $term_en ],
+					],
+					[
 						'taxonomy' => 'trtax',
 						'field'    => 'slug',
-						'terms'    => array( 'test2' ),
-					),
-				),
-			),
-		);
+						'terms'    => [ 'test2' ],
+					],
+				],
+			],
+		];
 		$query = new WP_Query( $args );
 
 		$this->assertEquals( $fr, $query->tax_query->queries[0]['terms'][0] );
@@ -164,89 +250,168 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'essai2', $query->tax_query->queries[1][1]['terms'][0] );
 
 		// #223
-		$args = array(
+		$args = [
 			'post_type' => 'trcpt',
 			'lang'      => '',
-			'tax_query' => array(
-				array(
+			'tax_query' => [
+				[
 					'taxonomy' => 'trtax',
-					'terms'    => array( $term_en, $term_fr ),
+					'terms'    => [ $term_en, $term_fr ],
 					'field'    => 'term_id',
-				),
-			),
-		);
+				],
+			],
+		];
 
 		$query = new WP_Query( $args );
 
-		$this->assertEqualSets( array( $post_en, $post_fr ), wp_list_pluck( $query->posts, 'ID' ) );
+		$this->assertEqualSets( [ $post_en, $post_fr ], wp_list_pluck( $query->posts, 'ID' ) );
 	}
 
 	function test_post() {
-		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$en = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$fr = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'p' => $en ) ) );
-		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'name' => 'test' ) ) );
-		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'name' => 'test', 'post_type' => 'post' ) ) );
-		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'name' => 'test', 'post_type' => 'any' ) ) );
-		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'name' => 'test', 'post_type' => array( 'post', 'page' ) ) ) );
-		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'post__in' => array( $en ) ) ) );
+		$this->assertEquals( [ get_post( $fr ) ], get_posts( [ 'p' => $en ] ) );
+		$this->assertEquals( [ get_post( $fr ) ], get_posts( [ 'name' => 'test' ] ) );
+		$this->assertEquals(
+			[ get_post( $fr ) ], get_posts(
+				[
+					'name' => 'test',
+					'post_type' => 'post',
+				]
+			)
+		);
+		$this->assertEquals(
+			[ get_post( $fr ) ], get_posts(
+				[
+					'name' => 'test',
+					'post_type' => 'any',
+				]
+			)
+		);
+		$this->assertEquals(
+			[ get_post( $fr ) ], get_posts(
+				[
+					'name' => 'test',
+					'post_type' => [ 'post', 'page' ],
+				]
+			)
+		);
+		$this->assertEquals( [ get_post( $fr ) ], get_posts( [ 'post__in' => [ $en ] ] ) );
 	}
 
 	function test_page() {
-		$parent_en = $en = $this->factory->post->create( array( 'post_title' => 'test_parent', 'post_type' => 'page' ) );
+		$parent_en = $en = $this->factory->post->create(
+			[
+				'post_title' => 'test_parent',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$parent_fr = $fr = $this->factory->post->create( array( 'post_title' => 'essai_parent', 'post_type' => 'page' ) );
+		$parent_fr = $fr = $this->factory->post->create(
+			[
+				'post_title' => 'essai_parent',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page', 'post_parent' => $parent_en ) );
+		$en = $this->factory->post->create(
+			[
+				'post_title' => 'test',
+				'post_type' => 'page',
+				'post_parent' => $parent_en,
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai', 'post_type' => 'page', 'post_parent' => $parent_fr ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_title' => 'essai',
+				'post_type' => 'page',
+				'post_parent' => $parent_fr,
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$query = new WP_Query( array( 'page_id' => $en ) );
-		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
-		$query = new WP_Query( array( 'pagename' => 'test_parent' ) ); // Top page
-		$this->assertEquals( array( get_post( $parent_fr ) ), $query->posts );
-		$query = new WP_Query( array( 'pagename' => 'test_parent/test' ) ); // Child page
-		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
-		$query = new WP_Query( array( 'post_parent' => $parent_en, 'post_type' => 'page' ) );
-		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
-		$query = new WP_Query( array( 'post_parent__in' => array( $parent_en ), 'post_type' => 'page' ) );
-		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
+		$query = new WP_Query( [ 'page_id' => $en ] );
+		$this->assertEquals( [ get_post( $fr ) ], $query->posts );
+		$query = new WP_Query( [ 'pagename' => 'test_parent' ] ); // Top page
+		$this->assertEquals( [ get_post( $parent_fr ) ], $query->posts );
+		$query = new WP_Query( [ 'pagename' => 'test_parent/test' ] ); // Child page
+		$this->assertEquals( [ get_post( $fr ) ], $query->posts );
+		$query = new WP_Query(
+			[
+				'post_parent' => $parent_en,
+				'post_type' => 'page',
+			]
+		);
+		$this->assertEquals( [ get_post( $fr ) ], $query->posts );
+		$query = new WP_Query(
+			[
+				'post_parent__in' => [ $parent_en ],
+				'post_type' => 'page',
+			]
+		);
+		$this->assertEquals( [ get_post( $fr ) ], $query->posts );
 	}
 
 	function test_get_terms() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$expected = get_term( $fr, 'category' );
-		$terms = get_terms( 'category', array( 'hide_empty' => 0, 'include' => array( $en ) ) );
-		$this->assertEquals( array( $expected->term_id ), wp_list_pluck( $terms, 'term_id' ) );
+		$terms    = get_terms(
+			'category', [
+				'hide_empty' => 0,
+				'include' => [ $en ],
+			]
+		);
+		$this->assertEquals( [ $expected->term_id ], wp_list_pluck( $terms, 'term_id' ) );
 
 		if ( version_compare( $GLOBALS['wp_version'], '4.5', '>=' ) ) {
 			// The taxonomy parameter is now optional
-			$terms = get_terms( array( 'hide_empty' => 0, 'include' => array( $en ) ) );
-			$this->assertEquals( array( $expected->term_id ), wp_list_pluck( $terms, 'term_id' ) );
+			$terms = get_terms(
+				[
+					'hide_empty' => 0,
+					'include' => [ $en ],
+				]
+			);
+			$this->assertEquals( [ $expected->term_id ], wp_list_pluck( $terms, 'term_id' ) );
 		}
 
 		$expected = get_term( $en, 'category' );
-		$terms = get_terms( 'category', array( 'hide_empty' => 0, 'include' => array( $en ), 'lang' => '' ) );
-		$this->assertEquals( array( $expected->term_id ), wp_list_pluck( $terms, 'term_id' ) );
+		$terms    = get_terms(
+			'category', [
+				'hide_empty' => 0,
+				'include' => [ $en ],
+				'lang' => '',
+			]
+		);
+		$this->assertEquals( [ $expected->term_id ], wp_list_pluck( $terms, 'term_id' ) );
 	}
 }

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -10,7 +10,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::create_language( 'fr_FR' );
 
 		require_once PLL_INC . '/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
+		$GLOBALS['polylang']                     = &self::$polylang;
 		self::$polylang->options['hide_default'] = 0;
 	}
 
@@ -19,9 +19,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 		global $wp_rewrite;
 
-		self::$polylang->options['post_types'] = array(
+		self::$polylang->options['post_types'] = [
 			'cpt' => 'cpt', // translate the cpt // FIXME /!\ 'after_setup_theme' already fired and the list of translated post types is already cached :(
-		);
+		];
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
@@ -30,14 +30,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		// register post types and taxonomies
 		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
-		register_post_type( 'cpt', array( 'public' => true ) ); // add custom post type
+		register_post_type( 'cpt', [ 'public' => true ] ); // add custom post type
 
 		// reset the links model according to the permalink structure
 		self::$polylang->links_model = self::$polylang->model->get_links_model();
 		self::$polylang->links_model->init();
 
 		// flush rules
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		self::$polylang->filters_links = new PLL_Frontend_Filters_Links( self::$polylang );
@@ -50,52 +50,98 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	function test_post() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'post-format-test-audio' ) );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'post-format-test-audio' ] );
 		self::$polylang->model->post->set_language( $post_id, 'en' );
-		$this->assertCanonical( '/en/post-format-test-audio/', array(
-			'url' => '/en/post-format-test-audio/',
-			'qv' => array( 'lang' => 'en', 'name' => 'post-format-test-audio', 'page' => '' ),
-		) );
+		$this->assertCanonical(
+			'/en/post-format-test-audio/', [
+				'url' => '/en/post-format-test-audio/',
+				'qv' => [
+					'lang' => 'en',
+					'name' => 'post-format-test-audio',
+					'page' => '',
+				],
+			]
+		);
 		$this->assertCanonical( '/fr/post-format-test-audio/', '/en/post-format-test-audio/' );
 		$this->assertCanonical( '/post-format-test-audio/', '/en/post-format-test-audio/' );
 	}
 
 	function test_page() {
-		$post_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'parent-page' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_title' => 'parent-page',
+			]
+		);
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
-		$this->assertCanonical( '/en/parent-page/', array(
-			'url' => '/en/parent-page/',
-			'qv' => array( 'lang' => 'en', 'pagename' => 'parent-page', 'page' => '' ),
-		) );
+		$this->assertCanonical(
+			'/en/parent-page/', [
+				'url' => '/en/parent-page/',
+				'qv' => [
+					'lang' => 'en',
+					'pagename' => 'parent-page',
+					'page' => '',
+				],
+			]
+		);
 		$this->assertCanonical( '/fr/parent-page/', '/en/parent-page/' );
 		$this->assertCanonical( '/parent-page/', '/en/parent-page/' );
 	}
 
 	function test_cpt() {
 		// custom post type
-		$post_id = $this->factory->post->create( array( 'import_id' => 416, 'post_type' => 'cpt', 'post_title' => 'custom-post' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'import_id' => 416,
+				'post_type' => 'cpt',
+				'post_title' => 'custom-post',
+			]
+		);
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
-		$this->assertCanonical( '/en/cpt/custom-post/', array(
-			'url' => '/en/cpt/custom-post/',
-			'qv' => array( 'lang' => 'en', 'cpt' => 'custom-post', 'name' => 'custom-post', 'post_type' => 'cpt', 'page' => '' ),
-		) );
+		$this->assertCanonical(
+			'/en/cpt/custom-post/', [
+				'url' => '/en/cpt/custom-post/',
+				'qv' => [
+					'lang' => 'en',
+					'cpt' => 'custom-post',
+					'name' => 'custom-post',
+					'post_type' => 'cpt',
+					'page' => '',
+				],
+			]
+		);
 		$this->assertCanonical( '/fr/cpt/custom-post/', '/en/cpt/custom-post/' );
 		$this->assertCanonical( '/cpt/custom-post/', '/en/cpt/custom-post/' );
 	}
 
 	function test_category() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'parent',
+			]
+		);
 		self::$polylang->model->term->set_language( $term_id, 'en' );
 
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent-fr' ) );
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'parent-fr',
+			]
+		);
 		self::$polylang->model->term->set_language( $term_id, 'fr' );
 
-		$this->assertCanonical( '/en/category/parent/', array(
-			'url' => '/en/category/parent/',
-			'qv' => array( 'lang' => 'en', 'category_name' => 'parent' ),
-		) );
+		$this->assertCanonical(
+			'/en/category/parent/', [
+				'url' => '/en/category/parent/',
+				'qv' => [
+					'lang' => 'en',
+					'category_name' => 'parent',
+				],
+			]
+		);
 		$this->assertCanonical( '/fr/category/parent/', '/en/category/parent/' );
 		$this->assertCanonical( '/category/parent/', '/en/category/parent/' );
 
@@ -107,10 +153,20 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
 		update_option( 'show_on_front', 'page' );
 
-		$this->posts_en = $en = $this->factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
+		$this->posts_en = $en = $this->factory->post->create(
+			[
+				'post_title' => 'posts',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$this->posts_fr = $fr = $this->factory->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
+		$this->posts_fr = $fr = $this->factory->post->create(
+			[
+				'post_title' => 'articles',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
@@ -124,10 +180,16 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::$polylang->static_pages = new PLL_Frontend_Static_Pages( self::$polylang );
 		self::$polylang->static_pages->pll_language_defined();
 
-		$this->assertCanonical( '/en/posts/', array(
-			'url' => '/en/posts/',
-			'qv' => array( 'lang' => 'en', 'pagename' => 'posts', 'page' => '' ),
-		) );
+		$this->assertCanonical(
+			'/en/posts/', [
+				'url' => '/en/posts/',
+				'qv' => [
+					'lang' => 'en',
+					'pagename' => 'posts',
+					'page' => '',
+				],
+			]
+		);
 		$this->assertCanonical( '/fr/posts/', '/en/posts/' );
 		$this->assertCanonical( '/posts/', '/en/posts/' );
 
@@ -137,7 +199,12 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	// bug introduced in 1.8.2 and fixed in 1.8.3
 	function test_page_when_static_front_page_displays_posts() {
-		$post_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'parent-page' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_title' => 'parent-page',
+			]
+		);
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
 		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
@@ -150,10 +217,16 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::$polylang->static_pages = new PLL_Frontend_Static_Pages( self::$polylang );
 		self::$polylang->static_pages->pll_language_defined();
 
-		$this->assertCanonical( '/en/parent-page/', array(
-			'url' => '/en/parent-page/',
-			'qv' => array( 'lang' => 'en', 'pagename' => 'parent-page', 'page' => '' ),
-		) );
+		$this->assertCanonical(
+			'/en/parent-page/', [
+				'url' => '/en/parent-page/',
+				'qv' => [
+					'lang' => 'en',
+					'pagename' => 'parent-page',
+					'page' => '',
+				],
+			]
+		);
 		$this->assertCanonical( '/fr/parent-page/', '/en/parent-page/' );
 		$this->assertCanonical( '/parent-page/', '/en/parent-page/' );
 	}

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -19,12 +19,12 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		global $wp_rewrite;
 
 		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['force_lang'] = 0;
-		self::$polylang->options['browser'] = 0;
+		self::$polylang->options['force_lang']   = 0;
+		self::$polylang->options['browser']      = 0;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
 		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
@@ -42,8 +42,8 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	// overrides WP_UnitTestCase::go_to
 	function go_to( $url ) {
 		// copy paste of WP_UnitTestCase::go_to
-		$_GET = $_POST = array();
-		foreach ( array( 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow' ) as $v ) {
+		$_GET = $_POST = [];
+		foreach ( [ 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow' ] as $v ) {
 			if ( isset( $GLOBALS[ $v ] ) ) {
 				unset( $GLOBALS[ $v ] );
 			}
@@ -76,8 +76,8 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 
 		// restart copy paste of WP_UnitTestCase::go_to
 		$GLOBALS['wp_the_query'] = new WP_Query();
-		$GLOBALS['wp_query'] = $GLOBALS['wp_the_query'];
-		$GLOBALS['wp'] = new WP();
+		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
+		$GLOBALS['wp']           = new WP();
 		_cleanup_query_vars();
 
 		$GLOBALS['wp']->main( $parts['query'] );
@@ -100,10 +100,10 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	}
 
 	function test_single_post() {
-		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$en = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$fr = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/essai/' ) );
@@ -114,10 +114,20 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	}
 
 	function test_page() {
-		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
+		$en = $this->factory->post->create(
+			[
+				'post_title' => 'test',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai', 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_title' => 'essai',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/essai/' ) );
@@ -128,7 +138,12 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	}
 
 	function test_category_default_lang() {
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
 		$this->go_to( home_url( '/category/test/' ) );
@@ -136,7 +151,12 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	}
 
 	function test_category_non_default_lang() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/category/essai/' ) );
@@ -144,7 +164,12 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	}
 
 	function test_post_tag_default_lang() {
-		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
 		$this->go_to( home_url( '/tag/test/' ) );
@@ -152,7 +177,12 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	}
 
 	function test_post_tag_non_default_lang() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/tag/essai/' ) );
@@ -160,10 +190,10 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	}
 
 	function test_archive() {
-		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
+		$en = $this->factory->post->create( [ 'post_date' => '2007-09-04 00:00:00' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
+		$fr = $this->factory->post->create( [ 'post_date' => '2007-09-04 00:00:00' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/fr/2007/' ) );
@@ -176,10 +206,10 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	function test_archive_with_default_permalinks() {
 		$GLOBALS['wp_rewrite']->set_permalink_structure( '' );
 
-		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
+		$en = $this->factory->post->create( [ 'post_date' => '2007-09-04 00:00:00' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
+		$fr = $this->factory->post->create( [ 'post_date' => '2007-09-04 00:00:00' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '?year=2007&lang=fr' ) );

--- a/tests/phpunit/tests/test-choose-lang-domain.php
+++ b/tests/phpunit/tests/test-choose-lang-domain.php
@@ -20,19 +20,19 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 
 		$this->server = $_SERVER; // save this
 
-		$this->hosts = array(
+		$this->hosts = [
 			'en' => 'http://example.org',
 			'fr' => 'http://example.fr',
 			'de' => 'http://example.de',
-		);
+		];
 
 		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['force_lang'] = 3;
-		self::$polylang->options['domains'] = $this->hosts;
+		self::$polylang->options['force_lang']   = 3;
+		self::$polylang->options['domains']      = $this->hosts;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
 		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
@@ -55,8 +55,8 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 	// overrides WP_UnitTestCase::go_to
 	function go_to( $url ) {
 		// copy paste of WP_UnitTestCase::go_to
-		$_GET = $_POST = array();
-		foreach ( array( 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow' ) as $v ) {
+		$_GET = $_POST = [];
+		foreach ( [ 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow' ] as $v ) {
 			if ( isset( $GLOBALS[ $v ] ) ) {
 				unset( $GLOBALS[ $v ] );
 			}
@@ -90,8 +90,8 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 
 		// restart copy paste of WP_UnitTestCase::go_to
 		$GLOBALS['wp_the_query'] = new WP_Query();
-		$GLOBALS['wp_query'] = $GLOBALS['wp_the_query'];
-		$GLOBALS['wp'] = new WP();
+		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
+		$GLOBALS['wp']           = new WP();
 		_cleanup_query_vars();
 
 		$GLOBALS['wp']->main( $parts['query'] );
@@ -107,21 +107,21 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		$this->go_to( $this->hosts['fr'] );
 		$this->assertEquals( 'fr', self::$polylang->curlang->slug );
 		$this->assertQueryTrue( 'is_home', 'is_front_page' );
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // bug introduced in 1.8.0.1, fixed in 1.8.0.2
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // bug introduced in 1.8.0.1, fixed in 1.8.0.2
 		$this->assertEquals( trailingslashit( $this->hosts['en'] ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 
 		$this->go_to( $this->hosts['en'] );
 		$this->assertEquals( 'en', self::$polylang->curlang->slug );
 		$this->assertQueryTrue( 'is_home', 'is_front_page' );
-		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $en ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEquals( trailingslashit( $this->hosts['fr'] ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
 	}
 
 	function test_single_post() {
-		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$en = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$fr = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( $this->hosts['fr'] . '/essai/' );

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -43,8 +43,13 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 	// bug fixed in 1.8
 	// see https://wordpress.org/support/topic/browser-detection
 	function test_browser_preferred_language_with_same_slug() {
-		self::create_language( 'en_GB', array( 'term_group' => 2 ) );
-		self::create_language( 'en_US', array( 'slug' => 'us', 'term_group' => 1 ) );
+		self::create_language( 'en_GB', [ 'term_group' => 2 ] );
+		self::create_language(
+			'en_US', [
+				'slug' => 'us',
+				'term_group' => 1,
+			]
+		);
 
 		// only languages with posts will be accepted
 		$post_id = $this->factory->post->create();

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -9,7 +9,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = self::factory()->user->create( [ 'role' => 'editor' ] );
 	}
 
 	function setUp() {
@@ -18,7 +18,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		// set a user to pass current_user_can tests
 		wp_set_current_user( self::$editor );
 
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		self::$polylang->links           = new PLL_Admin_Links( self::$polylang );
 		self::$polylang->filters_columns = new PLL_Admin_Filters_Columns( self::$polylang );
 	}
 
@@ -27,7 +27,7 @@ class Columns_Test extends PLL_UnitTestCase {
 
 		parent::tearDown();
 
-		$_REQUEST = $_GET = $_POST = array();
+		$_REQUEST = $_GET = $_POST = [];
 	}
 
 	function test_post_with_no_language() {
@@ -116,7 +116,7 @@ class Columns_Test extends PLL_UnitTestCase {
 
 	function test_term_with_no_language() {
 		$GLOBALS['post_type'] = 'post';
-		$GLOBALS['taxonomy'] = 'category';
+		$GLOBALS['taxonomy']  = 'category';
 
 		$term_id = $this->factory->category->create();
 
@@ -128,7 +128,7 @@ class Columns_Test extends PLL_UnitTestCase {
 
 	function test_term_language() {
 		$GLOBALS['post_type'] = 'post';
-		$GLOBALS['taxonomy'] = 'category';
+		$GLOBALS['taxonomy']  = 'category';
 
 		$en = $this->factory->category->create();
 		self::$polylang->model->term->set_language( $en, 'en' );
@@ -148,7 +148,7 @@ class Columns_Test extends PLL_UnitTestCase {
 
 	function test_untranslated_term() {
 		$GLOBALS['post_type'] = 'post';
-		$GLOBALS['taxonomy'] = 'category';
+		$GLOBALS['taxonomy']  = 'category';
 
 		$en = $this->factory->category->create();
 		self::$polylang->model->term->set_language( $en, 'en' );
@@ -166,7 +166,7 @@ class Columns_Test extends PLL_UnitTestCase {
 
 	function test_translated_term() {
 		$GLOBALS['post_type'] = 'post';
-		$GLOBALS['taxonomy'] = 'category';
+		$GLOBALS['taxonomy']  = 'category';
 
 		$en = $this->factory->category->create();
 		self::$polylang->model->term->set_language( $en, 'en' );
@@ -189,11 +189,11 @@ class Columns_Test extends PLL_UnitTestCase {
 
 	function test_add_post_column() {
 		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
-		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
+		$list_table                                    = _get_list_table( 'WP_Posts_List_Table', [ 'screen' => 'edit.php' ] );
 		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
-		$columns = array_intersect_key( $columns, array_flip( array( 'comments' ) ) ); // Keep only the Comments column
-		$columns = apply_filters( 'manage_edit-post_columns', $columns );
-		$columns = array_keys( $columns );
+		$columns                                       = array_intersect_key( $columns, array_flip( [ 'comments' ] ) ); // Keep only the Comments column
+		$columns                                       = apply_filters( 'manage_edit-post_columns', $columns );
+		$columns                                       = array_keys( $columns );
 		$en = array_search( 'language_en', $columns );
 
 		$this->assertNotFalse( $en );
@@ -204,19 +204,19 @@ class Columns_Test extends PLL_UnitTestCase {
 	function test_add_post_column_with_filter() {
 		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
 		self::$polylang->filter_lang = self::$polylang->model->get_language( 'en' );
-		$columns = apply_filters( 'manage_edit-post_columns', array() );
-		$columns = array_keys( $columns );
+		$columns                     = apply_filters( 'manage_edit-post_columns', [] );
+		$columns                     = array_keys( $columns );
 		$this->assertFalse( array_search( 'language_en', $columns ) );
 		$this->assertNotFalse( array_search( 'language_fr', $columns ) );
 	}
 
 	function test_add_term_column() {
 		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
-		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
+		$list_table                                    = _get_list_table( 'WP_Terms_List_Table', [ 'screen' => 'edit-tags.php' ] );
 		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
-		$columns = array_intersect_key( $columns, array_flip( array( 'posts' ) ) ); // Keep only the Count column
-		$columns = apply_filters( 'manage_edit-post_tag_columns', $columns );
-		$columns = array_keys( $columns );
+		$columns                                       = array_intersect_key( $columns, array_flip( [ 'posts' ] ) ); // Keep only the Count column
+		$columns                                       = apply_filters( 'manage_edit-post_tag_columns', $columns );
+		$columns                                       = array_keys( $columns );
 		$en = array_search( 'language_en', $columns );
 
 		$this->assertNotFalse( $en );
@@ -227,8 +227,8 @@ class Columns_Test extends PLL_UnitTestCase {
 	function test_add_term_column_with_filter() {
 		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
 		self::$polylang->filter_lang = self::$polylang->model->get_language( 'fr' );
-		$columns = apply_filters( 'manage_edit-post_tag_columns', array() );
-		$columns = array_keys( $columns );
+		$columns                     = apply_filters( 'manage_edit-post_tag_columns', [] );
+		$columns                     = array_keys( $columns );
 		$this->assertFalse( array_search( 'language_fr', $columns ) );
 		$this->assertNotFalse( array_search( 'language_en', $columns ) );
 	}
@@ -237,14 +237,14 @@ class Columns_Test extends PLL_UnitTestCase {
 		$en = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
+		$list_table = _get_list_table( 'WP_Posts_List_Table', [ 'screen' => 'edit.php' ] );
 		$list_table->prepare_items();
 		$GLOBALS['post'] = $GLOBALS['wp_the_query']->post; // Needed by touch_time
 
 		ob_start();
 		$list_table->inline_edit();
 		$form = ob_get_clean();
-		$doc = new DomDocument();
+		$doc  = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -4,14 +4,14 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 
 	function test_add_and_delete_language() {
 		// first language
-		$args = array(
+		$args = [
 			'name' => 'English',
 			'slug' => 'en',
 			'locale' => 'en_US',
 			'rtl' => 0,
 			'flag' => 'us',
 			'term_group' => 2,
-		);
+		];
 
 		$this->assertTrue( self::$polylang->model->add_language( $args ) );
 		unset( $GLOBALS['wp_settings_errors'] ); // clean "errors"
@@ -25,14 +25,14 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 2, $lang->term_group );
 
 		// second language (rtl)
-		$args = array(
+		$args = [
 			'name' => 'العربية',
 			'slug' => 'ar',
 			'locale' => 'ar',
 			'rtl' => 1,
 			'flag' => 'arab',
 			'term_group' => 1,
-		);
+		];
 
 		$this->assertTrue( self::$polylang->model->add_language( $args ) );
 		unset( $GLOBALS['wp_settings_errors'] ); // clean "errors"
@@ -53,7 +53,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $default_cat_lang->slug );
 
 		// check language order
-		$this->assertEqualSetsWithIndex( array( 'ar', 'en' ), self::$polylang->model->get_languages_list( array( 'fields' => 'slug' ) ) );
+		$this->assertEqualSetsWithIndex( [ 'ar', 'en' ], self::$polylang->model->get_languages_list( [ 'fields' => 'slug' ] ) );
 
 		// attempt to create a language with the same slug as an existing one
 		self::create_language( 'en_GB' );
@@ -70,27 +70,27 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		// delete the last language
 		$lang = self::$polylang->model->get_language( 'ar' );
 		self::$polylang->model->delete_language( $lang->term_id );
-		$this->assertEquals( array(), self::$polylang->model->get_languages_list() );
+		$this->assertEquals( [], self::$polylang->model->get_languages_list() );
 	}
 
 	// Bug fixed in 2.3
 	function test_unique_language_code_if_same_as_locale() {
 		// First language
-		$args = array(
+		$args = [
 			'name' => 'العربية',
 			'slug' => 'a', // Intentional mistake
 			'locale' => 'ar',
 			'rtl' => 1,
 			'flag' => 'arab',
 			'term_group' => 1,
-		);
+		];
 
 		$this->assertTrue( self::$polylang->model->add_language( $args ) );
 		unset( $GLOBALS['wp_settings_errors'] ); // clean "errors"
 
-		$lang = self::$polylang->model->get_language( 'ar' );
+		$lang            = self::$polylang->model->get_language( 'ar' );
 		$args['lang_id'] = $lang->term_id;
-		$args['slug'] = 'ar';
+		$args['slug']    = 'ar';
 		$this->assertTrue( self::$polylang->model->update_language( $args ) );
 		unset( $GLOBALS['wp_settings_errors'] ); // clean "errors"
 
@@ -100,44 +100,44 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	function test_invalid_languages() {
 		global $wp_settings_errors;
 
-		$args = array(
+		$args = [
 			'name' => '',
 			'slug' => 'en',
 			'locale' => 'en_US',
 			'rtl' => 0,
 			'flag' => 'us',
 			'term_group' => 1,
-		);
+		];
 
 		$this->assertFalse( self::$polylang->model->add_language( $args ) );
 		$this->assertEquals( 'The language must have a name', $wp_settings_errors[0]['message'] );
-		$wp_settings_errors = array(); // clean "errors"
+		$wp_settings_errors = []; // clean "errors"
 
-		$args['name'] = 'English';
+		$args['name']   = 'English';
 		$args['locale'] = 'EN';
 
 		$this->assertFalse( self::$polylang->model->add_language( $args ) );
 		$this->assertEquals( 'Enter a valid WordPress locale', $wp_settings_errors[0]['message'] );
-		$wp_settings_errors = array(); // clean "errors"
+		$wp_settings_errors = []; // clean "errors"
 
 		$args['locale'] = 'en-US';
 
 		$this->assertFalse( self::$polylang->model->add_language( $args ) );
 		$this->assertEquals( 'Enter a valid WordPress locale', $wp_settings_errors[0]['message'] );
-		$wp_settings_errors = array(); // clean "errors"
+		$wp_settings_errors = []; // clean "errors"
 
 		$args['locale'] = 'en_US';
-		$args['slug'] = 'EN';
+		$args['slug']   = 'EN';
 
 		$this->assertFalse( self::$polylang->model->add_language( $args ) );
 		$this->assertEquals( 'The language code contains invalid characters', $wp_settings_errors[0]['message'] );
-		$wp_settings_errors = array(); // clean "errors"
+		$wp_settings_errors = []; // clean "errors"
 
 		$args['slug'] = 'en';
 		$args['flag'] = 'en';
 		$this->assertFalse( self::$polylang->model->add_language( $args ) );
 		$this->assertEquals( 'The flag does not exist', $wp_settings_errors[0]['message'] );
-		$wp_settings_errors = array(); // clean "errors"
+		$wp_settings_errors = []; // clean "errors"
 	}
 }
 

--- a/tests/phpunit/tests/test-filters-links.php
+++ b/tests/phpunit/tests/test-filters-links.php
@@ -16,21 +16,31 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		global $wp_rewrite;
 
 		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['post_types'] = array(
+		self::$polylang->options['post_types']   = [
 			'trcpt' => 'trcpt',
-		);
-		self::$polylang->options['taxonomies'] = array(
+		];
+		self::$polylang->options['taxonomies']   = [
 			'trtax' => 'trtax',
-		);
+		];
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
 		$wp_rewrite->set_permalink_structure( $this->structure );
 		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
-		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // translated custom post type with archives
+		register_post_type(
+			'trcpt', [
+				'public' => true,
+				'has_archive' => true,
+			]
+		); // translated custom post type with archives
 		register_taxonomy( 'trtax', 'trcpt' ); // translated custom tax
-		register_post_type( 'cpt', array( 'public' => true, 'has_archive' => true ) ); // *untranslated* custom post type with archives
+		register_post_type(
+			'cpt', [
+				'public' => true,
+				'has_archive' => true,
+			]
+		); // *untranslated* custom post type with archives
 		register_taxonomy( 'tax', 'cpt' ); // *untranslated* custom tax
 		self::$polylang->links_model = self::$polylang->model->get_links_model();
 		self::$polylang->links_model->init();
@@ -38,7 +48,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$wp_rewrite->flush_rules();
 
 		// add links filter and de-activate the cache
-		self::$polylang->filters_links = new PLL_Frontend_Filters_Links( self::$polylang );
+		self::$polylang->filters_links        = new PLL_Frontend_Filters_Links( self::$polylang );
 		self::$polylang->filters_links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
 		self::$polylang->filters_links->cache->method( 'get' )->willReturn( false );
 	}
@@ -53,52 +63,77 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 	}
 
 	function test_get_permalink_for_posts() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 		$this->assertEquals( home_url( '/test/' ), get_permalink( $post_id ) );
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $post_id, 'fr' );
 		$this->assertEquals( home_url( '/fr/essai/' ), get_permalink( $post_id ) );
 	}
 
 	function test_get_permalink_for_pages() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'page-test', 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_title' => 'page-test',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 		$this->assertEquals( home_url( '/page-test/' ), get_permalink( $post_id ) );
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'page-essai', 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_title' => 'page-essai',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $post_id, 'fr' );
 		$this->assertEquals( home_url( '/fr/page-essai/' ), get_permalink( $post_id ) );
 	}
 
 	function test_get_permalink_for_cpt() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'trcpt' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_title' => 'test',
+				'post_type' => 'trcpt',
+			]
+		);
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 		$this->assertEquals( home_url( '/trcpt/test/' ), get_permalink( $post_id ) );
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'essai', 'post_type' => 'trcpt' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_title' => 'essai',
+				'post_type' => 'trcpt',
+			]
+		);
 		self::$polylang->model->post->set_language( $post_id, 'fr' );
 		$this->assertEquals( home_url( '/fr/trcpt/essai/' ), get_permalink( $post_id ) );
 	}
 
 	function test_get_permalink_for_untranslated_cpt() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'cpt' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_title' => 'test',
+				'post_type' => 'cpt',
+			]
+		);
 		$this->assertEquals( home_url( '/cpt/test/' ), get_permalink( $post_id ) );
 	}
 
 	function test_attached_attachment() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
-		$args = array(
+		$args = [
 			'post_mime_type' => 'image/jpeg',
 			'post_type' => 'attachment',
 			'post_title' => 'image-en',
 			'post_status' => 'inherit',
 			'post_parent' => $post_id,
 			'file' => 'image.jpg',
-		);
+		];
 
 		if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
 			$attachment_id = $this->factory->attachment->create_object( 'image.jpg', 0, $args );
@@ -109,17 +144,17 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		self::$polylang->model->post->set_language( $attachment_id, 'en' );
 		$this->assertEquals( home_url( '/test/image-en/' ), get_permalink( $attachment_id ) );
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $post_id, 'fr' );
 
-		$args = array(
+		$args = [
 			'post_mime_type' => 'image/jpeg',
 			'post_type' => 'attachment',
 			'post_title' => 'image-fr',
 			'post_status' => 'inherit',
 			'post_parent' => $post_id,
 			'file' => 'image.jpg',
-		);
+		];
 
 		if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
 			$attachment_id = $this->factory->attachment->create_object( 'image.jpg', 0, $args );
@@ -132,37 +167,56 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 	}
 
 	function test_unattached_attachment() {
-		$attachment_id = $this->factory->attachment->create_object( 'image.jpg', 0, array(
-			'post_mime_type' => 'image/jpeg',
-			'post_type' => 'attachment',
-			'post_title' => 'image-en',
-			'post_status' => 'inherit',
-		) );
+		$attachment_id = $this->factory->attachment->create_object(
+			'image.jpg', 0, [
+				'post_mime_type' => 'image/jpeg',
+				'post_type' => 'attachment',
+				'post_title' => 'image-en',
+				'post_status' => 'inherit',
+			]
+		);
 		self::$polylang->model->post->set_language( $attachment_id, 'en' );
 		$this->assertEquals( home_url( '/image-en/' ), get_permalink( $attachment_id ) );
 
-		$attachment_id = $this->factory->attachment->create_object( 'image.jpg', 0, array(
-			'post_mime_type' => 'image/jpeg',
-			'post_type' => 'attachment',
-			'post_title' => 'image-fr',
-			'post_status' => 'inherit',
-		) );
+		$attachment_id = $this->factory->attachment->create_object(
+			'image.jpg', 0, [
+				'post_mime_type' => 'image/jpeg',
+				'post_type' => 'attachment',
+				'post_title' => 'image-fr',
+				'post_status' => 'inherit',
+			]
+		);
 		self::$polylang->model->post->set_language( $attachment_id, 'fr' );
 		$this->assertEquals( home_url( '/fr/image-fr/' ), get_permalink( $attachment_id ) );
 	}
 
 	function test_translated_term_link() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'cats' ) );
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'cats',
+			]
+		);
 		self::$polylang->model->term->set_language( $term_id, 'en' );
 		$this->assertEquals( home_url( '/category/cats/' ), get_term_link( $term_id, 'category' ) );
 
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'chats' ) );
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'chats',
+			]
+		);
 		self::$polylang->model->term->set_language( $term_id, 'fr' );
 		$this->assertEquals( home_url( '/fr/category/chats/' ), get_term_link( $term_id, 'category' ) );
 	}
 
 	function test_untranslated_term_link() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'cats' ) );
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'tax',
+				'name' => 'cats',
+			]
+		);
 		$this->assertEquals( home_url( '/tax/cats/' ), get_term_link( $term_id, 'tax' ) );
 	}
 
@@ -174,7 +228,12 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 	}
 
 	function test_post_format_link() {
-		$this->factory->term->create( array( 'taxonomy' => 'post_format', 'name' => 'post-format-aside' ) ); // shouldn't WP do that ?
+		$this->factory->term->create(
+			[
+				'taxonomy' => 'post_format',
+				'name' => 'post-format-aside',
+			]
+		); // shouldn't WP do that ?
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 		$this->assertEquals( home_url( '/type/aside/' ), get_post_format_link( 'aside' ) );
@@ -209,19 +268,19 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		}
 
 		// Setup logo
-		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
-		$contents = file_get_contents( $filename );
-		$upload   = wp_upload_bits( basename( $filename ), null, $contents );
+		$filename        = dirname( __FILE__ ) . '/../data/image.jpg';
+		$contents        = file_get_contents( $filename );
+		$upload          = wp_upload_bits( basename( $filename ), null, $contents );
 		$custom_logo_url = $upload['url'];
 		$custom_logo_id  = $this->_make_attachment( $upload );
 		set_theme_mod( 'custom_logo', $custom_logo_id );
 
 		// For home_url filter
-		self::$polylang->links = new PLL_Frontend_Links( self::$polylang );
+		self::$polylang->links                      = new PLL_Frontend_Links( self::$polylang );
 		$GLOBALS['wp_actions']['template_redirect'] = 1;
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
-		$doc = new DomDocument();
+		$doc                     = new DomDocument();
 		$doc->loadHTML( get_custom_logo() );
 		$xpath = new DOMXpath( $doc );
 
@@ -229,7 +288,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'http://example.org/', $a->item( 0 )->getAttribute( 'href' ) );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$doc = new DomDocument();
+		$doc                     = new DomDocument();
 		$doc->loadHTML( get_custom_logo() );
 		$xpath = new DOMXpath( $doc );
 

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -23,11 +23,11 @@ class Filters_Test extends PLL_UnitTestCase {
 	}
 
 	function test_get_pages() {
-		foreach ( $this->factory->post->create_many( 3, array( 'post_type' => 'page' ) ) as $page ) {
+		foreach ( $this->factory->post->create_many( 3, [ 'post_type' => 'page' ] ) as $page ) {
 			self::$polylang->model->post->set_language( $page, 'en' );
 		}
 
-		foreach ( $this->factory->post->create_many( 3, array( 'post_type' => 'page' ) ) as $page ) {
+		foreach ( $this->factory->post->create_many( 3, [ 'post_type' => 'page' ] ) as $page ) {
 			self::$polylang->model->post->set_language( $page, 'fr' );
 		}
 
@@ -39,41 +39,51 @@ class Filters_Test extends PLL_UnitTestCase {
 		new PLL_Frontend_Filters( self::$polylang );
 
 		// request all pages
-		$pages = get_pages();
+		$pages       = get_pages();
 		$fr_page_ids = $pages = wp_list_pluck( $pages, 'ID' );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->post, 'get_language' ), $pages ), 'slug' );
+		$languages   = wp_list_pluck( array_map( [ self::$polylang->model->post, 'get_language' ], $pages ), 'slug' );
 		$this->assertCount( 3, $pages );
-		$this->assertEquals( array( 'fr' ), array_values( array_unique( $languages ) ) );
+		$this->assertEquals( [ 'fr' ], array_values( array_unique( $languages ) ) );
 
 		// request less pages than exist
-		$pages = get_pages( array( 'number' => 2 ) );
-		$pages = wp_list_pluck( $pages, 'ID' );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->post, 'get_language' ), $pages ), 'slug' );
+		$pages     = get_pages( [ 'number' => 2 ] );
+		$pages     = wp_list_pluck( $pages, 'ID' );
+		$languages = wp_list_pluck( array_map( [ self::$polylang->model->post, 'get_language' ], $pages ), 'slug' );
 		$this->assertCount( 2, $pages );
-		$this->assertEquals( array( 'fr' ), array_values( array_unique( $languages ) ) );
+		$this->assertEquals( [ 'fr' ], array_values( array_unique( $languages ) ) );
 
 		// request more pages than exist
-		$pages = get_pages( array( 'number' => 20 ) );
-		$pages = wp_list_pluck( $pages, 'ID' );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->post, 'get_language' ), $pages ), 'slug' );
+		$pages     = get_pages( [ 'number' => 20 ] );
+		$pages     = wp_list_pluck( $pages, 'ID' );
+		$languages = wp_list_pluck( array_map( [ self::$polylang->model->post, 'get_language' ], $pages ), 'slug' );
 		$this->assertCount( 3, $pages );
-		$this->assertEquals( array( 'fr' ), array_values( array_unique( $languages ) ) );
+		$this->assertEquals( [ 'fr' ], array_values( array_unique( $languages ) ) );
 
 		$fr_page_id = reset( $fr_page_ids ); // Just one valid page id
-		$pages = get_pages( array( 'number' => 1, 'exclude' => array( $fr_page_id ) ) );
+		$pages      = get_pages(
+			[
+				'number' => 1,
+				'exclude' => [ $fr_page_id ],
+			]
+		);
 		$this->assertCount( 1, $pages );
 
 		// Warning fixed in 2.3.2
-		$pages = get_pages( array( 'number' => 1, 'exclude' => $fr_page_id ) );
+		$pages = get_pages(
+			[
+				'number' => 1,
+				'exclude' => $fr_page_id,
+			]
+		);
 		$this->assertCount( 1, $pages );
 	}
 
 	function test_get_posts() {
-		foreach ( $this->factory->post->create_many( 3, array() ) as $p ) {
+		foreach ( $this->factory->post->create_many( 3, [] ) as $p ) {
 			self::$polylang->model->post->set_language( $p, 'en' );
 		}
 
-		foreach ( $this->factory->post->create_many( 3, array() ) as $p ) {
+		foreach ( $this->factory->post->create_many( 3, [] ) as $p ) {
 			self::$polylang->model->post->set_language( $p, 'fr' );
 		}
 
@@ -83,20 +93,35 @@ class Filters_Test extends PLL_UnitTestCase {
 		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
 		self::$polylang->init();
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$posts = get_posts( array( 'fields' => 'ids' ) );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->post, 'get_language' ), $posts ), 'slug' );
+		$posts                   = get_posts( [ 'fields' => 'ids' ] );
+		$languages               = wp_list_pluck( array_map( [ self::$polylang->model->post, 'get_language' ], $posts ), 'slug' );
 		$this->assertCount( 3, $posts );
-		$this->assertEquals( array( 'fr' ), array_values( array_unique( $languages ) ) );
+		$this->assertEquals( [ 'fr' ], array_values( array_unique( $languages ) ) );
 
-		$posts = get_posts( array( 'fields' => 'ids', 'lang' => 'en' ) );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->post, 'get_language' ), $posts ), 'slug' );
+		$posts     = get_posts(
+			[
+				'fields' => 'ids',
+				'lang' => 'en',
+			]
+		);
+		$languages = wp_list_pluck( array_map( [ self::$polylang->model->post, 'get_language' ], $posts ), 'slug' );
 		$this->assertCount( 3, $posts );
-		$this->assertEquals( array( 'en' ), array_values( array_unique( $languages ) ) );
+		$this->assertEquals( [ 'en' ], array_values( array_unique( $languages ) ) );
 
-		$posts = get_posts( array( 'fields' => 'ids', 'lang' => 'en,de' ) );
+		$posts = get_posts(
+			[
+				'fields' => 'ids',
+				'lang' => 'en,de',
+			]
+		);
 		$this->assertCount( 4, $posts );
 
-		$posts = get_posts( array( 'fields' => 'ids', 'lang' => array( 'fr', 'de' ) ) );
+		$posts = get_posts(
+			[
+				'fields' => 'ids',
+				'lang' => [ 'fr', 'de' ],
+			]
+		);
 		$this->assertCount( 4, $posts );
 	}
 
@@ -112,7 +137,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
 		self::$polylang->init();
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$sticky = get_option( 'sticky_posts' );
+		$sticky                  = get_option( 'sticky_posts' );
 		$this->assertCount( 1, $sticky );
 		$this->assertEquals( $fr, reset( $sticky ) ); // the sticky post
 	}
@@ -120,11 +145,21 @@ class Filters_Test extends PLL_UnitTestCase {
 	function test_get_comments() {
 		$en = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $en, 'en' );
-		$en = $this->factory->comment->create( array( 'comment_post_ID' => $en, 'comment_approved' => '1' ) );
+		$en = $this->factory->comment->create(
+			[
+				'comment_post_ID' => $en,
+				'comment_approved' => '1',
+			]
+		);
 
 		$fr = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $fr, 'fr' );
-		$fr = $this->factory->comment->create( array( 'comment_post_ID' => $fr, 'comment_approved' => '1' ) );
+		$fr = $this->factory->comment->create(
+			[
+				'comment_post_ID' => $fr,
+				'comment_approved' => '1',
+			]
+		);
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 		new PLL_Frontend_Filters( self::$polylang );
@@ -133,47 +168,81 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( get_comment( $fr )->comment_ID, reset( $comments )->comment_ID );
 
 		// don't use the same default args as above to avoid hitting the cache
-		$comments = get_comments( array( 'fields' => 'ids', 'lang' => 'en' ) );
+		$comments = get_comments(
+			[
+				'fields' => 'ids',
+				'lang' => 'en',
+			]
+		);
 		$this->assertCount( 1, $comments );
 		$this->assertEquals( get_comment( $en )->comment_ID, reset( $comments ) );
 	}
 
 	function test_get_terms() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$de = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$de = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 		self::$polylang->model->term->set_language( $de, 'de' );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 		new PLL_Frontend_Filters( self::$polylang );
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false ) );
-		$this->assertEqualSets( array( $fr ), $terms );
+		$terms = get_terms(
+			'post_tag', [
+				'fields' => 'ids',
+				'hide_empty' => false,
+			]
+		);
+		$this->assertEqualSets( [ $fr ], $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
-		$this->assertEqualSets( array( $en ), $terms );
+		$terms = get_terms(
+			'post_tag', [
+				'fields' => 'ids',
+				'hide_empty' => false,
+				'lang' => 'en',
+			]
+		);
+		$this->assertEqualSets( [ $en ], $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
-		$this->assertEqualSets( array( $en, $fr ), $terms );
+		$terms = get_terms(
+			'post_tag', [
+				'fields' => 'ids',
+				'hide_empty' => false,
+				'lang' => 'en,fr',
+			]
+		);
+		$this->assertEqualSets( [ $en, $fr ], $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'fr', 'de' ) ) );
-		$this->assertEqualSets( array( $de, $fr ), $terms );
+		$terms = get_terms(
+			'post_tag', [
+				'fields' => 'ids',
+				'hide_empty' => false,
+				'lang' => [ 'fr', 'de' ],
+			]
+		);
+		$this->assertEqualSets( [ $de, $fr ], $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => '' ) );
-		$this->assertEqualSets( array( $en, $fr, $de ), $terms );
+		$terms = get_terms(
+			'post_tag', [
+				'fields' => 'ids',
+				'hide_empty' => false,
+				'lang' => '',
+			]
+		);
+		$this->assertEqualSets( [ $en, $fr, $de ], $terms );
 	}
 
 	function test_adjacent_post_and_archives() {
 		for ( $i = 1; $i <= 3; $i++ ) {
-			$m = 2 * $i - 1;
-			$en[ $i ] = $this->factory->post->create( array( 'post_date' => "2012-0$m-01 12:00:00" ) );
+			$m        = 2 * $i - 1;
+			$en[ $i ] = $this->factory->post->create( [ 'post_date' => "2012-0$m-01 12:00:00" ] );
 			self::$polylang->model->post->set_language( $en[ $i ], 'en' );
 
-			$m = 2 * $i;
-			$fr[ $i ] = $this->factory->post->create( array( 'post_date' => "2012-0$m-01 12:00:00" ) );
+			$m        = 2 * $i;
+			$fr[ $i ] = $this->factory->post->create( [ 'post_date' => "2012-0$m-01 12:00:00" ] );
 			self::$polylang->model->post->set_language( $fr[ $i ], 'fr' );
 		}
 
@@ -194,10 +263,20 @@ class Filters_Test extends PLL_UnitTestCase {
 
 	// Bug fixed in v1.9
 	function test_adjacent_post_and_archives_for_untranslated_post_type() {
-		register_post_type( 'cpt', array( 'public' => true, 'has_archive' => true ) ); // *untranslated* custom post type with archives
+		register_post_type(
+			'cpt', [
+				'public' => true,
+				'has_archive' => true,
+			]
+		); // *untranslated* custom post type with archives
 
 		for ( $m = 1; $m <= 3; $m++ ) {
-			$p[ $m ] = $this->factory->post->create( array( 'post_type' => 'cpt', 'post_date' => "2012-0$m-01 12:00:00" ) );
+			$p[ $m ] = $this->factory->post->create(
+				[
+					'post_type' => 'cpt',
+					'post_date' => "2012-0$m-01 12:00:00",
+				]
+			);
 		}
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
@@ -208,7 +287,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( get_post( $p[3] ), get_next_post() );
 
 		ob_start();
-		wp_get_archives( array( 'post_type' => 'cpt' ) );
+		wp_get_archives( [ 'post_type' => 'cpt' ] );
 		$archives = ob_get_clean();
 		$this->assertNotFalse( strpos( $archives, 'February 2012' ) );
 
@@ -239,7 +318,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', self::$polylang->model->post->get_language( $post_id )->slug );
 
 		$_REQUEST['lang'] = 'fr';
-		$post_id = $this->factory->post->create();
+		$post_id          = $this->factory->post->create();
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $post_id )->slug );
 
 		unset( $_REQUEST );
@@ -249,9 +328,14 @@ class Filters_Test extends PLL_UnitTestCase {
 		new PLL_Frontend_Filters( self::$polylang );
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 
-		$parent = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$parent = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $parent, 'fr' );
-		$post_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_parent' => $parent ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_parent' => $parent,
+			]
+		);
 
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $parent )->slug );
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $post_id )->slug );
@@ -265,7 +349,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $term_id )->slug );
 
 		$_REQUEST['lang'] = 'fr';
-		$term_id = $this->factory->category->create();
+		$term_id          = $this->factory->category->create();
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $term_id )->slug );
 
 		unset( $_REQUEST );
@@ -277,41 +361,41 @@ class Filters_Test extends PLL_UnitTestCase {
 
 		$parent = $this->factory->category->create();
 		self::$polylang->model->term->set_language( $parent, 'fr' );
-		$term_id = $this->factory->category->create( array( 'parent' => $parent ) );
+		$term_id = $this->factory->category->create( [ 'parent' => $parent ] );
 
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $parent )->slug );
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $term_id )->slug );
 	}
 
 	function test_get_pages_language_filter() {
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->filters = new PLL_Filters( self::$polylang );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
-		$pages = get_pages();
+		$pages                   = get_pages();
 		$this->assertCount( 1, $pages );
 		$this->assertEquals( $en, reset( $pages )->ID );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$pages = get_pages();
+		$pages                   = get_pages();
 		$this->assertCount( 1, $pages );
 		$this->assertEquals( $fr, reset( $pages )->ID );
 
-		$pages = get_pages( array( 'lang' => 'en' ) );
+		$pages = get_pages( [ 'lang' => 'en' ] );
 		$this->assertCount( 1, $pages );
 		$this->assertEquals( $en, reset( $pages )->ID );
 
-		$pages = get_pages( array( 'lang' => 'fr' ) );
+		$pages = get_pages( [ 'lang' => 'fr' ] );
 		$this->assertCount( 1, $pages );
 		$this->assertEquals( $fr, reset( $pages )->ID );
 
 		// Bug fixed in 1.9.3
-		$this->assertCount( 2, get_pages( array( 'lang' => '' ) ) );
+		$this->assertCount( 2, get_pages( [ 'lang' => '' ] ) );
 	}
 
 	function test_site_title_in_password_change_email() {
@@ -319,7 +403,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->markTestSkipped();
 
 		$language = self::$polylang->model->get_language( 'fr' );
-		$_mo = new PLL_MO();
+		$_mo      = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mon site' ) );
 		$_mo->export_to_db( $language );
 
@@ -327,13 +411,13 @@ class Filters_Test extends PLL_UnitTestCase {
 		$user_id = self::factory()->user->create();
 		update_user_meta( $user_id, 'locale', 'fr_FR' );
 
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
+		self::$polylang          = new PLL_Admin( self::$polylang->links_model );
 		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang );
 
-		$userdata = array(
+		$userdata = [
 			'ID'        => $user_id,
 			'user_pass' => 'new password',
-		);
+		];
 		wp_update_user( $userdata );
 
 		$mailer = tests_retrieve_phpmailer_instance();
@@ -343,7 +427,7 @@ class Filters_Test extends PLL_UnitTestCase {
 	}
 
 	function _action_pre_get_posts() {
-		$terms = get_terms( 'post_tag', array( 'hide_empty' => false ) );
+		$terms    = get_terms( 'post_tag', [ 'hide_empty' => false ] );
 		$language = self::$polylang->model->term->get_language( $terms[0]->term_id );
 
 		$this->assertCount( 1, $terms );
@@ -352,16 +436,16 @@ class Filters_Test extends PLL_UnitTestCase {
 
 	// Bug fixed in 2.3.5
 	function test_get_terms_inside_query() {
-		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
 		self::$polylang->init();
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		add_action( 'pre_get_posts', array( $this, '_action_pre_get_posts' ) );
+		add_action( 'pre_get_posts', [ $this, '_action_pre_get_posts' ] );
 		$posts = get_posts();
 	}
 }

--- a/tests/phpunit/tests/test-hreflang.php
+++ b/tests/phpunit/tests/test-hreflang.php
@@ -5,8 +5,8 @@ class Hreflang_Test extends PLL_UnitTestCase {
 	static function wpSetUpBeforeClass() {
 		parent::wpSetUpBeforeClass();
 
-		self::create_language( 'en_GB', array( 'slug' => 'uk' ) );
-		self::create_language( 'en_US', array( 'slug' => 'us' ) );
+		self::create_language( 'en_GB', [ 'slug' => 'uk' ] );
+		self::create_language( 'en_US', [ 'slug' => 'us' ] );
 		self::create_language( 'fr_FR' );
 
 		require_once PLL_INC . '/api.php';
@@ -69,10 +69,10 @@ class Hreflang_Test extends PLL_UnitTestCase {
 	}
 
 	function test_paginated_post() {
-		$uk = $this->factory->post->create( array( 'post_content' => 'en1<!--nextpage-->en2' ) );
+		$uk = $this->factory->post->create( [ 'post_content' => 'en1<!--nextpage-->en2' ] );
 		self::$polylang->model->post->set_language( $uk, 'uk' );
 
-		$us = $this->factory->post->create( array( 'post_content' => 'en1<!--nextpage-->en2' ) );
+		$us = $this->factory->post->create( [ 'post_content' => 'en1<!--nextpage-->en2' ] );
 		self::$polylang->model->post->set_language( $us, 'us' );
 
 		self::$polylang->model->post->save_translations( $uk, compact( 'uk', 'us' ) );

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -35,30 +35,37 @@ class Install_Test extends PLL_UnitTestCase {
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
 		$post_translations_groups = get_terms( 'post_translations' );
-		$post_group = reset( $post_translations_groups );
+		$post_group               = reset( $post_translations_groups );
 
 		$term_translations_groups = get_terms( 'term_translations' );
-		$term_group = reset( $term_translations_groups );
+		$term_group               = reset( $term_translations_groups );
 
 		// User metas
 		update_user_meta( 1, 'pll_filter_content', 'en' );
-		update_user_meta( 1, 'pll_duplicate_content', array( 'post' => true ) );
+		update_user_meta( 1, 'pll_duplicate_content', [ 'post' => true ] );
 		update_user_meta( 1, 'description_fr', 'Biographie' );
 
 		// A menu with a language switcher
 		$menu_en = wp_create_nav_menu( 'menu_en' );
-		$item_id = wp_update_nav_menu_item( $menu_en, 0, array(
-			'menu-item-type'   => 'custom',
-			'menu-item-title'  => 'Language switcher',
-			'menu-item-url'    => '#pll_switcher',
-			'menu-item-status' => 'publish',
-		) );
+		$item_id = wp_update_nav_menu_item(
+			$menu_en, 0, [
+				'menu-item-type'   => 'custom',
+				'menu-item-title'  => 'Language switcher',
+				'menu-item-url'    => '#pll_switcher',
+				'menu-item-status' => 'publish',
+			]
+		);
 
-		update_post_meta( $item_id, '_pll_menu_item', array() );
+		update_post_meta( $item_id, '_pll_menu_item', [] );
 
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			define( 'WP_UNINSTALL_PLUGIN', true );
@@ -79,7 +86,7 @@ class Install_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( get_option( 'polylang' ) );
 
 		// No languages
-		$this->assertEmpty( get_terms( 'language', array( 'hide_empty' => false ) ) );
+		$this->assertEmpty( get_terms( 'language', [ 'hide_empty' => false ] ) );
 		$this->assertEmpty( get_terms( 'term_language' ) );
 
 		// No languages for posts and terms

--- a/tests/phpunit/tests/test-links-default.php
+++ b/tests/phpunit/tests/test-links-default.php
@@ -14,10 +14,10 @@ class Links_Default_Test extends PLL_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		self::$polylang->options['post_types'] = array(
+		self::$polylang->options['post_types'] = [
 			'cpt' => 'cpt',
-		);
-		register_post_type( 'cpt', array( 'public' => true ) ); // translated custom post type
+		];
+		register_post_type( 'cpt', [ 'public' => true ] ); // translated custom post type
 
 		self::$polylang->options['hide_default'] = 1;
 	}
@@ -54,7 +54,7 @@ class Links_Default_Test extends PLL_UnitTestCase {
 	}
 
 	function test_get_language_from_url() {
-		$_SERVER['HTTP_HOST'] = parse_url( $this->host, PHP_URL_HOST );
+		$_SERVER['HTTP_HOST']   = parse_url( $this->host, PHP_URL_HOST );
 		$_SERVER['REQUEST_URI'] = '/?p=test&lang=fr';
 		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
 	}
@@ -68,7 +68,7 @@ class Links_Default_Test extends PLL_UnitTestCase {
 	// bug fixed in v1.8
 	function test_language_code_in_post_url() {
 		self::$polylang->options['force_lang'] = 1;
-		self::$polylang->filter_links = new PLL_Filters_Links( self::$polylang );
+		self::$polylang->filter_links          = new PLL_Filters_Links( self::$polylang );
 
 		$en = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $en, 'en' );
@@ -79,19 +79,19 @@ class Links_Default_Test extends PLL_UnitTestCase {
 		$this->assertNotContains( 'lang=en', get_permalink( $en ) );
 		$this->assertContains( 'lang=fr', get_permalink( $fr ) );
 
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=en', get_permalink( $en ) );
 		$this->assertContains( 'lang=fr', get_permalink( $fr ) );
 
-		$en = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'cpt' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'cpt' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=en', get_permalink( $en ) );
@@ -100,19 +100,19 @@ class Links_Default_Test extends PLL_UnitTestCase {
 
 	function test_language_from_post_content() {
 		self::$polylang->options['force_lang'] = 0;
-		self::$polylang->filter_links = new PLL_Filters_Links( self::$polylang );
+		self::$polylang->filter_links          = new PLL_Filters_Links( self::$polylang );
 
 		$fr = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=fr', get_permalink( $fr ) );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=fr', get_permalink( $fr ) );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'cpt' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=fr', get_permalink( $fr ) );

--- a/tests/phpunit/tests/test-links-directory.php
+++ b/tests/phpunit/tests/test-links-directory.php
@@ -2,7 +2,7 @@
 
 class Links_Directory_Test extends PLL_UnitTestCase {
 	protected $structure = '/%postname%/';
-	protected $host = 'http://example.org';
+	protected $host      = 'http://example.org';
 
 	static function wpSetUpBeforeClass() {
 		parent::wpSetUpBeforeClass();
@@ -18,7 +18,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		global $wp_rewrite;
 
 		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['rewrite'] = 1;
+		self::$polylang->options['rewrite']      = 1;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
@@ -108,7 +108,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
 
 		self::$polylang->options['rewrite'] = 0;
-		$_SERVER['REQUEST_URI'] = '/language/fr/test/';
+		$_SERVER['REQUEST_URI']             = '/language/fr/test/';
 		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
 
 		$_SERVER = $server;

--- a/tests/phpunit/tests/test-links-domain.php
+++ b/tests/phpunit/tests/test-links-domain.php
@@ -7,15 +7,15 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 
 		global $wp_rewrite;
 
-		$this->hosts = array(
+		$this->hosts = [
 			'en' => 'http://example.org',
 			'fr' => 'http://example.fr',
 			'de' => 'http://example.de',
-		);
+		];
 
 		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['force_lang'] = 3;
-		self::$polylang->options['domains'] = $this->hosts;
+		self::$polylang->options['force_lang']   = 3;
+		self::$polylang->options['domains']      = $this->hosts;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
@@ -42,7 +42,7 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 	// Bug fixed in version 2.1.2
 	function test_second_level_domain() {
 		self::$polylang->options['domains']['fr'] = 'http://example.org.fr';
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		self::$polylang->links_model              = self::$polylang->model->get_links_model();
 
 		$url = 'http://example.org.fr';
 
@@ -66,7 +66,7 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 
 		// non www. to www.
 		self::$polylang->options['domains']['fr'] = 'http://www.example.fr';
-		$_SERVER['HTTP_HOST'] = 'example.fr';
+		$_SERVER['HTTP_HOST']                     = 'example.fr';
 		$this->assertEquals( 'http://www.example.fr', $filters_links->check_canonical_url( 'http://' . $_SERVER['HTTP_HOST'], false ) );
 		$this->assertEquals( 'http://www.example.fr/test/', $filters_links->check_canonical_url( 'http://' . $_SERVER['HTTP_HOST'] . '/test/', false ) );
 	}

--- a/tests/phpunit/tests/test-links-subdomain.php
+++ b/tests/phpunit/tests/test-links-subdomain.php
@@ -7,14 +7,14 @@ class Links_Subdomain_Test extends PLL_Domain_UnitTestCase {
 
 		global $wp_rewrite;
 
-		$this->hosts = array(
+		$this->hosts = [
 			'en' => 'http://example.org',
 			'fr' => 'http://fr.example.org',
 			'de' => 'http://de.example.org',
-		);
+		];
 
 		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['force_lang'] = 2;
+		self::$polylang->options['force_lang']   = 2;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();

--- a/tests/phpunit/tests/test-media.php
+++ b/tests/phpunit/tests/test-media.php
@@ -13,7 +13,7 @@ class Media_Test extends PLL_UnitTestCase {
 		parent::setUp();
 
 		self::$polylang->options['media_support'] = 1;
-		self::$polylang->filters_media = new PLL_Admin_Filters_Media( self::$polylang );
+		self::$polylang->filters_media            = new PLL_Admin_Filters_Media( self::$polylang );
 		add_filter( 'intermediate_image_sizes', '__return_empty_array' );  // don't create intermediate sizes to save time
 	}
 
@@ -21,7 +21,7 @@ class Media_Test extends PLL_UnitTestCase {
 		self::$polylang->pref_lang = self::$polylang->model->get_language( 'fr' );
 
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
-		$fr = $this->factory->attachment->create_upload_object( $filename );
+		$fr       = $this->factory->attachment->create_upload_object( $filename );
 		$this->assertEquals( self::$polylang->pref_lang, self::$polylang->model->post->get_language( $fr ) );
 
 		// cleanup
@@ -32,15 +32,15 @@ class Media_Test extends PLL_UnitTestCase {
 		self::$polylang->pref_lang = self::$polylang->model->get_language( 'en' );
 
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
-		$en = $this->factory->attachment->create_upload_object( $filename );
-		$fr = self::$polylang->filters_media->create_media_translation( $en, 'fr' );
+		$en       = $this->factory->attachment->create_upload_object( $filename );
+		$fr       = self::$polylang->filters_media->create_media_translation( $en, 'fr' );
 
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $fr )->slug );
 		$this->assertEquals( self::$polylang->model->post->get_translation( $en, 'fr' ), $fr );
 
-		$data = wp_get_attachment_metadata( $en );
+		$data        = wp_get_attachment_metadata( $en );
 		$uploads_dir = wp_upload_dir();
-		$filename = $uploads_dir['basedir'] . '/' . $data['file'];
+		$filename    = $uploads_dir['basedir'] . '/' . $data['file'];
 
 		// deleting a translation does not delete the file
 		wp_delete_attachment( $en );
@@ -53,7 +53,7 @@ class Media_Test extends PLL_UnitTestCase {
 
 	function test_attachment_fields_to_edit() {
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
-		$fr = $this->factory->attachment->create_upload_object( $filename );
+		$fr       = $this->factory->attachment->create_upload_object( $filename );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$fields = get_attachment_fields_to_edit( $fr );
@@ -68,31 +68,36 @@ class Media_Test extends PLL_UnitTestCase {
 
 		// Don't use on the Edit Media panel
 		$GLOBALS['pagenow'] = 'post.php';
-		$fields = get_attachment_fields_to_edit( $fr );
+		$fields             = get_attachment_fields_to_edit( $fr );
 		$this->assertFalse( isset( $fields['language'] ) );
 	}
 
 	function test_attachment_fields_to_save() {
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
-		$en = $this->factory->attachment->create_upload_object( $filename );
+		$en       = $this->factory->attachment->create_upload_object( $filename );
 		self::$polylang->model->post->set_language( $en, 'en' );
 		$fr = $this->factory->attachment->create_upload_object( $filename );
 
-		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$editor = self::factory()->user->create( [ 'role' => 'editor' ] );
 		wp_set_current_user( $editor ); // Set a user to pass current_user_can tests
 
-		$_REQUEST = $_POST = array(
+		$_REQUEST = $_POST = [
 			'post_ID'       => $fr,
 			'post_title'    => 'Test image',
-			'attachments'   => array( $fr => array( 'language' => 'fr' ) ),
-			'media_tr_lang' => array( 'en' => $en ),
+			'attachments'   => [ $fr => [ 'language' => 'fr' ] ],
+			'media_tr_lang' => [ 'en' => $en ],
 			'_pll_nonce'    => wp_create_nonce( 'pll_language' ),
-		);
+		];
 		edit_post();
 
 		$this->assertEquals( 'en', self::$polylang->model->post->get_language( $en )->slug );
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $fr )->slug );
-		$this->assertEqualSets( array( 'en' => $en, 'fr' => $fr ), self::$polylang->model->post->get_translations( $en ) );
+		$this->assertEqualSets(
+			[
+				'en' => $en,
+				'fr' => $fr,
+			], self::$polylang->model->post->get_translations( $en )
+		);
 
 		unset( $_REQUEST, $_POST );
 	}

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -15,20 +15,38 @@ class Model_Test extends PLL_UnitTestCase {
 	function test_languages_list() {
 		self::$polylang->model->post->register_taxonomy(); // needed otherwise posts are not counted
 
-		$this->assertEquals( array( 'en', 'fr' ), self::$polylang->model->get_languages_list( array( 'fields' => 'slug' ) ) );
-		$this->assertEquals( array( 'English', 'Français' ), self::$polylang->model->get_languages_list( array( 'fields' => 'name' ) ) );
-		$this->assertEquals( array(), self::$polylang->model->get_languages_list( array( 'hide_empty' => true ) ) );
+		$this->assertEquals( [ 'en', 'fr' ], self::$polylang->model->get_languages_list( [ 'fields' => 'slug' ] ) );
+		$this->assertEquals( [ 'English', 'Français' ], self::$polylang->model->get_languages_list( [ 'fields' => 'name' ] ) );
+		$this->assertEquals( [], self::$polylang->model->get_languages_list( [ 'hide_empty' => true ] ) );
 
 		$post_id = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
-		$this->assertEquals( array( 'en' ), self::$polylang->model->get_languages_list( array( 'fields' => 'slug', 'hide_empty' => true ) ) );
+		$this->assertEquals(
+			[ 'en' ], self::$polylang->model->get_languages_list(
+				[
+					'fields' => 'slug',
+					'hide_empty' => true,
+				]
+			)
+		);
 	}
 
 	function test_term_exists() {
-		$parent = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
+		$parent = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'parent',
+			]
+		);
 		self::$polylang->model->term->set_language( $parent, 'en' );
-		$child = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'child', 'parent' => $parent ) );
+		$child = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'child',
+				'parent' => $parent,
+			]
+		);
 		self::$polylang->model->term->set_language( $child, 'en' );
 
 		$this->assertEquals( $parent, self::$polylang->model->term_exists( 'parent', 'category', 0, 'en' ) );
@@ -43,34 +61,65 @@ class Model_Test extends PLL_UnitTestCase {
 		$en = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
+		$en = $this->factory->post->create(
+			[
+				'post_date' => '2007-09-04 00:00:00',
+				'post_author' => 1,
+			]
+		);
 		set_post_format( $en, 'aside' );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
-		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1, 'post_status' => 'draft' ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_date' => '2007-09-04 00:00:00',
+				'post_author' => 1,
+				'post_status' => 'draft',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
-		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_date' => '2007-09-04 00:00:00',
+				'post_author' => 1,
+			]
+		);
 		set_post_format( $fr, 'aside' );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$language = self::$polylang->model->get_language( 'fr' );
 		$this->assertEquals( 2, self::$polylang->model->count_posts( $language ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'post_format' => 'post-format-aside' ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'year' => 2007 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9, 'day' => 4 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'm' => 2007 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'm' => 200709 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'm' => 20070904 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'author' => 1 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'author_name' => 'admin' ) ) );
+		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, [ 'post_format' => 'post-format-aside' ] ) );
+		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, [ 'year' => 2007 ] ) );
+		$this->assertEquals(
+			1, self::$polylang->model->count_posts(
+				$language, [
+					'year' => 2007,
+					'monthnum' => 9,
+				]
+			)
+		);
+		$this->assertEquals(
+			1, self::$polylang->model->count_posts(
+				$language, [
+					'year' => 2007,
+					'monthnum' => 9,
+					'day' => 4,
+				]
+			)
+		);
+		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, [ 'm' => 2007 ] ) );
+		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, [ 'm' => 200709 ] ) );
+		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, [ 'm' => 20070904 ] ) );
+		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, [ 'author' => 1 ] ) );
+		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, [ 'author_name' => 'admin' ] ) );
 
 		// Bug fixed in version 2.2.6
-		$this->assertEquals( 2, self::$polylang->model->count_posts( $language, array( 'post_type' => array( 'post', 'page' ) ) ) );
+		$this->assertEquals( 2, self::$polylang->model->count_posts( $language, [ 'post_type' => [ 'post', 'page' ] ] ) );
 	}
 
 	function test_backward_compat_1_8() {
@@ -98,12 +147,12 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertEquals( @self::$polylang->model->where_clause( 'en', 'post' ), self::$polylang->model->post->where_clause( 'en' ) );
 
 		// term
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $en )->slug );
 		$this->assertEquals( 'en', @self::$polylang->model->get_term_language( $en )->slug );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		@self::$polylang->model->set_term_language( $fr, 'fr' );
 		@self::$polylang->model->save_translations( 'term', $en, compact( 'en', 'fr' ) );
 		$this->assertEquals( $en, @self::$polylang->model->get_term( $fr, 'en' ) );
@@ -154,9 +203,9 @@ class Model_Test extends PLL_UnitTestCase {
 	}
 
 	function test_is_translated_post_type() {
-		self::$polylang->options['post_types'] = array(
+		self::$polylang->options['post_types'] = [
 			'trcpt' => 'trcpt',
-		);
+		];
 
 		register_post_type( 'trcpt' ); // translated custom post type
 		register_post_type( 'cpt' ); // *untranslated* custom post type
@@ -164,19 +213,19 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertTrue( pll_is_translated_post_type( 'trcpt' ) );
 		$this->assertFalse( pll_is_translated_post_type( 'cpt' ) );
 
-		$this->assertTrue( pll_is_translated_post_type( array( 'trcpt' ) ) );
-		$this->assertFalse( pll_is_translated_post_type( array( 'cpt' ) ) );
+		$this->assertTrue( pll_is_translated_post_type( [ 'trcpt' ] ) );
+		$this->assertFalse( pll_is_translated_post_type( [ 'cpt' ] ) );
 
-		$this->assertTrue( pll_is_translated_post_type( array( 'trcpt', 'cpt' ) ) );
+		$this->assertTrue( pll_is_translated_post_type( [ 'trcpt', 'cpt' ] ) );
 
 		_unregister_post_type( 'cpt' );
 		_unregister_post_type( 'trcpt' );
 	}
 
 	function test_is_translated_taxonomy() {
-		self::$polylang->options['taxonomies'] = array(
+		self::$polylang->options['taxonomies'] = [
 			'trtax' => 'trtax',
-		);
+		];
 
 		register_taxonomy( 'trtax', 'post' ); // translated custom tax
 		register_taxonomy( 'tax', 'post' ); // *untranslated* custom tax
@@ -184,20 +233,20 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertTrue( pll_is_translated_taxonomy( 'trtax' ) );
 		$this->assertFalse( pll_is_translated_taxonomy( 'tax' ) );
 
-		$this->assertTrue( pll_is_translated_taxonomy( array( 'trtax' ) ) );
-		$this->assertFalse( pll_is_translated_taxonomy( array( 'tax' ) ) );
+		$this->assertTrue( pll_is_translated_taxonomy( [ 'trtax' ] ) );
+		$this->assertFalse( pll_is_translated_taxonomy( [ 'tax' ] ) );
 
-		$this->assertTrue( pll_is_translated_taxonomy( array( 'trtax', 'tax' ) ) );
+		$this->assertTrue( pll_is_translated_taxonomy( [ 'trtax', 'tax' ] ) );
 
 		_unregister_taxonomy( 'tax' );
 		_unregister_taxonomy( 'trtax' );
 	}
 
 	function test_is_filtered_taxonomy() {
-		$this->assertTrue( self::$polylang->model->is_filtered_taxonomy( array( 'post_format' ) ) );
-		$this->assertFalse( self::$polylang->model->is_filtered_taxonomy( array( 'category' ) ) );
+		$this->assertTrue( self::$polylang->model->is_filtered_taxonomy( [ 'post_format' ] ) );
+		$this->assertFalse( self::$polylang->model->is_filtered_taxonomy( [ 'category' ] ) );
 
-		$this->assertTrue( self::$polylang->model->is_filtered_taxonomy( array( 'post_format', 'category' ) ) );
+		$this->assertTrue( self::$polylang->model->is_filtered_taxonomy( [ 'post_format', 'category' ] ) );
 	}
 }
 

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -22,54 +22,60 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 	function tearDown() {
 		parent::tearDown();
 
-		$_POST = $_REQUEST = array();
+		$_POST = $_REQUEST = [];
 	}
 
 	function test_nav_menu_locations() {
 		// get the primary location of the current theme
-		$locations = array_keys( get_registered_nav_menus() );
+		$locations        = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
 
 		// create 3 menus
 		$menu_en = wp_create_nav_menu( 'menu_en' );
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Hello World' ) );
-		$item_id = wp_update_nav_menu_item( $menu_en, 0, array(
-			'menu-item-type'      => 'post_type',
-			'menu-item-object'    => 'post',
-			'menu-item-object-id' => $post_id,
-			'menu-item-title'     => 'Hello World',
-			'menu-item-status'    => 'publish',
-		) );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'Hello World' ] );
+		$item_id = wp_update_nav_menu_item(
+			$menu_en, 0, [
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-title'     => 'Hello World',
+				'menu-item-status'    => 'publish',
+			]
+		);
 
 		$menu_fr = wp_create_nav_menu( 'menu_fr' );
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Bonjour' ) );
-		$item_id = wp_update_nav_menu_item( $menu_fr, 0, array(
-			'menu-item-type'      => 'post_type',
-			'menu-item-object'    => 'post',
-			'menu-item-object-id' => $post_id,
-			'menu-item-title'     => 'Bonjour',
-			'menu-item-status'    => 'publish',
-		) );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'Bonjour' ] );
+		$item_id = wp_update_nav_menu_item(
+			$menu_fr, 0, [
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-title'     => 'Bonjour',
+				'menu-item-status'    => 'publish',
+			]
+		);
 
-		$menu_0 = wp_create_nav_menu( 'menu_0' );
-		$post_id = $this->factory->post->create( array( 'post_title' => 'No language' ) );
-		$item_id = wp_update_nav_menu_item( $menu_0, 0, array(
-			'menu-item-type'      => 'post_type',
-			'menu-item-object'    => 'post',
-			'menu-item-object-id' => $post_id,
-			'menu-item-title'     => 'No language',
-			'menu-item-status'    => 'publish',
-		) );
+		$menu_0  = wp_create_nav_menu( 'menu_0' );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'No language' ] );
+		$item_id = wp_update_nav_menu_item(
+			$menu_0, 0, [
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-title'     => 'No language',
+				'menu-item-status'    => 'publish',
+			]
+		);
 
 		// assign our menus to locations
 		$nav_menu = new PLL_Admin_Nav_Menu( self::$polylang );
 		$nav_menu->create_nav_menu_locations();
 
-		$locations = array_keys( get_registered_nav_menus() );
-		$nav_menu_locations = array(
+		$locations          = array_keys( get_registered_nav_menus() );
+		$nav_menu_locations = [
 			$locations[0] => $menu_en,
 			$locations[1] => $menu_fr,
-		);
+		];
 
 		set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$nav_menu->update_nav_menu_locations( $nav_menu_locations ); // our filter update_nav_menu_locations does not run due to security checks
@@ -77,28 +83,43 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		// test nav menus on frontend when using theme locations
 		self::$polylang->nav_menu = new PLL_Frontend_Nav_Menu( self::$polylang );
 
-		$args = array( 'theme_location' => $primary_location, 'echo' => false );
+		$args = [
+			'theme_location' => $primary_location,
+			'echo' => false,
+		];
 		$this->assertContains( 'Hello World', wp_nav_menu( $args ) );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 
-		$args = array( 'theme_location' => $primary_location, 'echo' => false );
+		$args = [
+			'theme_location' => $primary_location,
+			'echo' => false,
+		];
 		$this->assertContains( 'Bonjour', wp_nav_menu( $args ) );
 
 		// test with hardcoded menu
-		$args = array( 'menu' => 'menu_en', 'echo' => false );
+		$args = [
+			'menu' => 'menu_en',
+			'echo' => false,
+		];
 		$this->assertContains( 'Bonjour', wp_nav_menu( $args ) );
 
 		// test with wrong hardcoded menu
-		$args = array( 'menu' => $primary_location, 'echo' => false ); // this is what we often see in themes
+		$args = [
+			'menu' => $primary_location,
+			'echo' => false,
+		]; // this is what we often see in themes
 		$this->assertContains( 'Bonjour', wp_nav_menu( $args ) );
 
 		// test without theme location or hardcoded menu
-		$args = array( 'echo' => false );
+		$args = [ 'echo' => false ];
 		$this->assertContains( 'Bonjour', wp_nav_menu( $args ) );
 
 		// test with untranslated menu hardcoded
-		$args = array( 'menu' => 'menu_0', 'echo' => false );
+		$args = [
+			'menu' => 'menu_0',
+			'echo' => false,
+		];
 		$this->assertContains( 'No language', wp_nav_menu( $args ) );
 	}
 
@@ -106,7 +127,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$theme = get_option( 'stylesheet' );
 
 		// get the primary location of the current theme
-		$locations = array_keys( get_registered_nav_menus() );
+		$locations        = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
 
 		// create 2 menus
@@ -117,17 +138,22 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$nav_menu = new PLL_Admin_Nav_Menu( self::$polylang );
 		$nav_menu->create_nav_menu_locations();
 
-		$locations = array_keys( get_registered_nav_menus() );
-		$nav_menu_locations = array(
+		$locations          = array_keys( get_registered_nav_menus() );
+		$nav_menu_locations = [
 			$locations[0] => $menu_en,
 			$locations[1] => $menu_fr,
-		);
+		];
 
 		set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$nav_menu->update_nav_menu_locations( $nav_menu_locations ); // our filter update_nav_menu_locations does not run due to security checks
 
 		$options = get_option( 'polylang' );
-		$this->assertEquals( array( 'en' => $menu_en, 'fr' => $menu_fr ), $options['nav_menus'][ $theme ][ $primary_location ] );
+		$this->assertEquals(
+			[
+				'en' => $menu_en,
+				'fr' => $menu_fr,
+			], $options['nav_menus'][ $theme ][ $primary_location ]
+		);
 
 		// setup filters
 		$nav_menu->admin_init();
@@ -136,7 +162,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		wp_delete_nav_menu( $menu_en );
 
 		$options = get_option( 'polylang' );
-		$this->assertEquals( array( 'fr' => $menu_fr ), $options['nav_menus'][ $theme ][ $primary_location ] );
+		$this->assertEquals( [ 'fr' => $menu_fr ], $options['nav_menus'][ $theme ][ $primary_location ] );
 	}
 
 	function test_auto_add_pages_to_menu() {
@@ -145,13 +171,13 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$menu_fr = wp_create_nav_menu( 'menu_fr' );
 
 		// add our 2 menus to auto added pages
-		update_option( 'nav_menu_options', array( 'auto_add' => array( $menu_en, $menu_fr ) ) );
+		update_option( 'nav_menu_options', [ 'auto_add' => [ $menu_en, $menu_fr ] ] );
 
-		$locations = array_keys( get_registered_nav_menus() );
-		$nav_menu_locations = array(
+		$locations          = array_keys( get_registered_nav_menus() );
+		$nav_menu_locations = [
 			$locations[0] => $menu_en,
 			$locations[1] => $menu_fr,
-		);
+		];
 
 		// assign our menus to locations
 		$nav_menu = new PLL_Admin_Nav_Menu( self::$polylang );
@@ -161,14 +187,19 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$nav_menu->update_nav_menu_locations( $nav_menu_locations ); // our filter update_nav_menu_locations does not run due to security checks
 
 		// add the filter we want to test
-		add_action( 'transition_post_status', array( &$nav_menu, 'auto_add_pages_to_menu' ), 5, 3 ); // before _wp_auto_add_pages_to_menu
+		add_action( 'transition_post_status', [ &$nav_menu, 'auto_add_pages_to_menu' ], 5, 3 ); // before _wp_auto_add_pages_to_menu
 
 		// create a draft as we want to set the language *before* publication
-		$post_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_status' => 'draft' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_status' => 'draft',
+			]
+		);
 		self::$polylang->model->post->set_language( $post_id, 'fr' );
 		wp_publish_post( $post_id );
 
-		$this->assertEquals( array(), wp_get_nav_menu_items( $menu_en ) ); // no menu item in menu_en
+		$this->assertEquals( [], wp_get_nav_menu_items( $menu_en ) ); // no menu item in menu_en
 
 		$menu_items = wp_get_nav_menu_items( $menu_fr );
 		$this->assertEquals( $post_id, reset( $menu_items )->object_id ); // our page menu item in menu_fr
@@ -185,44 +216,56 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 	function test_explode_location() {
 		$nav_menu = new PLL_Nav_Menu( self::$polylang );
 
-		$this->assertEquals( array( 'location' => 'primary', 'lang' => 'en' ), $nav_menu->explode_location( 'primary' ) );
-		$this->assertEquals( array( 'location' => 'primary', 'lang' => 'fr' ), $nav_menu->explode_location( 'primary___fr' ) );
+		$this->assertEquals(
+			[
+				'location' => 'primary',
+				'lang' => 'en',
+			], $nav_menu->explode_location( 'primary' )
+		);
+		$this->assertEquals(
+			[
+				'location' => 'primary',
+				'lang' => 'fr',
+			], $nav_menu->explode_location( 'primary___fr' )
+		);
 	}
 
 	function setup_nav_menus( $options ) {
 		// create posts
-		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$en = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$fr = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		// create 1 menu
 		$menu_en = wp_create_nav_menu( 'menu_en' );
-		$item_id = wp_update_nav_menu_item( $menu_en, 0, array(
-			'menu-item-type'   => 'custom',
-			'menu-item-title'  => 'Language switcher',
-			'menu-item-url'    => '#pll_switcher',
-			'menu-item-status' => 'publish',
-		) );
+		$item_id = wp_update_nav_menu_item(
+			$menu_en, 0, [
+				'menu-item-type'   => 'custom',
+				'menu-item-title'  => 'Language switcher',
+				'menu-item-url'    => '#pll_switcher',
+				'menu-item-status' => 'publish',
+			]
+		);
 
 		$options['hide_if_empty'] = 0; // FIXME for some reason the languages counts are 0 even if I manually call clean_languages_cache()
 		update_post_meta( $item_id, '_pll_menu_item', $options );
 
 		// get the primary location of the current theme
-		$locations = array_keys( get_registered_nav_menus() );
+		$locations        = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
 
 		// assign our menus to locations
 		$nav_menu = new PLL_Admin_Nav_Menu( self::$polylang );
 		$nav_menu->create_nav_menu_locations();
 
-		$locations = array_keys( get_registered_nav_menus() );
-		$nav_menu_locations = array(
+		$locations          = array_keys( get_registered_nav_menus() );
+		$nav_menu_locations = [
 			$locations[0] => $menu_en,
-		);
+		];
 
 		set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$nav_menu->update_nav_menu_locations( $nav_menu_locations ); // our filter update_nav_menu_locations does not run due to security checks
@@ -231,18 +274,27 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 	}
 
 	function test_nav_menu_language_switcher() {
-		$options = array( 'hide_if_no_translation' => 0, 'hide_current' => 0, 'force_home' => 0, 'show_flags' => 0, 'show_names' => 1 ); // default values
+		$options          = [
+			'hide_if_no_translation' => 0,
+			'hide_current' => 0,
+			'force_home' => 0,
+			'show_flags' => 0,
+			'show_names' => 1,
+		]; // default values
 		$primary_location = $this->setup_nav_menus( $options );
 
 		// test nav menus on frontend when using theme locations
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
-		self::$polylang->links = new PLL_Frontend_Links( self::$polylang );
+		self::$polylang->curlang  = self::$polylang->model->get_language( 'en' );
+		self::$polylang->links    = new PLL_Frontend_Links( self::$polylang );
 		self::$polylang->nav_menu = new PLL_Frontend_Nav_Menu( self::$polylang );
 
 		require_once PLL_INC . '/api.php'; // usually loaded only if an instance of Polylang exists
 		$GLOBALS['polylang'] = self::$polylang; // FIXME we still use PLL() in PLL_Frontend_Nav_Menu
 
-		$args = array( 'theme_location' => $primary_location, 'echo' => false );
+		$args = [
+			'theme_location' => $primary_location,
+			'echo' => false,
+		];
 		$this->assertContains( 'Français', wp_nav_menu( $args ) );
 		$this->assertContains( 'English', wp_nav_menu( $args ) );
 
@@ -250,19 +302,29 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 	}
 
 	function test_nav_menu_language_switcher_as_dropdown() {
-		$options = array( 'hide_if_no_translation' => 0, 'hide_current' => 1, 'force_home' => 0, 'show_flags' => 0, 'show_names' => 1, 'dropdown' => 1 );
+		$options          = [
+			'hide_if_no_translation' => 0,
+			'hide_current' => 1,
+			'force_home' => 0,
+			'show_flags' => 0,
+			'show_names' => 1,
+			'dropdown' => 1,
+		];
 		$primary_location = $this->setup_nav_menus( $options );
 
 		// test nav menus on frontend when using theme locations
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
-		self::$polylang->links = new PLL_Frontend_Links( self::$polylang );
+		self::$polylang->curlang  = self::$polylang->model->get_language( 'en' );
+		self::$polylang->links    = new PLL_Frontend_Links( self::$polylang );
 		self::$polylang->nav_menu = new PLL_Frontend_Nav_Menu( self::$polylang );
 
 		require_once PLL_INC . '/api.php'; // usually loaded only if an instance of Polylang exists
 		$GLOBALS['polylang'] = self::$polylang; // FIXME we still use PLL() in PLL_Frontend_Nav_Menu
 
-		$args = array( 'theme_location' => $primary_location, 'echo' => false );
-		$doc = new DomDocument();
+		$args = [
+			'theme_location' => $primary_location,
+			'echo' => false,
+		];
+		$doc  = new DomDocument();
 		$menu = wp_nav_menu( $args );
 		$menu = preg_replace( '#<svg(.+)</svg>#', '', $menu ); // Remove SVG Added by Twenty Seventeen to avoid an error in loadHTML()
 		$menu = mb_convert_encoding( $menu, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
@@ -281,27 +343,34 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$nav_menu = new PLL_Admin_Nav_Menu( self::$polylang );
 		$nav_menu->admin_init(); // Setup filters
 
-		$args = array(
+		$args = [
 			'menu-item-type'   => 'custom',
 			'menu-item-title'  => 'Language switcher',
 			'menu-item-url'    => '#pll_switcher',
 			'menu-item-status' => 'publish',
-		);
+		];
 
 		$menu_en = wp_create_nav_menu( 'menu_en' );
 		$item_id = wp_update_nav_menu_item( $menu_en, 0, $args );
 
-		$_REQUEST = $_POST = array(
-			'menu-item-url'         => array( $item_id => '#pll_switcher' ),
-			'menu-item-show_names'  => array( $item_id => 1 ),
-			'menu-item-show_flags'  => array( $item_id => 1 ),
-			'menu-item-pll-detect'  => array( $item_id => 1 ),
+		$_REQUEST = $_POST = [
+			'menu-item-url'         => [ $item_id => '#pll_switcher' ],
+			'menu-item-show_names'  => [ $item_id => 1 ],
+			'menu-item-show_flags'  => [ $item_id => 1 ],
+			'menu-item-pll-detect'  => [ $item_id => 1 ],
 			'update-nav-menu-nonce' => wp_create_nonce( 'update-nav_menu' ),
-		);
+		];
 
 		wp_update_nav_menu_item( $menu_en, $item_id, $args );
 
-		$expected = array( 'hide_if_no_translation' => 0, 'hide_current' => 0, 'force_home' => 0, 'show_flags' => 1, 'show_names' => 1, 'dropdown' => 0 );
+		$expected = [
+			'hide_if_no_translation' => 0,
+			'hide_current' => 0,
+			'force_home' => 0,
+			'show_flags' => 1,
+			'show_names' => 1,
+			'dropdown' => 0,
+		];
 		$this->assertEqualSets( $expected, get_post_meta( $item_id, '_pll_menu_item', true ) );
 	}
 
@@ -324,7 +393,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		wp_set_current_user( 1 );
 
 		// Get the primary location of the current theme
-		$locations = array_keys( get_registered_nav_menus() );
+		$locations        = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
 
 		$nav_menu = new PLL_Admin_Nav_Menu( self::$polylang );
@@ -334,20 +403,25 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$locations = array_keys( get_registered_nav_menus() );
 
 		// Assign some menu ids to locations
-		$nav_menu_locations = array(
+		$nav_menu_locations = [
 			$locations[0] => 2,
 			$locations[1] => 3,
-		);
+		];
 
-		$_POST = $_REQUEST = array(
+		$_POST = $_REQUEST = [
 			'menu-locations'        => $nav_menu_locations,
 			'action'                => 'update',
 			'update-nav-menu-nonce' => wp_create_nonce( 'update-nav_menu' ),
-		);
+		];
 
-		$mods = set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
+		$mods    = set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$options = get_option( 'polylang' );
-		$this->assertEqualSets( array( 'en' => 2, 'fr' => 3 ), $options['nav_menus'][ get_stylesheet() ][ $primary_location ] );
+		$this->assertEqualSets(
+			[
+				'en' => 2,
+				'fr' => 3,
+			], $options['nav_menus'][ get_stylesheet() ][ $primary_location ]
+		);
 		$options = get_option( 'theme_mods_' . get_stylesheet() );
 		$this->assertEquals( 2, $options['nav_menu_locations'][ $primary_location ] );
 	}
@@ -356,7 +430,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		wp_set_current_user( 1 );
 
 		// Get the primary location of the current theme
-		$locations = array_keys( get_registered_nav_menus() );
+		$locations        = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
 
 		$nav_menu = new PLL_Admin_Nav_Menu( self::$polylang );
@@ -366,24 +440,29 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$locations = array_keys( get_registered_nav_menus() );
 
 		// Assign some menu ids to locations
-		$nav_menu_locations = array(
+		$nav_menu_locations = [
 			$locations[0] => 4,
 			$locations[1] => 5,
-		);
+		];
 
-		$_GET['action'] = 'locations';
+		$_GET['action']       = 'locations';
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'save-menu-locations' );
 
-		$mods = set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
+		$mods    = set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$options = get_option( 'polylang' );
-		$this->assertEqualSets( array( 'en' => 4, 'fr' => 5 ), $options['nav_menus'][ get_stylesheet() ][ $primary_location ] );
+		$this->assertEqualSets(
+			[
+				'en' => 4,
+				'fr' => 5,
+			], $options['nav_menus'][ get_stylesheet() ][ $primary_location ]
+		);
 		$options = get_option( 'theme_mods_' . get_stylesheet() );
 		$this->assertEquals( 4, $options['nav_menu_locations'][ $primary_location ] );
 	}
 
 	function test_admin_nav_menus_scripts() {
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		self::$polylang            = new PLL_Admin( self::$polylang->links_model );
+		self::$polylang->links     = new PLL_Admin_Links( self::$polylang );
 		self::$polylang->nav_menus = new PLL_Admin_Nav_Menu( self::$polylang );
 		self::$polylang->nav_menus->admin_init();
 

--- a/tests/phpunit/tests/test-olt-manager.php
+++ b/tests/phpunit/tests/test-olt-manager.php
@@ -3,11 +3,11 @@
 class OLT_Manager_Test extends PLL_UnitTestCase {
 
 	function test_polylang_first() {
-		$plugins = array(
+		$plugins = [
 			'jetpack/jetpack.php',
 			POLYLANG_BASENAME,
 			'woocommerce/woocommerce.php',
-		);
+		];
 
 		update_option( 'active_plugins', $plugins );
 		$active_plugins = get_option( 'active_plugins' );

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -19,23 +19,33 @@ class Query_Test extends PLL_UnitTestCase {
 		global $wp_rewrite;
 
 		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['post_types'] = array(
+		self::$polylang->options['post_types']   = [
 			'trcpt' => 'trcpt',
-		);
-		self::$polylang->options['taxonomies'] = array(
+		];
+		self::$polylang->options['taxonomies']   = [
 			'trtax' => 'trtax',
-		);
+		];
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
 		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
-		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // translated custom post type with archives
+		register_post_type(
+			'trcpt', [
+				'public' => true,
+				'has_archive' => true,
+			]
+		); // translated custom post type with archives
 		register_taxonomy( 'trtax', 'trcpt' ); // translated custom tax
-		register_post_type( 'cpt', array( 'public' => true, 'has_archive' => true ) ); // *untranslated* custom post type with archives
+		register_post_type(
+			'cpt', [
+				'public' => true,
+				'has_archive' => true,
+			]
+		); // *untranslated* custom post type with archives
 		register_taxonomy( 'tax', 'cpt' ); // *untranslated* custom tax
 
 		self::$polylang->links_model = self::$polylang->model->get_links_model();
@@ -74,20 +84,20 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->go_to( home_url( '/' ) );
 
 		$this->assertQueryTrue( 'is_home', 'is_front_page' );
-		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $en ) ], $GLOBALS['wp_query']->posts );
 
 		$this->go_to( home_url( '/fr/' ) );
 
 		$this->assertQueryTrue( 'is_home', 'is_front_page' );
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEquals( home_url( '/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 	}
 
 	function test_single_post() {
-		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$en = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$fr = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
@@ -101,12 +111,18 @@ class Query_Test extends PLL_UnitTestCase {
 
 	function test_single_post_private_translation() {
 		// the 'get_user_metadata' filter in frontend-filters breaks this user_description gets '' instead of an array ?
-		$author_en = $this->factory->user->create( array( 'role' => 'author' ) );
+		$author_en = $this->factory->user->create( [ 'role' => 'author' ] );
 
-		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_author' => $author_en, 'post_status' => 'private' ) );
+		$en = $this->factory->post->create(
+			[
+				'post_title' => 'test',
+				'post_author' => $author_en,
+				'post_status' => 'private',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$fr = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
@@ -128,10 +144,20 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	function test_page() {
-		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
+		$en = $this->factory->post->create(
+			[
+				'post_title' => 'test',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai', 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_title' => 'essai',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
@@ -144,50 +170,70 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	function test_category() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$post_id = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $post_id, 'fr' );
-		wp_set_post_terms( $post_id, array( $fr ), 'category' );
+		wp_set_post_terms( $post_id, [ $fr ], 'category' );
 
 		$this->go_to( home_url( '/fr/category/essai/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_category' );
-		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $post_id ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEquals( home_url( '/fr/category/essai/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) ); // Link to self
 		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
 
 		$post_id = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $post_id, 'en' );
-		wp_set_post_terms( $post_id, array( $en ), 'category' );
+		wp_set_post_terms( $post_id, [ $en ], 'category' );
 
 		$this->assertEquals( home_url( '/category/test/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 	}
 
 	function test_post_tag() {
-		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$post_id = $this->factory->post->create( array( 'tags_input' => array( 'essai' ) ) );
+		$post_id = $this->factory->post->create( [ 'tags_input' => [ 'essai' ] ] );
 		self::$polylang->model->post->set_language( $post_id, 'fr' );
 
 		$this->go_to( home_url( '/fr/tag/essai/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_tag' );
-		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $post_id ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEquals( home_url( '/fr/tag/essai/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
 		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
 
-		$post_id = $this->factory->post->create( array( 'tags_input' => array( 'test' ) ) );
+		$post_id = $this->factory->post->create( [ 'tags_input' => [ 'test' ] ] );
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
 		$this->assertEquals( home_url( '/tag/test/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
@@ -201,7 +247,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->go_to( home_url( '/fr/type/aside/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_tax' );
-		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $post_id ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEquals( home_url( '/fr/type/aside/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
 		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
 
@@ -214,14 +260,24 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translated_custom_tax() {
-		$en = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'trtax',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'trtax',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$post_id = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
+		$post_id = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
 		wp_set_post_terms( $post_id, 'essai', 'trtax' ); // don't use 'tax_input' above as we don't pass current_user_can test in wp_insert_post
 		self::$polylang->model->post->set_language( $post_id, 'fr' );
 
@@ -230,11 +286,11 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertQueryTrue( 'is_archive', 'is_tax' );
 		$this->assertTrue( is_tax( 'trtax' ) );
 		$this->assertFalse( is_tax( 'language' ) );
-		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $post_id ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEquals( home_url( '/fr/trtax/essai/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
 		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
 
-		$post_id = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
+		$post_id = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
 		wp_set_post_terms( $post_id, 'test', 'trtax' );
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
@@ -242,20 +298,25 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	function test_untranslated_custom_tax() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
-		$post_id = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'tax',
+				'name' => 'test',
+			]
+		);
+		$post_id = $this->factory->post->create( [ 'post_type' => 'cpt' ] );
 		wp_set_post_terms( $post_id, 'test', 'tax' );
 
 		$this->go_to( home_url( '/tax/test/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_tax' );
 		$this->assertTrue( is_tax( 'tax' ) );
-		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $post_id ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
 	}
 
 	function test_translated_post_type_archive() {
-		$fr = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/fr/trcpt/' ) );
@@ -264,31 +325,41 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/trcpt/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
 		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
 
-		$en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
 		$this->go_to( home_url( '/fr/trcpt/' ) );
 
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 		$this->assertEquals( home_url( '/trcpt/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 	}
 
 	function test_untranslated_post_type_archive() {
-		$post_id = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
+		$post_id = $this->factory->post->create( [ 'post_type' => 'cpt' ] );
 
 		$this->go_to( home_url( '/cpt/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_post_type_archive' );
-		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $post_id ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
 
 		// Secondary query which would erroneously forces the language
-		$query = new WP_Query( array( 'post_type' => 'cpt', 'lang' => 'fr' ) );
-		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
+		$query = new WP_Query(
+			[
+				'post_type' => 'cpt',
+				'lang' => 'fr',
+			]
+		);
+		$this->assertEquals( [ get_post( $post_id ) ], $GLOBALS['wp_query']->posts );
 	}
 
 	function test_archives() {
-		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_date' => '2007-09-04 00:00:00',
+				'post_author' => 1,
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		// author
@@ -319,86 +390,113 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/2007/09/04/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
 		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
 
-		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
+		$en = $this->factory->post->create(
+			[
+				'post_date' => '2007-09-04 00:00:00',
+				'post_author' => 1,
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
 		// author
 		$this->go_to( home_url( '/fr/author/admin/' ) );
 
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 		$this->assertEquals( home_url( '/author/admin/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 
 		// year
 		$this->go_to( home_url( '/fr/2007/' ) );
 
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 		$this->assertEquals( home_url( '/2007/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 
 		// month
 		$this->go_to( home_url( '/fr/2007/09/' ) );
 
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 		$this->assertEquals( home_url( '/2007/09/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 
 		// day
 		$this->go_to( home_url( '/fr/2007/09/04/' ) );
 
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 		$this->assertEquals( home_url( '/2007/09/04/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 	}
 
 	function test_search() {
-		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$en = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'test fr' ) );
+		$fr = $this->factory->post->create( [ 'post_title' => 'test fr' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/fr/?s=test' ) );
 
 		$this->assertQueryTrue( 'is_search' ); // we don't want is_tax
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 		$this->assertEquals( home_url( '/fr/?s=test' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
 		$this->assertEquals( home_url( '/?s=test' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 	}
 
 	function test_search_in_category() {
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $post_id, 'en' );
-		wp_set_post_terms( $post_id, array( $en ), 'category' );
+		wp_set_post_terms( $post_id, [ $en ], 'category' );
 
-		$searched = $this->factory->post->create( array( 'post_title' => 'test fr' ) );
+		$searched = $this->factory->post->create( [ 'post_title' => 'test fr' ] );
 		self::$polylang->model->post->set_language( $searched, 'fr' );
-		wp_set_post_terms( $searched, array( $fr ), 'category' );
+		wp_set_post_terms( $searched, [ $fr ], 'category' );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force otherwise get_translation_url fails to translate the category slug
 		$this->go_to( home_url( '/fr/category/essai/?s=test' ) );
 
 		$this->assertQueryTrue( 'is_search', 'is_category', 'is_archive' ); // we don't want is_tax
-		$this->assertEquals( array( get_post( $searched ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $searched ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 		$this->assertEquals( home_url( '/category/test/?s=test' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
 	}
 
 	// bug fixed in v1.7.11: error 404 for attachments
 	// bug fixed in v1.9.1: language switcher does not link to media translation for anonymous user
 	function test_attachment() {
-		$post_en = $this->factory->post->create( array( 'post_title' => 'test' ) );
+		$post_en = $this->factory->post->create( [ 'post_title' => 'test' ] );
 		self::$polylang->model->post->set_language( $post_en, 'en' );
 
-		$post_fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$post_fr = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $post_fr, 'fr' );
 
-		$en = $this->factory->post->create( array( 'post_title' => 'img_en', 'post_type' => 'attachment', 'post_parent' => $post_en ) );
+		$en = $this->factory->post->create(
+			[
+				'post_title' => 'img_en',
+				'post_type' => 'attachment',
+				'post_parent' => $post_en,
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'img_fr', 'post_type' => 'attachment', 'post_parent' => $post_fr ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_title' => 'img_fr',
+				'post_type' => 'attachment',
+				'post_parent' => $post_fr,
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
@@ -406,16 +504,26 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->go_to( home_url( '/fr/essai/img_fr/' ) );
 
 		$this->assertQueryTrue( 'is_attachment', 'is_singular', 'is_single' ); // bug fixed in v1.7.11
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 		$this->assertEquals( home_url( '/test/img_en/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // bug fixed in v1.9.1
 	}
 
 	// Bug fixed in 2.1: language switcher does not link to media translation for unattached media
 	function test_unattached_attachment() {
-		$en = $this->factory->post->create( array( 'post_title' => 'img_en', 'post_type' => 'attachment' ) );
+		$en = $this->factory->post->create(
+			[
+				'post_title' => 'img_en',
+				'post_type' => 'attachment',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'img_fr', 'post_type' => 'attachment' ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_title' => 'img_fr',
+				'post_type' => 'attachment',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
@@ -423,7 +531,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->go_to( home_url( '/fr/img_fr/' ) );
 
 		$this->assertQueryTrue( 'is_attachment', 'is_singular', 'is_single' );
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 		$this->assertEquals( home_url( '/img_en/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // bug fixed in v1.9.1
 	}
 
@@ -437,7 +545,7 @@ class Query_Test extends PLL_UnitTestCase {
 
 		$this->go_to( home_url( '/fr/feed/' ) );
 		$this->assertQueryTrue( 'is_feed' ); // we don't want is_tax
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts ); // only posts in fr
 
 		$this->go_to( home_url( '/feed/' ) );
 		$this->assertQueryTrue( 'is_feed' );
@@ -447,33 +555,57 @@ class Query_Test extends PLL_UnitTestCase {
 	// see https://wordpress.org/support/topic/issue-with-get_posts-in-version-18
 	function test_untranslated_custom_tax_with_translated_cpt() {
 		register_taxonomy( 'tax', 'trcpt' );
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'tax',
+				'name' => 'test',
+			]
+		);
 
-		$en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 		wp_set_post_terms( $en, 'test', 'tax' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 		wp_set_post_terms( $fr, 'test', 'tax' );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'post_type' => 'trcpt', 'tax' => 'test' ) ) ); // initial bug
+		$this->assertEquals(
+			[ get_post( $fr ) ], get_posts(
+				[
+					'post_type' => 'trcpt',
+					'tax' => 'test',
+				]
+			)
+		); // initial bug
 
 		// additional test for post_type = any
-		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'post_type' => 'any', 'tax' => 'test' ) ) );
+		$this->assertEquals(
+			[ get_post( $fr ) ], get_posts(
+				[
+					'post_type' => 'any',
+					'tax' => 'test',
+				]
+			)
+		);
 
 		// additional test for empty post_type
-		$query = new WP_Query( array( 'tax' => 'test' ) ); // get_posts sets 'post' as default post type
-		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
+		$query = new WP_Query( [ 'tax' => 'test' ] ); // get_posts sets 'post' as default post type
+		$this->assertEquals( [ get_post( $fr ) ], $query->posts );
 	}
 
 	// "Issue" fixed in 2.0.10: Drafts should not appear in language switcher
 	function test_draft() {
-		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_status' => 'draft' ) );
+		$en = $this->factory->post->create(
+			[
+				'post_title' => 'test',
+				'post_status' => 'draft',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
+		$fr = $this->factory->post->create( [ 'post_title' => 'essai' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
@@ -485,37 +617,47 @@ class Query_Test extends PLL_UnitTestCase {
 
 	function test_cat() {
 		// Categories
-		$cat_en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$cat_en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $cat_en, 'en' );
 
-		$cat_fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$cat_fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $cat_fr, 'fr' );
 
 		// Posts
 		$en = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $en, 'en' );
-		wp_set_post_terms( $en, array( $cat_en ), 'category' );
+		wp_set_post_terms( $en, [ $cat_en ], 'category' );
 
 		$fr = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $fr, 'fr' );
-		wp_set_post_terms( $fr, array( $cat_fr ), 'category' );
+		wp_set_post_terms( $fr, [ $cat_fr ], 'category' );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 
-		$query = new WP_Query( array( 'cat' => $cat_en ) );
-		$this->assertEquals( array( get_post( $en ) ), $query->posts );
+		$query = new WP_Query( [ 'cat' => $cat_en ] );
+		$this->assertEquals( [ get_post( $en ) ], $query->posts );
 
-		$query = new WP_Query( array( 'cat' => -$cat_fr ) );
-		$this->assertEquals( array( get_post( $en ) ), $query->posts );
+		$query = new WP_Query( [ 'cat' => -$cat_fr ] );
+		$this->assertEquals( [ get_post( $en ) ], $query->posts );
 
 		// Bug fixed in 2.2.1
-		$query = new WP_Query( array( 'cat' => -$cat_en ) );
+		$query = new WP_Query( [ 'cat' => -$cat_en ] );
 		$this->assertEmpty( $query->posts );
 
 		// The test was broken by WP 4.9 and fixed in 2.2.7
 		// See also https://core.trac.wordpress.org/ticket/42104
-		$query = new WP_Query( array( 'cat' => $cat_fr ) );
-		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
+		$query = new WP_Query( [ 'cat' => $cat_fr ] );
+		$this->assertEquals( [ get_post( $fr ) ], $query->posts );
 	}
 
 	// Bug introduced in 2.2 and fixed in 2.2.4
@@ -527,16 +669,26 @@ class Query_Test extends PLL_UnitTestCase {
 		$fr = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
-		$query = new WP_Query( array( 'post_type' => 'any', 'lang' => 'en' ) );
-		$this->assertEquals( array( get_post( $en ) ), $query->posts );
+		$query = new WP_Query(
+			[
+				'post_type' => 'any',
+				'lang' => 'en',
+			]
+		);
+		$this->assertEquals( [ get_post( $en ) ], $query->posts );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 
-		$query = new WP_Query( array( 'post_type' => 'any' ) );
-		$this->assertEquals( array( get_post( $en ) ), $query->posts );
+		$query = new WP_Query( [ 'post_type' => 'any' ] );
+		$this->assertEquals( [ get_post( $en ) ], $query->posts );
 
-		$query = new WP_Query( array( 'post_type' => 'any', 'lang' => 'fr' ) );
-		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
+		$query = new WP_Query(
+			[
+				'post_type' => 'any',
+				'lang' => 'fr',
+			]
+		);
+		$this->assertEquals( [ get_post( $fr ) ], $query->posts );
 	}
 
 	// Bug fixed in 2.3.3
@@ -544,32 +696,37 @@ class Query_Test extends PLL_UnitTestCase {
 		register_taxonomy_for_object_type( 'tax', 'trcpt' ); // *untranslated* custom tax
 
 		// Taxonomy
-		$tag = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
+		$tag = $this->factory->term->create(
+			[
+				'taxonomy' => 'tax',
+				'name' => 'test',
+			]
+		);
 
 		// Posts
-		$en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
-		wp_set_post_terms( $en, array( $tag ), 'tax' );
+		wp_set_post_terms( $en, [ $tag ], 'tax' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
-		wp_set_post_terms( $fr, array( $tag ), 'tax' );
+		wp_set_post_terms( $fr, [ $tag ], 'tax' );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 
-		$args = array(
+		$args = [
 			'post_type' => 'trcpt',
-			'tax_query' => array(
+			'tax_query' => [
 				'relation' => 'OR',
-				array(
+				[
 					'field'    => 'id',
 					'terms'    => $tag,
 					'taxonomy' => 'tax',
-				),
-			),
-		);
+				],
+			],
+		];
 
 		$query = new WP_Query( $args );
-		$this->assertEquals( array( get_post( $en ) ), $query->posts );
+		$this->assertEquals( [ get_post( $en ) ], $query->posts );
 	}
 }

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -22,7 +22,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
 		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
@@ -45,7 +45,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 
 		$admin_bar = new WP_Admin_Bar;
 		$admin_bar->add_menus();
-		do_action_ref_array( 'admin_bar_menu', array( &$admin_bar ) ); // ndeed add menus to the admin bar
+		do_action_ref_array( 'admin_bar_menu', [ &$admin_bar ] ); // ndeed add menus to the admin bar
 		$node = $admin_bar->get_node( 'search' );
 
 		$this->assertContains( home_url( '/fr/' ), $node->title );
@@ -55,7 +55,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		global $wp_rewrite;
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$form = get_search_form( false ); // don't echo
+		$form                    = get_search_form( false ); // don't echo
 
 		$this->assertContains( home_url( '/fr/' ), $form );
 

--- a/tests/phpunit/tests/test-settings-cpt.php
+++ b/tests/phpunit/tests/test-settings-cpt.php
@@ -9,8 +9,8 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		self::$polylang->model->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
 		self::$polylang->model->cache->method( 'get' )->willReturn( false );
 
-		self::$polylang->options['post_types'] = array();
-		self::$polylang->options['taxonomies'] = array();
+		self::$polylang->options['post_types'] = [];
+		self::$polylang->options['taxonomies'] = [];
 	}
 
 	function tearDown() {
@@ -70,7 +70,12 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_untranslated_public_post_type() {
-		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
+		register_post_type(
+			'cpt', [
+				'public' => true,
+				'label' => 'CPT',
+			]
+		);
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();
@@ -83,8 +88,13 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translated_public_post_type() {
-		self::$polylang->options['post_types'] = array( 'cpt' );
-		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
+		self::$polylang->options['post_types'] = [ 'cpt' ];
+		register_post_type(
+			'cpt', [
+				'public' => true,
+				'label' => 'CPT',
+			]
+		);
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();
@@ -97,8 +107,13 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_programmatically_translated_public_post_type() {
-		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ), 10, 2 );
-		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
+		add_filter( 'pll_get_post_types', [ $this, 'filter_translated_post_type_in_settings' ], 10, 2 );
+		register_post_type(
+			'cpt', [
+				'public' => true,
+				'label' => 'CPT',
+			]
+		);
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();
@@ -111,28 +126,48 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_untranslated_private_post_type() {
-		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
+		register_post_type(
+			'cpt', [
+				'public' => false,
+				'label' => 'CPT',
+			]
+		);
 		$module = new PLL_Settings_CPT( self::$polylang );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_translated_private_post_type() {
-		self::$polylang->options['post_types'] = array( 'cpt' );
-		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
+		self::$polylang->options['post_types'] = [ 'cpt' ];
+		register_post_type(
+			'cpt', [
+				'public' => false,
+				'label' => 'CPT',
+			]
+		);
 		$module = new PLL_Settings_CPT( self::$polylang );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_programmatically_translated_private_post_type() {
-		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_not_in_settings' ), 10, 2 );
-		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
+		add_filter( 'pll_get_post_types', [ $this, 'filter_translated_post_type_not_in_settings' ], 10, 2 );
+		register_post_type(
+			'cpt', [
+				'public' => false,
+				'label' => 'CPT',
+			]
+		);
 		$module = new PLL_Settings_CPT( self::$polylang );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_untranslated_private_post_type_in_settings() {
-		add_filter( 'pll_get_post_types', array( $this, 'filter_untranslated_post_type_in_settings' ), 10, 2 );
-		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
+		add_filter( 'pll_get_post_types', [ $this, 'filter_untranslated_post_type_in_settings' ], 10, 2 );
+		register_post_type(
+			'cpt', [
+				'public' => false,
+				'label' => 'CPT',
+			]
+		);
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();
@@ -145,9 +180,14 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translated_private_post_type_in_settings() {
-		self::$polylang->options['post_types'] = array( 'cpt' );
-		add_filter( 'pll_get_post_types', array( $this, 'filter_untranslated_post_type_in_settings' ), 10, 2 );
-		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
+		self::$polylang->options['post_types'] = [ 'cpt' ];
+		add_filter( 'pll_get_post_types', [ $this, 'filter_untranslated_post_type_in_settings' ], 10, 2 );
+		register_post_type(
+			'cpt', [
+				'public' => false,
+				'label' => 'CPT',
+			]
+		);
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();
@@ -160,7 +200,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_untranslated_public_taxonomy() {
-		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
+		register_taxonomy( 'tax', [ 'post' ], [ 'public' => true ] );
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();
@@ -173,8 +213,8 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translated_public_taxonomy() {
-		self::$polylang->options['taxonomies'] = array( 'tax' );
-		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
+		self::$polylang->options['taxonomies'] = [ 'tax' ];
+		register_taxonomy( 'tax', [ 'post' ], [ 'public' => true ] );
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();
@@ -187,8 +227,8 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_programmatically_translated_public_taxonomy() {
-		add_filter( 'pll_get_taxonomies', array( $this, 'filter_translated_taxonomy_in_settings' ), 10, 2 );
-		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
+		add_filter( 'pll_get_taxonomies', [ $this, 'filter_translated_taxonomy_in_settings' ], 10, 2 );
+		register_taxonomy( 'tax', [ 'post' ], [ 'public' => true ] );
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();
@@ -201,29 +241,29 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_untranslated_private_taxonomy() {
-		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
+		register_taxonomy( 'tax', [ 'post' ], [ 'public' => false ] );
 		$module = new PLL_Settings_CPT( self::$polylang );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_translated_private_taxonomy() {
-		self::$polylang->options['taxonomies'] = array( 'tax' );
-		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
+		self::$polylang->options['taxonomies'] = [ 'tax' ];
+		register_taxonomy( 'tax', [ 'post' ], [ 'public' => false ] );
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_programmatically_translated_private_taxonomy() {
-		add_filter( 'pll_get_taxonomies', array( $this, 'filter_translated_taxonomy_not_in_settings' ), 10, 2 );
-		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
+		add_filter( 'pll_get_taxonomies', [ $this, 'filter_translated_taxonomy_not_in_settings' ], 10, 2 );
+		register_taxonomy( 'tax', [ 'post' ], [ 'public' => false ] );
 		$module = new PLL_Settings_CPT( self::$polylang );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_untranslated_private_taxonomy_in_settings() {
-		add_filter( 'pll_get_taxonomies', array( $this, 'filter_untranslated_taxonomy_in_settings' ), 10, 2 );
-		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
+		add_filter( 'pll_get_taxonomies', [ $this, 'filter_untranslated_taxonomy_in_settings' ], 10, 2 );
+		register_taxonomy( 'tax', [ 'post' ], [ 'public' => false ] );
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();
@@ -236,9 +276,9 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translated_private_taxonomy_in_settings() {
-		self::$polylang->options['taxonomies'] = array( 'tax' );
-		add_filter( 'pll_get_taxonomies', array( $this, 'filter_untranslated_taxonomy_in_settings' ), 10, 2 );
-		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
+		self::$polylang->options['taxonomies'] = [ 'tax' ];
+		add_filter( 'pll_get_taxonomies', [ $this, 'filter_untranslated_taxonomy_in_settings' ], 10, 2 );
+		register_taxonomy( 'tax', [ 'post' ], [ 'public' => false ] );
 		$module = new PLL_Settings_CPT( self::$polylang );
 
 		$doc = new DomDocument();

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -19,7 +19,7 @@ class Settings_Test extends PLL_UnitTestCase {
 	function tearDown() {
 		parent::tearDown();
 
-		$_REQUEST = $_GET = $_POST = array();
+		$_REQUEST = $_GET = $_POST = [];
 		unset( $GLOBALS['hook_suffix'], $GLOBALS['current_screen'] );
 	}
 
@@ -28,9 +28,9 @@ class Settings_Test extends PLL_UnitTestCase {
 		$lang = self::$polylang->model->get_language( 'fr' );
 
 		// setup globals
-		$_GET['page'] = 'mlang';
-		$_GET['pll_action'] = $_REQUEST['pll_action'] = 'edit'; // languages_page() tests $_REQUEST
-		$_GET['lang'] = $lang->term_id;
+		$_GET['page']           = 'mlang';
+		$_GET['pll_action']     = $_REQUEST['pll_action'] = 'edit'; // languages_page() tests $_REQUEST
+		$_GET['lang']           = $lang->term_id;
 		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
 		get_admin_page_title();
 		set_current_screen();
@@ -65,7 +65,7 @@ class Settings_Test extends PLL_UnitTestCase {
 			$this->markTestSkipped(); // For some reason, the test dos not work in previous versions
 		}
 
-		$_GET['page'] = 'mlang';
+		$_GET['page']           = 'mlang';
 		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
 		set_current_screen();
 

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -12,11 +12,21 @@ class Slugs_Test extends PLL_UnitTestCase {
 	function test_term_slugs() {
 		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang ); // activate our filters
 
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $term_id, 'en' );
 
 		$_POST['term_lang_choice'] = 'fr';
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$term_id                   = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $term_id, 'fr' );
 
 		$term = get_term( $term_id, 'category' );

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -7,7 +7,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	static function wpSetUpBeforeClass() {
 		parent::wpSetUpBeforeClass();
 
-		add_filter( 'pll_languages_list', array( 'PLL_Static_Pages', 'pll_languages_list' ), 2, 2 );
+		add_filter( 'pll_languages_list', [ 'PLL_Static_Pages', 'pll_languages_list' ], 2, 2 );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
@@ -17,35 +17,51 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$GLOBALS['polylang'] = &self::$polylang;
 
 		// page on front
-		self::$home_en = $en = self::factory()->post->create( array(
-			'post_title' => 'home',
-			'post_type' => 'page',
-			'post_content' => 'en1<!--nextpage-->en2',
-		) );
+		self::$home_en = $en = self::factory()->post->create(
+			[
+				'post_title' => 'home',
+				'post_type' => 'page',
+				'post_content' => 'en1<!--nextpage-->en2',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		self::$home_fr = $fr = self::factory()->post->create( array(
-			'post_title' => 'accueil',
-			'post_type' => 'page',
-			'post_content' => 'fr1<!--nextpage-->fr2',
-		) );
+		self::$home_fr = $fr = self::factory()->post->create(
+			[
+				'post_title' => 'accueil',
+				'post_type' => 'page',
+				'post_content' => 'fr1<!--nextpage-->fr2',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
-		self::$home_de = $de = self::factory()->post->create( array(
-			'post_title' => 'startseite',
-			'post_type' => 'page',
-			'post_content' => 'de1<!--nextpage-->de2',
-		) );
+		self::$home_de = $de = self::factory()->post->create(
+			[
+				'post_title' => 'startseite',
+				'post_type' => 'page',
+				'post_content' => 'de1<!--nextpage-->de2',
+			]
+		);
 		self::$polylang->model->post->set_language( $de, 'de' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
 
 		// page for posts
 		// intentionally do not create one in German
-		self::$posts_en = $en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
+		self::$posts_en = $en = self::factory()->post->create(
+			[
+				'post_title' => 'posts',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		self::$posts_fr = $fr = self::factory()->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
+		self::$posts_fr = $fr = self::factory()->post->create(
+			[
+				'post_title' => 'articles',
+				'post_type' => 'page',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
@@ -54,14 +70,14 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		self::$polylang->options['hide_default'] = 0;
+		self::$polylang->options['hide_default']  = 0;
 		self::$polylang->options['redirect_lang'] = 0;
 
 		global $wp_rewrite;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
 		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
@@ -91,7 +107,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		wp_delete_post( self::$posts_fr );
 
 		parent::wpTearDownAfterClass();
-		remove_filter( 'pll_languages_list', array( 'PLL_Static_Pages', 'pll_languages_list' ), 2, 2 ); // Avoid breaking next tests
+		remove_filter( 'pll_languages_list', [ 'PLL_Static_Pages', 'pll_languages_list' ], 2, 2 ); // Avoid breaking next tests
 	}
 
 	function test_front_page_with_default_options() {
@@ -100,7 +116,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		$this->assertEquals( home_url( '/en/home/' ), get_permalink( self::$home_en ) );
@@ -112,7 +128,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
 		$this->assertEquals( home_url( '/en/home/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( self::$home_fr ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/' ), false ) );
 	}
 
@@ -122,7 +138,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
@@ -131,7 +147,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
 		$this->assertEquals( home_url( '/en/home/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( self::$home_fr ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/?query=1' ), false ) );
 	}
 
@@ -141,7 +157,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
@@ -171,7 +187,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		$this->assertEquals( home_url( '/' ), get_permalink( self::$home_en ) );
@@ -183,7 +199,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
 		$this->assertEquals( home_url( '/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( self::$home_fr ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/' ), false ) );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
@@ -192,7 +208,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
 		$this->assertEquals( home_url( '/fr/accueil/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEquals( array( get_post( self::$home_en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( self::$home_en ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/' ), false ) );
 		$this->assertEquals( home_url( '/' ), redirect_canonical( home_url( '/en/home/' ), false ) );
 	}
@@ -205,7 +221,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$wp_rewrite->flush_rules();
 
 		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		self::$polylang->links_model             = self::$polylang->model->get_links_model();
 		self::$polylang->model->clean_languages_cache();
 
 		$this->assertEquals( home_url( '/' ), get_permalink( self::$home_en ) ); // trailing slash kept for home page
@@ -217,7 +233,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
 		$this->assertEquals( home_url( '/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( self::$home_fr ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/' ), false ) );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
@@ -226,7 +242,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
 		$this->assertEquals( home_url( '?page_id=' . self::$home_fr . '&lang=fr' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEquals( array( get_post( self::$home_en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( self::$home_en ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/' ), false ) );
 	}
 
@@ -237,7 +253,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$wp_rewrite->flush_rules();
 
 		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		self::$polylang->links_model             = self::$polylang->model->get_links_model();
 		self::$polylang->model->clean_languages_cache();
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
@@ -267,7 +283,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		$this->assertEquals( home_url( '/en/' ), get_permalink( self::$home_en ) );
@@ -279,7 +295,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
 		$this->assertEquals( home_url( '/en/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( self::$home_fr ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/' ), false ) );
 	}
 
@@ -295,14 +311,14 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 
 		$this->assertQueryTrue( 'is_home', 'is_posts_page' );
 		$this->assertEquals( home_url( '/en/posts/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $fr ) ], $GLOBALS['wp_query']->posts );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
 		$this->go_to( home_url( '/en/posts/' ) );
 
 		$this->assertQueryTrue( 'is_home', 'is_posts_page' );
 		$this->assertEquals( home_url( '/fr/articles/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $en ) ], $GLOBALS['wp_query']->posts );
 	}
 
 	function test_paged_page_for_posts() {
@@ -355,7 +371,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
@@ -377,7 +393,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
@@ -406,10 +422,10 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( ob_get_clean(), "<span class='post-state'>Posts Page</span>" ) );
 
 		// test for standard pages too
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		ob_start();
@@ -430,7 +446,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		unset( $wp_settings_errors ); // just in case
 
 		// attempt to assign an untranslated message
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 		update_option( 'page_on_front', $en );
 
@@ -459,27 +475,33 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_archives_with_front_page_with_redirect_lang() {
 		global $wp_rewrite;
 
-		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
+		$en = $this->factory->post->create(
+			[
+				'post_title' => 'test',
+				'post_date' => '2007-09-04 00:00:00',
+				'post_author' => 1,
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
 		self::$polylang->options['redirect_lang'] = 1;
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		$this->go_to( home_url( '/en/author/admin/' ) );
-		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $en ) ], $GLOBALS['wp_query']->posts );
 
 		$this->go_to( home_url( '/en/2007/' ) );
-		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $en ) ], $GLOBALS['wp_query']->posts );
 
 		$this->go_to( home_url( '/en/feed/' ) );
-		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $en ) ], $GLOBALS['wp_query']->posts );
 
 		$this->go_to( home_url( '/en/?s=test' ) );
-		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $en ) ], $GLOBALS['wp_query']->posts );
 	}
 
 	// Bug introduced and fixed in 2.3
@@ -487,15 +509,20 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		global $wp_rewrite;
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 
-		self::$polylang->options['post_types'] = array(
+		self::$polylang->options['post_types'] = [
 			'trcpt' => 'trcpt',
-		);
+		];
 
-		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // translated custom post type with archives
+		register_post_type(
+			'trcpt', [
+				'public' => true,
+				'has_archive' => true,
+			]
+		); // translated custom post type with archives
 
-		$en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'trcpt' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
 		self::$polylang->options['redirect_lang'] = 1;
@@ -504,7 +531,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$wp_rewrite->flush_rules();
 
 		$this->go_to( home_url( '/en/trcpt/' ) );
-		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( $en ) ], $GLOBALS['wp_query']->posts );
 
 		_unregister_post_type( 'trcpt' );
 	}
@@ -525,15 +552,15 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_extra_query_var_with_front_page_with_query_with_redirect_lang() {
 		global $wp_rewrite;
 
-		add_filter( 'query_vars', array( $this, 'extra_query_vars' ) );
-		add_filter( 'root_rewrite_rules', array( $this, 'extra_root_rewrite_rules' ), 1 );
+		add_filter( 'query_vars', [ $this, 'extra_query_vars' ] );
+		add_filter( 'root_rewrite_rules', [ $this, 'extra_root_rewrite_rules' ], 1 );
 
-		self::$polylang->options['hide_default'] = 1;
+		self::$polylang->options['hide_default']  = 1;
 		self::$polylang->options['redirect_lang'] = 1;
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
@@ -549,7 +576,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$polylang->model->clean_languages_cache();
 
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
@@ -558,7 +585,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
 		$this->assertEquals( home_url( '/en/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( [ get_post( self::$home_fr ) ], $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/?orderby=price' ), false ) );
 	}
 }

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -22,23 +22,23 @@ class Strings_Test extends PLL_UnitTestCase {
 	function clean_up_global_scope() {
 		global $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
 
-		$wp_registered_sidebars = array();
-		$wp_registered_widgets = array();
-		$wp_registered_widget_controls = array();
-		$wp_registered_widget_updates = array();
-		$wp_widget_factory->widgets = array();
+		$wp_registered_sidebars        = [];
+		$wp_registered_widgets         = [];
+		$wp_registered_widget_controls = [];
+		$wp_registered_widget_updates  = [];
+		$wp_widget_factory->widgets    = [];
 
 		parent::clean_up_global_scope();
 	}
 
 	function __return_fr_FR() {
-		return array( 'fr_FR' );
+		return [ 'fr_FR' ];
 	}
 
 	function test_base_strings() {
 		$strings = PLL_Admin_Strings::get_strings();
-		$names = wp_list_pluck( $strings, 'name' );
-		$this->assertCount( 4, array_intersect( array( 'Site Title', 'Tagline', 'Date Format', 'Time Format' ), $names ) );
+		$names   = wp_list_pluck( $strings, 'name' );
+		$this->assertCount( 4, array_intersect( [ 'Site Title', 'Tagline', 'Date Format', 'Time Format' ], $names ) );
 	}
 
 	// FIXME: order of nest two tests matters due to static protected strings in PLL_Admin_Strings
@@ -49,16 +49,16 @@ class Strings_Test extends PLL_UnitTestCase {
 
 		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang );
 
-		$_POST = array(
+		$_POST = [
 			'widget-id'     => 'search-2',
 			'id_base'       => 'search',
 			'widget_number' => 2,
 			'multi_number'  => '',
-		);
+		];
 
-		$_POST['widget-search'][2] = array(
+		$_POST['widget-search'][2] = [
 			'title' => 'My Title',
-		);
+		];
 
 		$_POST['search-2_lang_choice'] = 'en';
 
@@ -77,16 +77,16 @@ class Strings_Test extends PLL_UnitTestCase {
 
 		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang );
 
-		$_POST = array(
+		$_POST = [
 			'widget-id'     => 'search-2',
 			'id_base'       => 'search',
 			'widget_number' => 2,
 			'multi_number'  => '',
-		);
+		];
 
-		$_POST['widget-search'][2] = array(
+		$_POST['widget-search'][2] = [
 			'title' => 'My Title',
-		);
+		];
 
 		$_POST['search-2_lang_choice'] = 0;
 
@@ -103,7 +103,7 @@ class Strings_Test extends PLL_UnitTestCase {
 	function test_html_string() {
 		update_option( 'use_balanceTags', 1 ); // To break malformed html in versions < 2.1
 		self::$polylang->curlang = $language = self::$polylang->model->get_language( 'fr' );
-		$_mo = new PLL_MO();
+		$_mo                     = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( '<p>test</p>', '<p>test fr</p>' ) );
 		$_mo->add_entry( $_mo->make_entry( '<p>malformed<p>', '<p>malformed fr<p>' ) );
 		$_mo->export_to_db( $language );
@@ -121,7 +121,7 @@ class Strings_Test extends PLL_UnitTestCase {
 	// Test #94
 	function test_slashed_string() {
 		self::$polylang->curlang = $language = self::$polylang->model->get_language( 'fr' );
-		$_mo = new PLL_MO();
+		$_mo                     = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( '\slashed', '\slashed fr' ) );
 		$_mo->add_entry( $_mo->make_entry( '\\slashed', '\\slashed fr' ) );
 		$_mo->add_entry( $_mo->make_entry( '\\\slashed', '\\\slashed fr' ) );
@@ -153,12 +153,12 @@ class Strings_Test extends PLL_UnitTestCase {
 		$mo->export_to_db( self::$polylang->model->get_language( 'fr' ) );
 
 		// Reset $wp_locale_switcher to add fr_FR in the list of available languages
-		add_filter( 'get_available_languages', array( $this, '__return_fr_FR' ) );
-		$old_locale_switcher = $GLOBALS['wp_locale_switcher'];
+		add_filter( 'get_available_languages', [ $this, '__return_fr_FR' ] );
+		$old_locale_switcher           = $GLOBALS['wp_locale_switcher'];
 		$GLOBALS['wp_locale_switcher'] = new WP_Locale_Switcher();
 		$GLOBALS['wp_locale_switcher']->init();
 
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+		self::$polylang          = new PLL_Frontend( self::$polylang->links_model );
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 		do_action( 'pll_language_defined' );
 

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -45,10 +45,10 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->go_to( get_permalink( $en ) );
 
 		// Raw with default arguments
-		$args = array(
+		$args = [
 			'raw' => 1,
-		);
-		$arr = $this->switcher->the_languages( self::$polylang->links, $args );
+		];
+		$arr  = $this->switcher->the_languages( self::$polylang->links, $args );
 
 		$this->assertCount( 3, $arr );
 		$this->assertTrue( $arr['de']['no_translation'] );
@@ -59,13 +59,15 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'English', $arr['en']['name'] );
 
 		// Other arguments
-		$args = array_merge( $args, array(
-			'force_home' => 1,
-			'hide_current' => 1,
-			'hide_if_no_translation' => 1,
-			'display_names_as' => 'slug',
-		) );
-		$arr = $this->switcher->the_languages( self::$polylang->links, $args );
+		$args = array_merge(
+			$args, [
+				'force_home' => 1,
+				'hide_current' => 1,
+				'hide_if_no_translation' => 1,
+				'display_names_as' => 'slug',
+			]
+		);
+		$arr  = $this->switcher->the_languages( self::$polylang->links, $args );
 
 		$this->assertCount( 1, $arr ); // Only fr in the array
 		$this->assertEquals( home_url( '?lang=fr' ), $arr['fr']['url'] ); // force_home
@@ -74,11 +76,11 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->go_to( home_url( '/' ) );
 
 		// Post_id
-		$args = array(
+		$args = [
 			'raw' => 1,
 			'post_id' => $en,
-		);
-		$arr = $this->switcher->the_languages( self::$polylang->links, $args );
+		];
+		$arr  = $this->switcher->the_languages( self::$polylang->links, $args );
 		$this->assertEquals( get_permalink( $fr ), $arr['fr']['url'] );
 	}
 
@@ -99,10 +101,10 @@ class Switcher_Test extends PLL_UnitTestCase {
 		self::$polylang->links->curlang = self::$polylang->model->get_language( 'en' );
 		$this->go_to( get_permalink( $en ) );
 
-		$args = array( 'echo' => 0 );
+		$args     = [ 'echo' => 0 ];
 		$switcher = $this->switcher->the_languages( self::$polylang->links, $args );
 		$switcher = mb_convert_encoding( $switcher, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
-		$doc = new DomDocument();
+		$doc      = new DomDocument();
 		$doc->loadHTML( $switcher );
 		$xpath = new DOMXpath( $doc );
 
@@ -113,7 +115,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->assertEquals( get_permalink( $fr ), $a->item( 0 )->getAttribute( 'href' ) );
 
 		// Test echo option
-		$args = array( 'echo' => 1 );
+		$args = [ 'echo' => 1 ];
 		ob_start();
 		$this->switcher->the_languages( self::$polylang->links, $args );
 		$this->assertNotEmpty( ob_get_clean() );
@@ -136,13 +138,13 @@ class Switcher_Test extends PLL_UnitTestCase {
 		self::$polylang->links->curlang = self::$polylang->model->get_language( 'en' );
 		$this->go_to( get_permalink( $en ) );
 
-		$args = array(
+		$args     = [
 			'dropdown' => 1,
 			'echo'     => 0,
-		);
+		];
 		$switcher = $this->switcher->the_languages( self::$polylang->links, $args );
 		$switcher = mb_convert_encoding( $switcher, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
-		$doc = new DomDocument();
+		$doc      = new DomDocument();
 		$doc->loadHTML( $switcher );
 		$xpath = new DOMXpath( $doc );
 

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -9,7 +9,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = self::factory()->user->create( [ 'role' => 'editor' ] );
 	}
 
 	function setUp() {
@@ -21,54 +21,54 @@ class Sync_Test extends PLL_UnitTestCase {
 	function tearDown() {
 		parent::tearDown();
 
-		$_REQUEST = $_GET = $_POST = array();
+		$_REQUEST = $_GET = $_POST = [];
 	}
 
 	function test_copy_taxonomies() {
-		$untranslated = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$untranslated = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $untranslated, 'en' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
 
 		$from = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $from, 'en' );
-		wp_set_post_terms( $from, array( $untranslated, $en ), 'category' );
+		wp_set_post_terms( $from, [ $untranslated, $en ], 'category' );
 		set_post_format( $from, 'aside' );
 
 		$to = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $to, 'fr' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->post->save_translations( $from, [ 'fr' => $to ] );
 
 		// copy
 		$sync = new PLL_Admin_Sync( self::$polylang );
 		$sync->taxonomies->copy( $from, $to, 'fr' ); // copy
 
-		$this->assertEquals( array( $fr ), wp_get_post_terms( $to, 'category', array( 'fields' => 'ids' ) ) );
+		$this->assertEquals( [ $fr ], wp_get_post_terms( $to, 'category', [ 'fields' => 'ids' ] ) );
 		$this->assertEquals( 'aside', get_post_format( $to ) );
 
 		// sync
-		self::$polylang->options['sync'] = array( 'taxonomies' );
-		wp_set_post_terms( $from, array( $untranslated, $en ), 'category' );
+		self::$polylang->options['sync'] = [ 'taxonomies' ];
+		wp_set_post_terms( $from, [ $untranslated, $en ], 'category' );
 
-		$this->assertEquals( array( $untranslated, $en ), wp_get_post_terms( $from, 'category', array( 'fields' => 'ids' ) ) );
+		$this->assertEquals( [ $untranslated, $en ], wp_get_post_terms( $from, 'category', [ 'fields' => 'ids' ] ) );
 		$this->assertEquals( 'aside', get_post_format( $from ) );
 
 		// remove taxonomies and post format and sync taxonomies
-		wp_set_post_terms( $to, array(), 'category' );
+		wp_set_post_terms( $to, [], 'category' );
 		set_post_format( $to, '' );
 
-		$this->assertEquals( array( $untranslated ), wp_get_post_terms( $from, 'category', array( 'fields' => 'ids' ) ) );
+		$this->assertEquals( [ $untranslated ], wp_get_post_terms( $from, 'category', [ 'fields' => 'ids' ] ) );
 		$this->assertEquals( 'aside', get_post_format( $from ) );
 
 		// sync post format
-		self::$polylang->options['sync'] = array( 'post_format' );
+		self::$polylang->options['sync'] = [ 'post_format' ];
 		set_post_format( $to, '' );
 		$this->assertFalse( get_post_format( $from ) );
 	}
@@ -81,7 +81,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$to = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $to, 'fr' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->post->save_translations( $from, [ 'fr' => $to ] );
 
 		// copy
 		$sync = new PLL_Admin_Sync( self::$polylang );
@@ -89,7 +89,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'value', get_post_meta( $to, 'key', true ) );
 
 		// sync
-		self::$polylang->options['sync'] = array( 'post_meta' );
+		self::$polylang->options['sync'] = [ 'post_meta' ];
 		$this->assertTrue( update_post_meta( $to, 'key', 'new_value' ) );
 		$this->assertEquals( 'new_value', get_post_meta( $from, 'key', true ) );
 
@@ -99,8 +99,8 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function test_sync_multiple_custom_fields() {
-		self::$polylang->options['sync'] = array( 'post_meta' );
-		$sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->options['sync'] = [ 'post_meta' ];
+		$sync                            = new PLL_Admin_Sync( self::$polylang );
 
 		$from = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $from, 'en' );
@@ -114,43 +114,43 @@ class Sync_Test extends PLL_UnitTestCase {
 		add_post_meta( $from, 'key', 'value3' );
 
 		$sync->post_metas->copy( $from, $to, 'fr', true );
-		$this->assertEqualSets( array( 'value1', 'value2', 'value3' ), get_post_meta( $to, 'key' ) );
+		$this->assertEqualSets( [ 'value1', 'value2', 'value3' ], get_post_meta( $to, 'key' ) );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->post->save_translations( $from, [ 'fr' => $to ] );
 
 		// Delete
 		$this->assertTrue( delete_post_meta( $from, 'key', 'value3' ) );
-		$this->assertEqualSets( array( 'value1', 'value2' ), get_post_meta( $to, 'key' ) );
+		$this->assertEqualSets( [ 'value1', 'value2' ], get_post_meta( $to, 'key' ) );
 
 		// Update
 		$this->assertTrue( update_post_meta( $from, 'key', 'value4', 'value2' ) );
-		$this->assertEqualSets( array( 'value1', 'value4' ), get_post_meta( $to, 'key' ) );
+		$this->assertEqualSets( [ 'value1', 'value4' ], get_post_meta( $to, 'key' ) );
 
 		// Add
 		$mid = add_post_meta( $from, 'key', 'value5' );
-		$this->assertEqualSets( array( 'value1', 'value4', 'value5' ), get_post_meta( $to, 'key' ) );
+		$this->assertEqualSets( [ 'value1', 'value4', 'value5' ], get_post_meta( $to, 'key' ) );
 
 		// update_metadata_by_mid
 		$this->assertTrue( update_meta( $mid, 'key', 'value6' ) );
-		$this->assertEqualSets( array( 'value1', 'value4', 'value6' ), get_post_meta( $to, 'key' ) );
+		$this->assertEqualSets( [ 'value1', 'value4', 'value6' ], get_post_meta( $to, 'key' ) );
 
 		// delete_metadata_by_mid
 		$this->assertTrue( delete_meta( $mid ) );
-		$this->assertEqualSets( array( 'value1', 'value4' ), get_post_meta( $to, 'key' ) );
+		$this->assertEqualSets( [ 'value1', 'value4' ], get_post_meta( $to, 'key' ) );
 	}
 
 	function test_create_post_translation() {
 		// categories
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
 
 		// source post
-		$from = $this->factory->post->create( array( 'post_category' => array( $en ) ) );
+		$from = $this->factory->post->create( [ 'post_category' => [ $en ] ] );
 		self::$polylang->model->post->set_language( $from, 'en' );
 		add_post_meta( $from, 'key', 'value' );
 		add_post_meta( $from, '_thumbnail_id', 1234 );
@@ -158,19 +158,19 @@ class Sync_Test extends PLL_UnitTestCase {
 		stick_post( $from );
 
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 
 		$GLOBALS['pagenow'] = 'post-new.php';
-		$_GET = array(
+		$_GET               = [
 			'from_post' => $from,
 			'new_lang'  => 'fr',
-		);
+		];
 
 		$to = $this->factory->post->create();
 		do_action( 'add_meta_boxes', 'post', get_post( $to ) ); // fires the copy
 
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $to )->slug );
-		$this->assertEquals( array( get_category( $fr ) ), get_the_category( $to ) );
+		$this->assertEquals( [ get_category( $fr ) ], get_the_category( $to ) );
 		$this->assertEquals( 'value', get_post_meta( $to, 'key', true ) );
 		$this->assertEquals( 1234, get_post_thumbnail_id( $to ) );
 		$this->assertEquals( 'aside', get_post_format( $to ) );
@@ -179,30 +179,36 @@ class Sync_Test extends PLL_UnitTestCase {
 
 	function test_create_page_translation() {
 		// parent pages
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
 
 		// source page
-		$from = $this->factory->post->create( array( 'post_type' => 'page', 'menu_order' => 12, 'post_parent' => $en ) );
+		$from = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'menu_order' => 12,
+				'post_parent' => $en,
+			]
+		);
 		self::$polylang->model->post->set_language( $from, 'en' );
 		add_post_meta( $from, '_wp_page_template', 'full-width.php' );
 
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 
 		$GLOBALS['pagenow'] = 'post-new.php';
-		$_GET = array(
+		$_GET               = [
 			'from_post' => $from,
 			'new_lang'  => 'fr',
 			'post_type' => 'page',
-		);
+		];
 
-		$to = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$to                                        = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		do_action( 'add_meta_boxes', 'page', $page = get_post( $to ) ); // fires the copy
 
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $to )->slug );
@@ -215,14 +221,14 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Attachment for thumbnail
-		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
+		$filename     = dirname( __FILE__ ) . '/../data/image.jpg';
 		$thumbnail_id = $this->factory->attachment->create_upload_object( $filename );
 
 		// categories
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
@@ -231,80 +237,108 @@ class Sync_Test extends PLL_UnitTestCase {
 		$to = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $to, 'fr' );
 
-		$from = $this->factory->post->create( array( 'post_category' => array( $en ), 'post_date' => '2007-09-04 00:00:00' ) );
+		$from = $this->factory->post->create(
+			[
+				'post_category' => [ $en ],
+				'post_date' => '2007-09-04 00:00:00',
+			]
+		);
 		self::$polylang->model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->post->save_translations( $from, [ 'fr' => $to ] );
 
-		$key = add_post_meta( $from, 'key', 'value' );
-		$metas[ $key ] = array( 'key' => 'key', 'value' => 'value' );
+		$key           = add_post_meta( $from, 'key', 'value' );
+		$metas[ $key ] = [
+			'key' => 'key',
+			'value' => 'value',
+		];
 
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 		$_REQUEST['sticky'] = 'sticky'; // sticky posts not managed by wp_insert_post
 		add_post_meta( $from, '_thumbnail_id', $thumbnail_id );
 
-		edit_post( array(
-			'post_ID'     => $from,
-			'post_format' => 'aside',
-			'meta'        => $metas,
-			'_thumbnail_id' => $thumbnail_id, // Since WP 4.6
-		) ); // fires the sync
+		edit_post(
+			[
+				'post_ID'     => $from,
+				'post_format' => 'aside',
+				'meta'        => $metas,
+				'_thumbnail_id' => $thumbnail_id, // Since WP 4.6
+			]
+		); // fires the sync
 		stick_post( $from );
 
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $to )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$polylang->model->post->get_translations( $from ) );
-		$this->assertEquals( array( get_category( $fr ) ), get_the_category( $to ) );
+		$this->assertEqualSetsWithIndex(
+			[
+				'en' => $from,
+				'fr' => $to,
+			], self::$polylang->model->post->get_translations( $from )
+		);
+		$this->assertEquals( [ get_category( $fr ) ], get_the_category( $to ) );
 		$this->assertEquals( '2007-09-04', get_the_date( 'Y-m-d', $to ) );
-		$this->assertEquals( array( 'value' ), get_post_meta( $to, 'key' ) );
-		$this->assertEquals( array( 'value' ), get_post_meta( $from, 'key' ) ); // Test reverse sync
+		$this->assertEquals( [ 'value' ], get_post_meta( $to, 'key' ) );
+		$this->assertEquals( [ 'value' ], get_post_meta( $from, 'key' ) ); // Test reverse sync
 		$this->assertEquals( $thumbnail_id, get_post_thumbnail_id( $to ) );
 		$this->assertEquals( 'aside', get_post_format( $to ) );
 		$this->assertTrue( is_sticky( $to ) );
 	}
 
 	function filter_theme_page_templates() {
-		return array( 'templates/test.php' => 'Test Template Page' );
+		return [ 'templates/test.php' => 'Test Template Page' ];
 	}
 
 	function test_save_page_with_sync() {
 		$GLOBALS['post_type'] = 'page';
-		add_filter( 'theme_page_templates', array( $this, 'filter_theme_page_templates' ) ); // Allow to test templates with themes without templates
+		add_filter( 'theme_page_templates', [ $this, 'filter_theme_page_templates' ] ); // Allow to test templates with themes without templates
 
 		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// parent pages
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
 
 		// pages page
-		$to = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$to = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $to, 'fr' );
 
-		$from = $this->factory->post->create( array( 'post_type' => 'page', 'menu_order' => 12, 'post_parent' => $en ) );
+		$from = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'menu_order' => 12,
+				'post_parent' => $en,
+			]
+		);
 		self::$polylang->model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->post->save_translations( $from, [ 'fr' => $to ] );
 
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
-		edit_post( array(
-			'post_ID'       => $from,
-			'page_template' => 'templates/test.php',
-		) ); // fires the sync
+		edit_post(
+			[
+				'post_ID'       => $from,
+				'page_template' => 'templates/test.php',
+			]
+		); // fires the sync
 
 		$page = get_post( $to );
 
 		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $to )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$polylang->model->post->get_translations( $from ) );
+		$this->assertEqualSetsWithIndex(
+			[
+				'en' => $from,
+				'fr' => $to,
+			], self::$polylang->model->post->get_translations( $from )
+		);
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );
 		$this->assertEquals( 12, $page->menu_order );
 		$this->assertEquals( 'templates/test.php', get_page_template_slug( $to ) );
@@ -313,13 +347,13 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function test_save_term_with_sync_in_post() {
-		self::$polylang->options['sync'] = array( 'taxonomies' );
+		self::$polylang->options['sync'] = [ 'taxonomies' ];
 
-		$from = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$from = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $from, 'en' );
 
 		// posts
-		$en = $this->factory->post->create( array( 'post_category' => array( $from ) ) );
+		$en = $this->factory->post->create( [ 'post_category' => [ $from ] ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
@@ -328,74 +362,89 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
-		$_REQUEST = $_POST = array(
+		$_REQUEST = $_POST = [
 			'action'           => 'add-tag',
 			'term_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
-			'term_tr_lang'     => array( 'en' => $from ),
-		);
+			'term_tr_lang'     => [ 'en' => $from ],
+		];
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 
-		$to = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$to = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $to )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$polylang->model->term->get_translations( $from ) );
+		$this->assertEqualSetsWithIndex(
+			[
+				'en' => $from,
+				'fr' => $to,
+			], self::$polylang->model->term->get_translations( $from )
+		);
 		$this->assertTrue( is_object_in_term( $fr, 'category', $to ) );
 	}
 
 	function test_save_term_with_parent_sync() {
-		self::$polylang->options['sync'] = array( 'taxonomies' );
+		self::$polylang->options['sync'] = [ 'taxonomies' ];
 
 		// Parents
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
 
 		// child
-		$from = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$from = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $from, 'en' );
 
 		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
-		$_REQUEST = $_POST = array(
+		$_REQUEST = $_POST = [
 			'action'           => 'add-tag',
 			'post_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
-			'term_tr_lang'     => array( 'en' => $from ),
+			'term_tr_lang'     => [ 'en' => $from ],
 			'parent'           => $fr,
-		);
+		];
 
-		$to = $this->factory->term->create( array( 'taxonomy' => 'category', 'parent' => $fr ) );
+		$to = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'parent' => $fr,
+			]
+		);
 		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $to )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$polylang->model->term->get_translations( $from ) );
+		$this->assertEqualSetsWithIndex(
+			[
+				'en' => $from,
+				'fr' => $to,
+			], self::$polylang->model->term->get_translations( $from )
+		);
 		$this->assertEquals( $fr, get_category( $to )->parent );
 		$this->assertEquals( $en, get_category( $from )->parent );
 	}
 
 	function test_create_post_translation_with_sync_post_date() {
 		// source post
-		$from = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
+		$from = $this->factory->post->create( [ 'post_date' => '2007-09-04 00:00:00' ] );
 		self::$polylang->model->post->set_language( $from, 'en' );
 
-		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
-		self::$polylang->options['sync'] = array( 'post_date' ); // Sync publish date
+		self::$polylang->filters_post    = new PLL_Admin_Filters_Post( self::$polylang );
+		self::$polylang->sync            = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->options['sync'] = [ 'post_date' ]; // Sync publish date
 
 		$GLOBALS['pagenow'] = 'post-new.php';
-		$_GET = array(
+		$_GET               = [
 			'from_post' => $from,
 			'new_lang'  => 'fr',
-		);
+		];
 
 		$to = $this->factory->post->create();
 		clean_post_cache( $to ); // Necessary before calling get_post() below otherwise we don't get the synchronized date
@@ -411,28 +460,33 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// parent pages
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
 
 		// pages page
-		$to = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$to = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $to, 'fr' );
 
-		$from = $this->factory->post->create( array( 'post_type' => 'page', 'post_parent' => $en ) );
+		$from = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_parent' => $en,
+			]
+		);
 		self::$polylang->model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->post->save_translations( $from, [ 'fr' => $to ] );
 
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
-		wp_update_post( array( 'ID' => $from ) ); // fires the sync
+		wp_update_post( [ 'ID' => $from ] ); // fires the sync
 		$page = get_post( $to );
 
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );
@@ -444,17 +498,17 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// source post
-		$from = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
+		$from = $this->factory->post->create( [ 'post_date' => '2007-09-04 00:00:00' ] );
 		self::$polylang->model->post->set_language( $from, 'en' );
 
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 
 		$GLOBALS['pagenow'] = 'post-new.php';
-		$_GET = array(
+		$_GET               = [
 			'from_post' => $from,
 			'new_lang'  => 'fr',
-		);
+		];
 
 		$to = $this->factory->post->create();
 		do_action( 'add_meta_boxes', 'post', get_post( $to ) ); // fires the copy
@@ -465,7 +519,7 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function _add_term_meta_to_copy() {
-		return array( 'key' );
+		return [ 'key' ];
 	}
 
 	function test_copy_term_metas() {
@@ -475,9 +529,9 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		$to = $this->factory->term->create();
 		self::$polylang->model->term->set_language( $to, 'fr' );
-		self::$polylang->model->term->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->term->save_translations( $from, [ 'fr' => $to ] );
 
-		add_filter( 'pll_copy_term_metas', array( $this, '_add_term_meta_to_copy' ) );
+		add_filter( 'pll_copy_term_metas', [ $this, '_add_term_meta_to_copy' ] );
 
 		// copy
 		$sync = new PLL_Admin_Sync( self::$polylang );
@@ -502,23 +556,23 @@ class Sync_Test extends PLL_UnitTestCase {
 		$to = $this->factory->term->create();
 		self::$polylang->model->term->set_language( $to, 'fr' );
 
-		self::$polylang->model->term->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->term->save_translations( $from, [ 'fr' => $to ] );
 
-		add_filter( 'pll_copy_term_metas', array( $this, '_add_term_meta_to_copy' ) );
+		add_filter( 'pll_copy_term_metas', [ $this, '_add_term_meta_to_copy' ] );
 
 		// Add
 		add_term_meta( $from, 'key', 'value1' );
 		add_term_meta( $from, 'key', 'value2' );
 		add_term_meta( $from, 'key', 'value3' );
-		$this->assertEqualSets( array( 'value1', 'value2', 'value3' ), get_term_meta( $to, 'key' ) );
+		$this->assertEqualSets( [ 'value1', 'value2', 'value3' ], get_term_meta( $to, 'key' ) );
 
 		// Delete
 		$this->assertTrue( delete_term_meta( $from, 'key', 'value3' ) );
-		$this->assertEqualSets( array( 'value1', 'value2' ), get_term_meta( $to, 'key' ) );
+		$this->assertEqualSets( [ 'value1', 'value2' ], get_term_meta( $to, 'key' ) );
 
 		// Update
 		$this->assertTrue( update_term_meta( $from, 'key', 'value4', 'value2' ) );
-		$this->assertEqualSets( array( 'value1', 'value4' ), get_term_meta( $to, 'key' ) );
+		$this->assertEqualSets( [ 'value1', 'value4' ], get_term_meta( $to, 'key' ) );
 	}
 
 	function test_sync_post_with_metas_to_remove() {
@@ -531,27 +585,32 @@ class Sync_Test extends PLL_UnitTestCase {
 		$from = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->post->save_translations( $from, [ 'fr' => $to ] );
 
 		add_post_meta( $to, 'key1', 'value' );
 		add_post_meta( $to, 'key2', 'value1' );
 		add_post_meta( $to, 'key2', 'value2' );
-		$key = add_post_meta( $from, 'key2', 'value1' );
-		$metas[ $key ] = array( 'key' => 'key2', 'value' => 'value1' );
+		$key           = add_post_meta( $from, 'key2', 'value1' );
+		$metas[ $key ] = [
+			'key' => 'key2',
+			'value' => 'value1',
+		];
 
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
-		edit_post( array(
-			'post_ID' => $from,
-			'meta'    => $metas,
-		) ); // Fires the sync
+		edit_post(
+			[
+				'post_ID' => $from,
+				'meta'    => $metas,
+			]
+		); // Fires the sync
 
 		$this->assertEmpty( get_post_meta( $to, 'key1' ) );
 		$this->assertEmpty( get_post_meta( $from, 'key1' ) );
-		$this->assertEqualSets( array( 'value1' ), get_post_meta( $to, 'key2' ) );
-		$this->assertEqualSets( array( 'value1' ), get_post_meta( $from, 'key2' ) );
+		$this->assertEqualSets( [ 'value1' ], get_post_meta( $to, 'key2' ) );
+		$this->assertEqualSets( [ 'value1' ], get_post_meta( $from, 'key2' ) );
 	}
 
 	function test_source_post_was_sticky_before_sync_was_active() {
@@ -564,19 +623,21 @@ class Sync_Test extends PLL_UnitTestCase {
 		$from = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->post->save_translations( $from, [ 'fr' => $to ] );
 
 		stick_post( $from );
 
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		$_REQUEST['sticky'] = 'sticky'; // sticky posts not managed by wp_insert_post
-		edit_post( array(
-			'post_ID' => $from,
-			'sticky'  => 'sticky',
-		) ); // Fires the sync
+		edit_post(
+			[
+				'post_ID' => $from,
+				'sticky'  => 'sticky',
+			]
+		); // Fires the sync
 
 		$this->assertTrue( is_sticky( $to ) );
 	}
@@ -591,17 +652,19 @@ class Sync_Test extends PLL_UnitTestCase {
 		$from = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$polylang->model->post->save_translations( $from, [ 'fr' => $to ] );
 
 		stick_post( $to );
 
 		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		self::$polylang->sync         = new PLL_Admin_Sync( self::$polylang );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
-		edit_post( array(
-			'post_ID' => $from,
-		) ); // Fires the sync
+		edit_post(
+			[
+				'post_ID' => $from,
+			]
+		); // Fires the sync
 
 		$this->assertfalse( is_sticky( $to ) );
 	}
@@ -611,27 +674,27 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Categories
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
 
 		// Posts
-		$post_fr = $this->factory->post->create( array( 'post_category' => array( $fr ) ) );
+		$post_fr = $this->factory->post->create( [ 'post_category' => [ $fr ] ] );
 		self::$polylang->model->post->set_language( $post_fr, 'fr' );
 
-		$post_en = $this->factory->post->create( array( 'post_category' => array( $en ) ) );
+		$post_en = $this->factory->post->create( [ 'post_category' => [ $en ] ] );
 		self::$polylang->model->post->set_language( $post_en, 'en' );
 
-		self::$polylang->model->post->save_translations( $post_en, array( 'fr' => $post_fr ) );
+		self::$polylang->model->post->save_translations( $post_en, [ 'fr' => $post_fr ] );
 
 		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
 
 		wp_delete_category( $fr );
 
-		$this->assertEquals( array( $en ), wp_get_post_categories( $post_en ) );
+		$this->assertEquals( [ $en ], wp_get_post_categories( $post_en ) );
 	}
 }

--- a/tests/phpunit/tests/test-terms-list.php
+++ b/tests/phpunit/tests/test-terms-list.php
@@ -9,39 +9,61 @@ class Terms_List_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = self::factory()->user->create( [ 'role' => 'editor' ] );
 	}
 
 	function setUp() {
 		parent::setUp();
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang ); // To activate the fix_delete_default_category() filter
+		self::$polylang               = new PLL_Admin( self::$polylang->links_model );
+		self::$polylang->filters      = new PLL_Admin_Filters( self::$polylang ); // To activate the fix_delete_default_category() filter
 		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang );
 	}
 
 	function tearDown() {
 		parent::tearDown();
 
-		$_REQUEST = $_GET = $_POST = array();
+		$_REQUEST = $_GET = $_POST = [];
 		unset( $GLOBALS['hook_suffix'], $GLOBALS['current_screen'] );
 	}
 
 	function test_term_list_with_admin_language_filter() {
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'essai',
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'enfant', 'parent' => $fr ) );
+		$fr = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'enfant',
+				'parent' => $fr,
+			]
+		);
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'child', 'parent' => $en ) );
+		$en = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name' => 'child',
+				'parent' => $en,
+			]
+		);
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$GLOBALS['taxnow'] = $_REQUEST['taxonomy'] = $_GET['taxonomy'] = 'category'; // WP_Screen tests $_REQUEST, Polylang tests $_GET
+		$GLOBALS['taxnow']      = $_REQUEST['taxonomy'] = $_GET['taxonomy'] = 'category'; // WP_Screen tests $_REQUEST, Polylang tests $_GET
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';
 		set_current_screen();
 		$wp_list_table = _get_list_table( 'WP_Terms_List_Table' );
@@ -75,12 +97,12 @@ class Terms_List_Test extends PLL_UnitTestCase {
 
 	// bug introduced by WP 4.3 and fixed in v1.8.2
 	function test_default_category_in_list_table() {
-		$id = $this->factory->term->create( array( 'taxonomy' => 'category' ) ); // a non default category
+		$id      = $this->factory->term->create( [ 'taxonomy' => 'category' ] ); // a non default category
 		$default = get_option( 'default_category' );
-		$en = self::$polylang->model->term->get( $default, 'en' );
-		$fr = self::$polylang->model->term->get( $default, 'fr' );
+		$en      = self::$polylang->model->term->get( $default, 'en' );
+		$fr      = self::$polylang->model->term->get( $default, 'fr' );
 
-		$GLOBALS['taxnow'] = $_REQUEST['taxonomy'] = $_GET['taxonomy'] = 'category'; // WP_Screen tests $_REQUEST, Polylang tests $_GET
+		$GLOBALS['taxnow']      = $_REQUEST['taxonomy'] = $_GET['taxonomy'] = 'category'; // WP_Screen tests $_REQUEST, Polylang tests $_GET
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';
 		set_current_screen();
 		$wp_list_table = _get_list_table( 'WP_Terms_List_Table' );

--- a/tests/phpunit/tests/test-widgets-calendar.php
+++ b/tests/phpunit/tests/test-widgets-calendar.php
@@ -30,10 +30,10 @@ class Widget_Calendar_Test extends PLL_UnitTestCase {
 	}
 
 	function test_get_calendar() {
-		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
+		$en = $this->factory->post->create( [ 'post_date' => '2007-09-04 00:00:00' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-05 00:00:00' ) );
+		$fr = $this->factory->post->create( [ 'post_date' => '2007-09-05 00:00:00' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->filters_links = new PLL_Frontend_Filters_Links( self::$polylang );

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -28,11 +28,11 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 	function clean_up_global_scope() {
 		global $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
 
-		$wp_registered_sidebars = array();
-		$wp_registered_widgets = array();
-		$wp_registered_widget_controls = array();
-		$wp_registered_widget_updates = array();
-		$wp_widget_factory->widgets = array();
+		$wp_registered_sidebars        = [];
+		$wp_registered_widgets         = [];
+		$wp_registered_widget_controls = [];
+		$wp_registered_widget_updates  = [];
+		$wp_widget_factory->widgets    = [];
 
 		parent::clean_up_global_scope();
 	}
@@ -42,7 +42,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 
 		set_current_screen( 'widgets' );
 		wp_widgets_init();
-		$wp_widget_search = $wp_registered_widgets['search-2']['callback'][0];
+		$wp_widget_search        = $wp_registered_widgets['search-2']['callback'][0];
 		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang );
 		ob_start();
 		$wp_widget_search->form_callback( 2 );
@@ -53,12 +53,12 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 	function update_lang_choice( $widget, $lang ) {
 		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang );
 
-		$_POST = array(
+		$_POST = [
 			'widget-id'     => $widget->id,
 			'id_base'       => $widget->id_base,
 			'widget_number' => $widget->number,
 			'multi_number'  => '',
-		);
+		];
 
 		$_POST[ $widget->id . '_lang_choice' ] = $lang;
 		$widget->update_callback();
@@ -72,7 +72,12 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$this->update_lang_choice( $wp_widget_search, 'en' );
 
 		self::$polylang->filters = new PLL_Frontend_Filters( self::$polylang );
-		$args = array( 'before_title' => '', 'after_title' => '', 'before_widget' => '', 'after_widget' => '' );
+		$args                    = [
+			'before_title' => '',
+			'after_title' => '',
+			'before_widget' => '',
+			'after_widget' => '',
+		];
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 		ob_start();
 		$wp_widget_search->display_callback( $args, 2 );
@@ -92,7 +97,12 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$this->update_lang_choice( $wp_widget_search, 0 );
 
 		self::$polylang->filters = new PLL_Frontend_Filters( self::$polylang );
-		$args = array( 'before_title' => '', 'after_title' => '', 'before_widget' => '', 'after_widget' => '' );
+		$args                    = [
+			'before_title' => '',
+			'after_title' => '',
+			'before_widget' => '',
+			'after_widget' => '',
+		];
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 		ob_start();
 		$wp_widget_search->display_callback( $args, 2 );
@@ -111,25 +121,29 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		}
 
 		self::$polylang->options['media_support'] = 1;
-		self::$polylang->filters_media = new PLL_Admin_Filters_Media( self::$polylang );
+		self::$polylang->filters_media            = new PLL_Admin_Filters_Media( self::$polylang );
 
 		self::$polylang->pref_lang = self::$polylang->model->get_language( 'en' );
-		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
+		$filename                  = dirname( __FILE__ ) . '/../data/image.jpg';
 
 		$en = $this->factory->attachment->create_upload_object( $filename );
-		wp_update_post( array(
-			'ID'           => $en,
-			'post_title'   => 'Test image EN',
-			'post_excerpt' => 'Caption EN',
-		) );
+		wp_update_post(
+			[
+				'ID'           => $en,
+				'post_title'   => 'Test image EN',
+				'post_excerpt' => 'Caption EN',
+			]
+		);
 		update_post_meta( $en, '_wp_attachment_image_alt', 'Alt text EN' );
 
 		$fr = self::$polylang->filters_media->create_media_translation( $en, 'fr' );
-		wp_update_post( array(
-			'ID'           => $fr,
-			'post_title'   => 'Test image FR',
-			'post_excerpt' => 'Caption FR',
-		) );
+		wp_update_post(
+			[
+				'ID'           => $fr,
+				'post_title'   => 'Test image FR',
+				'post_excerpt' => 'Caption FR',
+			]
+		);
 		update_post_meta( $fr, '_wp_attachment_image_alt', 'Alt text FR' );
 
 		// Switch to frontend
@@ -137,10 +151,18 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 
 		$widget = new WP_Widget_Media_Image();
-		$args = array( 'before_title' => '', 'after_title' => '', 'before_widget' => '', 'after_widget' => '' );
+		$args   = [
+			'before_title' => '',
+			'after_title' => '',
+			'before_widget' => '',
+			'after_widget' => '',
+		];
 
 		// Empty fields in Edit Image
-		$instance = array( 'attachment_id' => $en, 'caption' => null ); // Need to explicitely set 'caption' to null since WP 4.9. See #42350
+		$instance = [
+			'attachment_id' => $en,
+			'caption' => null,
+		]; // Need to explicitely set 'caption' to null since WP 4.9. See #42350
 		ob_start();
 		$widget->widget( $args, $instance );
 		$output = ob_get_clean();
@@ -151,7 +173,12 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$this->assertNotContains( 'Test image FR', $output );
 
 		// Edit Image fields are filled
-		$instance = array( 'attachment_id' => $en, 'alt' => 'Custom alt', 'caption' => 'Custom caption', 'image_title' => 'Custom title' );
+		$instance = [
+			'attachment_id' => $en,
+			'alt' => 'Custom alt',
+			'caption' => 'Custom caption',
+			'image_title' => 'Custom title',
+		];
 		ob_start();
 		$widget->widget( $args, $instance );
 		$output = ob_get_clean();
@@ -170,11 +197,11 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 
 		self::$polylang->filters = new PLL_Frontend_Filters( self::$polylang );
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
-		$sidebars = wp_get_sidebars_widgets();
+		$sidebars                = wp_get_sidebars_widgets();
 		$this->assertTrue( in_array( 'search-2', $sidebars['sidebar-1'] ) );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$sidebars = wp_get_sidebars_widgets();
+		$sidebars                = wp_get_sidebars_widgets();
 		$this->assertFalse( in_array( 'search-2', $sidebars['sidebar-1'] ) );
 	}
 }

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -198,10 +198,10 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		self::$polylang->filters = new PLL_Frontend_Filters( self::$polylang );
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 		$sidebars                = wp_get_sidebars_widgets();
-		$this->assertTrue( in_array( 'search-2', $sidebars['sidebar-1'] ) );
+		$this->assertTrue( in_array( 'search-2', $sidebars['sidebar-1'], true ) );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 		$sidebars                = wp_get_sidebars_widgets();
-		$this->assertFalse( in_array( 'search-2', $sidebars['sidebar-1'] ) );
+		$this->assertFalse( in_array( 'search-2', $sidebars['sidebar-1'], true ) );
 	}
 }

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -31,30 +31,30 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 
 	function prepare_options() {
 		// mirror options defined in the sample wpml-config.xml
-		$my_plugins_options = array(
+		$my_plugins_options = [
 			'option_name_1' => 'val1',
 			'option_name_2' => 'val2',
-			'options_group_1' => array(
+			'options_group_1' => [
 				'sub_option_name_11' => 'val11',
 				'sub_option_name_12' => 'val12',
-			),
-			'options_group_2' => array(
+			],
+			'options_group_2' => [
 				'sub_key_21' => 'val21',
-				'sub_key_22' => array(
+				'sub_key_22' => [
 					'sub_sub_221' => 'val221',
-					'sub_sub_222' => array(
+					'sub_sub_222' => [
 						'sub_sub_sub_2221' => 'val2221',
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 		update_option( 'my_plugins_options', $my_plugins_options );
 		update_option( 'simple_string_option', 'val' );
 	}
 
 	function translate_options( $slug ) {
 		$language = self::$polylang->model->get_language( $slug );
-		$mo = new PLL_MO();
+		$mo       = new PLL_MO();
 		$mo->import_from_db( $language );
 		$mo->add_entry( $mo->make_entry( 'val', "val_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'val1', "val1_$slug" ) );
@@ -126,8 +126,13 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertFalse( self::$polylang->model->is_translated_post_type( 'DVD' ) );
 
 		// settings
-		$post_types = get_post_types( array( 'public' => true, '_builtin' => false ) );
-		$post_types = array_diff( $post_types, get_post_types( array( '_pll' => true ) ) );
+		$post_types = get_post_types(
+			[
+				'public' => true,
+				'_builtin' => false,
+			]
+		);
+		$post_types = array_diff( $post_types, get_post_types( [ '_pll' => true ] ) );
 		$post_types = array_unique( apply_filters( 'pll_get_post_types', $post_types, true ) );
 		$this->assertNotContains( 'book', $post_types );
 		$this->assertNotContains( 'DVD', $post_types );
@@ -149,8 +154,13 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertFalse( self::$polylang->model->is_translated_taxonomy( 'publisher' ) );
 
 		// settings
-		$taxonomies = get_taxonomies( array( 'public' => true, '_builtin' => false ) );
-		$taxonomies = array_diff( $taxonomies, get_taxonomies( array( '_pll' => true ) ) );
+		$taxonomies = get_taxonomies(
+			[
+				'public' => true,
+				'_builtin' => false,
+			]
+		);
+		$taxonomies = array_diff( $taxonomies, get_taxonomies( [ '_pll' => true ] ) );
 		$taxonomies = array_unique( apply_filters( 'pll_get_taxonomies', $taxonomies, true ) );
 		$this->assertNotContains( 'genre', $taxonomies );
 		$this->assertNotContains( 'publisher', $taxonomies );

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -34,7 +34,7 @@ class WPML_Test extends PLL_UnitTestCase {
 	function test_acf() {
 		register_post_type( 'acf' );
 
-		$id = $this->factory->post->create( array( 'post_type' => 'acf' ) );
+		$id = $this->factory->post->create( [ 'post_type' => 'acf' ] );
 		$this->assertEquals( icl_object_id( $id, 'acf', true, 'en' ), $id );
 
 		_unregister_post_type( 'acf' );
@@ -43,10 +43,10 @@ class WPML_Test extends PLL_UnitTestCase {
 	function test_wpml_active_languages() {
 		self::$polylang->model->post->register_taxonomy(); // Needed otherwise posts are not counted
 
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->clean_languages_cache(); // For some reason (global state?) we need to reset the posts count
@@ -59,7 +59,7 @@ class WPML_Test extends PLL_UnitTestCase {
 
 		$languages = apply_filters( 'wpml_active_languages', null );
 
-		$expected = array(
+		$expected = [
 			'id' => self::$polylang->model->get_language( 'fr' )->term_id,
 			'active' => 1,
 			'native_name' => 'Français',
@@ -68,13 +68,13 @@ class WPML_Test extends PLL_UnitTestCase {
 			'language_code' => 'fr',
 			'country_flag_url' => plugins_url( '/flags/fr.png', POLYLANG_FILE ),
 			'url' => home_url( "?page_id={$fr}&lang=fr" ),
-		);
+		];
 
 		$this->assertCount( 3, $languages ); // All languages are returned, even German which has no content
 		$this->assertEqualSets( $expected, $languages['fr'] );
 		$this->assertEquals( 1, $languages['en']['missing'] );
 
-		$languages = apply_filters( 'wpml_active_languages', null, array( 'skip_missing' => 1 ) );
+		$languages = apply_filters( 'wpml_active_languages', null, [ 'skip_missing' => 1 ] );
 
 		$this->assertCount( 1, $languages );
 		$this->assertNotEmpty( $languages['fr'] );
@@ -82,10 +82,10 @@ class WPML_Test extends PLL_UnitTestCase {
 		// test orderby and order only in WP 4.7+
 		if ( function_exists( 'wp_list_sort' ) ) {
 			$languages = apply_filters( 'wpml_active_languages', null, 'orderby=code&order=asc' );
-			$this->assertEqualSetsWithIndex( array( 'de', 'en', 'fr' ), array_keys( $languages ) );
+			$this->assertEqualSetsWithIndex( [ 'de', 'en', 'fr' ], array_keys( $languages ) );
 
 			$languages = apply_filters( 'wpml_active_languages', null, 'orderby=code&order=desc' );
-			$this->assertEqualSetsWithIndex( array( 'fr', 'en', 'de' ), array_keys( $languages ) );
+			$this->assertEqualSetsWithIndex( [ 'fr', 'en', 'de' ], array_keys( $languages ) );
 		}
 	}
 
@@ -113,11 +113,11 @@ class WPML_Test extends PLL_UnitTestCase {
 	}
 
 	function test_wpml_post_language_details() {
-		$id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$id = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $id, 'en' );
 
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$lang = apply_filters( 'wpml_post_language_details', null, $id );
+		$lang                    = apply_filters( 'wpml_post_language_details', null, $id );
 
 		$this->assertEquals( 'en', $lang['language_code'] );
 		$this->assertEquals( 'en_US', $lang['locale'] );
@@ -125,28 +125,42 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'English', $lang['native_name'] );
 		$this->assertTrue( $lang['different_language'] );
 
-		$GLOBALS['post'] = get_post( $id );
+		$GLOBALS['post']         = get_post( $id );
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
-		$lang = apply_filters( 'wpml_post_language_details', null );
+		$lang                    = apply_filters( 'wpml_post_language_details', null );
 
 		$this->assertEquals( 'en', $lang['language_code'] );
 		$this->assertFalse( $lang['different_language'] );
 	}
 
 	function test_wpml_language_code() {
-		$id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$id = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $id, 'en' );
 
-		$this->assertEquals( 'en', apply_filters( 'wpml_element_language_code', null, array( 'element_id' => $id, 'element_type' => 'page' ) ) );
+		$this->assertEquals(
+			'en', apply_filters(
+				'wpml_element_language_code', null, [
+					'element_id' => $id,
+					'element_type' => 'page',
+				]
+			)
+		);
 
-		$id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $id, 'en' );
 
-		$this->assertEquals( 'en', apply_filters( 'wpml_element_language_code', null, array( 'element_id' => $id, 'element_type' => 'category' ) ) );
+		$this->assertEquals(
+			'en', apply_filters(
+				'wpml_element_language_code', null, [
+					'element_id' => $id,
+					'element_type' => 'category',
+				]
+			)
+		);
 	}
 
 	function test_wpml_home_url() {
-		self::$polylang->links = new PLL_Frontend_Links( self::$polylang );
+		self::$polylang->links   = new PLL_Frontend_Links( self::$polylang );
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 
 		$this->assertEquals( 'http://example.org/?lang=fr', apply_filters( 'wpml_home_url', null ) );
@@ -158,12 +172,12 @@ class WPML_Test extends PLL_UnitTestCase {
 
 		// Switch to pretty permalinks
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // Brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // Brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 		create_initial_taxonomies(); // Needed for catery links
 
 		self::$polylang->options['force_lang'] = 1;
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		self::$polylang->links_model           = self::$polylang->model->get_links_model();
 		self::$polylang->links_model->init();
 
 		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
@@ -176,10 +190,20 @@ class WPML_Test extends PLL_UnitTestCase {
 		self::$polylang->filters_links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
 		self::$polylang->filters_links->cache->method( 'get' )->willReturn( false );
 
-		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'test' ) );
+		$en = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_title' => 'test',
+			]
+		);
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$tag = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
+		$tag = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name' => 'test',
+			]
+		);
 		self::$polylang->model->term->set_language( $tag, 'en' );
 
 		ob_start();
@@ -192,7 +216,12 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '<a href="http://example.org/en/test/">Custom link</a>', ob_get_clean() );
 
 		ob_start();
-		apply_filters( 'wpml_element_link', $en, 'page', '', array( 'category' => 'foo', 'bar' => 'baz' ) );
+		apply_filters(
+			'wpml_element_link', $en, 'page', '', [
+				'category' => 'foo',
+				'bar' => 'baz',
+			]
+		);
 		$this->assertEquals( '<a href="http://example.org/en/test/?category=foo&#038;bar=baz">test</a>', ob_get_clean() );
 
 		ob_start();
@@ -216,7 +245,12 @@ class WPML_Test extends PLL_UnitTestCase {
 		$link = apply_filters( 'wpml_element_link', $en, 'page', '', '', '', false, false );
 		$this->assertEquals( '', $link ); // return_original_if_missing false
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'test fr' ) );
+		$fr = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+				'post_title' => 'test fr',
+			]
+		);
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
@@ -228,10 +262,10 @@ class WPML_Test extends PLL_UnitTestCase {
 	function test_wpml_object_id() {
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
@@ -240,7 +274,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $fr, apply_filters( 'wpml_object_id', $en, 'page' ) );
 		$this->assertEquals( $en, apply_filters( 'wpml_object_id', $fr, 'page', false, 'en' ) );
 
-		$cat = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$cat = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $cat, 'en' );
 
 		$this->assertNull( apply_filters( 'wpml_object_id', $cat, 'category' ) );
@@ -266,11 +300,11 @@ class WPML_Test extends PLL_UnitTestCase {
 		$nav_menu = new PLL_Admin_Nav_Menu( self::$polylang );
 		$nav_menu->create_nav_menu_locations();
 
-		$locations = array_keys( get_registered_nav_menus() );
-		$nav_menu_locations = array(
+		$locations          = array_keys( get_registered_nav_menus() );
+		$nav_menu_locations = [
 			$locations[0] => $menu_en,
 			$locations[1] => $menu_fr,
-		);
+		];
 
 		set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$nav_menu->update_nav_menu_locations( $nav_menu_locations ); // Our filter update_nav_menu_locations does not run due to security checks
@@ -285,30 +319,30 @@ class WPML_Test extends PLL_UnitTestCase {
 	}
 
 	function test_wpml_element_has_translations() {
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$en = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
-		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$fr = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
 
-		$id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$id = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		self::$polylang->model->post->set_language( $id, 'en' );
 
 		$this->assertTrue( apply_filters( 'wpml_element_has_translations', null, $en, 'page' ) );
 		$this->assertTrue( apply_filters( 'wpml_element_has_translations', null, $fr, 'page' ) );
 		$this->assertFalse( apply_filters( 'wpml_element_has_translations', null, $id, 'page' ) );
 
-		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$en = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $en, 'en' );
 
-		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$fr = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $fr, 'fr' );
 
 		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
 
-		$id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 		self::$polylang->model->term->set_language( $id, 'en' );
 
 		$this->assertTrue( apply_filters( 'wpml_element_has_translations', null, $en, 'category' ) );
@@ -317,12 +351,12 @@ class WPML_Test extends PLL_UnitTestCase {
 	}
 
 	function test_strings_translations() {
-		add_action( 'pll_get_strings', array( PLL_WPML_Compat::instance(), 'get_strings' ) ); // Add filter as it is removed at the end of fisrt test (singleton!)
+		add_action( 'pll_get_strings', [ PLL_WPML_Compat::instance(), 'get_strings' ] ); // Add filter as it is removed at the end of fisrt test (singleton!)
 
 		// Register
 		do_action( 'wpml_register_single_string', 'wpml_string_context', 'wpml_string_name', 'wpml_string_test' );
 
-		$str = wp_list_filter( PLL_Admin_Strings::get_strings(), array( 'icl' => 1 ) );
+		$str = wp_list_filter( PLL_Admin_Strings::get_strings(), [ 'icl' => 1 ] );
 		$str = reset( $str );
 
 		$this->assertEquals( 'wpml_string_context', $str['context'] );
@@ -330,15 +364,15 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'wpml_string_test', $str['string'] );
 
 		// Translate
-		foreach ( array( 'en', 'fr' ) as $lang ) {
+		foreach ( [ 'en', 'fr' ] as $lang ) {
 			$language = self::$polylang->model->get_language( $lang );
-			$mo = new PLL_MO();
+			$mo       = new PLL_MO();
 			$mo->import_from_db( $language );
 			$mo->add_entry( $mo->make_entry( 'wpml_string_test', "wpml_string_test_$lang" ) );
 			$mo->export_to_db( $language );
 		}
 
-		$GLOBALS['polylang'] = self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+		$GLOBALS['polylang']     = self::$polylang = new PLL_Frontend( self::$polylang->links_model );
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 		do_action( 'pll_language_defined' );
 
@@ -357,11 +391,11 @@ class WPML_Test extends PLL_UnitTestCase {
 
 		// Switch to pretty permalinks
 		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // Brute force since WP does not do it :(
+		$wp_rewrite->extra_rules_top = []; // Brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
 		self::$polylang->options['force_lang'] = 1;
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		self::$polylang->links_model           = self::$polylang->model->get_links_model();
 		self::$polylang->links_model->init();
 
 		$this->assertEquals( home_url( '/fr/test/' ), apply_filters( 'wpml_permalink', home_url( '/test/' ), 'fr' ) );

--- a/tests/phpunit/tests/themes/test-twenty-fourteen.php
+++ b/tests/phpunit/tests/themes/test-twenty-fourteen.php
@@ -4,116 +4,131 @@ $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( file_exists( $_tests_dir . '../wordpress/wp-content/themes/twentyfourteen/style.css' ) ) {
 
-class Twenty_Fourteen_Test extends PLL_UnitTestCase {
-	static $stylesheet, $tag_en, $tag_fr;
+	class Twenty_Fourteen_Test extends PLL_UnitTestCase {
+		static $stylesheet, $tag_en, $tag_fr;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+		static function wpSetUpBeforeClass() {
+			parent::wpSetUpBeforeClass();
 
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
+			self::create_language( 'en_US' );
+			self::create_language( 'fr_FR' );
 
-		require_once PLL_INC . '/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
+			require_once PLL_INC . '/api.php';
+			$GLOBALS['polylang'] = &self::$polylang;
 
-		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
-		switch_theme( 'twentyfourteen' );
+			self::$stylesheet = get_option( 'stylesheet' ); // save default theme
+			switch_theme( 'twentyfourteen' );
+		}
+
+		function setUp() {
+			parent::setUp();
+
+			// we need to add these filters manually as the constructor of PLL_Plugins_Compat is called before activation of Twenty Fourteen
+			add_filter( 'transient_featured_content_ids', [ PLL_Plugins_Compat::instance(), 'twenty_fourteen_featured_content_ids' ] );
+			add_filter( 'option_featured-content', [ PLL_Plugins_Compat::instance(), 'twenty_fourteen_option_featured_content' ] );
+
+			require_once get_template_directory() . '/functions.php';
+			twentyfourteen_setup();
+			Featured_Content::init();
+
+			self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+			self::$polylang->init();
+		}
+
+		static function wpTearDownAfterClass() {
+			parent::wpTearDownAfterClass();
+
+			unset( $GLOBALS['polylang'] );
+			switch_theme( self::$stylesheet );
+		}
+
+		function test_ephemera_widget() {
+			$GLOBALS['wp_rewrite']->set_permalink_structure( '' );
+
+			$en = $this->factory->post->create( [ 'post_content' => 'Test' ] );
+			set_post_format( $en, 'aside' );
+			self::$polylang->model->post->set_language( $en, 'en' );
+
+			$fr = $this->factory->post->create( [ 'post_content' => 'Essai' ] );
+			set_post_format( $fr, 'aside' );
+			self::$polylang->model->post->set_language( $fr, 'fr' );
+
+			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+
+			require_once get_template_directory() . '/inc/widgets.php';
+			$widget   = new Twenty_Fourteen_Ephemera_Widget();
+			$args     = [
+				'before_title' => '',
+				'after_title' => '',
+				'before_widget' => '',
+				'after_widget' => '',
+			];
+			$instance = [];
+
+			ob_start();
+			$widget->widget( $args, $instance );
+			$out = ob_get_clean();
+
+			$this->assertFalse( strpos( $out, '<p>Test</p>' ) );
+			$this->assertNotFalse( strpos( $out, '<p>Essai</p>' ) );
+		}
+
+		function setup_featured_tags() {
+			self::$tag_en = $en = $this->factory->term->create(
+				[
+					'taxonomy' => 'post_tag',
+					'name' => 'featured',
+				]
+			);
+			self::$polylang->model->term->set_language( $en, 'en' );
+
+			self::$tag_fr = $fr = $this->factory->term->create(
+				[
+					'taxonomy' => 'post_tag',
+					'name' => 'en avant',
+				]
+			);
+			self::$polylang->model->term->set_language( $fr, 'fr' );
+			self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+
+			$options = [
+				'hide-tag' => 1,
+				'tag-id'   => $en,
+				'tag-name' => 'featured',
+			];
+
+			update_option( 'featured-content', $options );
+		}
+
+		function test_option_featured_content() {
+			$this->setup_featured_tags();
+
+			self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+			$settings                = Featured_Content::get_setting();
+			$this->assertEquals( self::$tag_en, $settings['tag-id'] );
+
+			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+			$settings                = Featured_Content::get_setting();
+			$this->assertEquals( self::$tag_fr, $settings['tag-id'] );
+		}
+
+		function test_featured_content_ids() {
+			$this->setup_featured_tags();
+
+			$en = $this->factory->post->create( [ 'tags_input' => [ 'featured' ] ] );
+			self::$polylang->model->post->set_language( $en, 'en' );
+
+			$fr = $this->factory->post->create( [ 'tags_input' => [ 'en avant' ] ] );
+			self::$polylang->model->post->set_language( $fr, 'fr' );
+
+			do_action_ref_array( 'pll_init', [ &self::$polylang ] ); // to pass the test in PLL_Plugins_Compat::twenty_fourteen_featured_content_ids
+
+			self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+			$this->assertEquals( [ get_post( $en ) ], twentyfourteen_get_featured_posts() );
+
+			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+			$this->assertEquals( [ get_post( $fr ) ], twentyfourteen_get_featured_posts() );
+		}
 	}
-
-	function setUp() {
-		parent::setUp();
-
-		// we need to add these filters manually as the constructor of PLL_Plugins_Compat is called before activation of Twenty Fourteen
-		add_filter( 'transient_featured_content_ids', array( PLL_Plugins_Compat::instance(), 'twenty_fourteen_featured_content_ids' ) );
-		add_filter( 'option_featured-content', array( PLL_Plugins_Compat::instance(), 'twenty_fourteen_option_featured_content' ) );
-
-		require_once get_template_directory() . '/functions.php';
-		twentyfourteen_setup();
-		Featured_Content::init();
-
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
-	}
-
-	static function wpTearDownAfterClass() {
-		parent::wpTearDownAfterClass();
-
-		unset( $GLOBALS['polylang'] );
-		switch_theme( self::$stylesheet );
-	}
-
-	function test_ephemera_widget() {
-		$GLOBALS['wp_rewrite']->set_permalink_structure( '' );
-
-		$en = $this->factory->post->create( array( 'post_content' => 'Test' ) );
-		set_post_format( $en, 'aside' );
-		self::$polylang->model->post->set_language( $en, 'en' );
-
-		$fr = $this->factory->post->create( array( 'post_content' => 'Essai' ) );
-		set_post_format( $fr, 'aside' );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-
-		require_once get_template_directory() . '/inc/widgets.php';
-		$widget = new Twenty_Fourteen_Ephemera_Widget();
-		$args = array( 'before_title' => '', 'after_title' => '', 'before_widget' => '', 'after_widget' => '' );
-		$instance = array();
-
-		ob_start();
-		$widget->widget( $args, $instance );
-		$out = ob_get_clean();
-
-		$this->assertFalse( strpos( $out, '<p>Test</p>' ) );
-		$this->assertNotFalse( strpos( $out, '<p>Essai</p>' ) );
-	}
-
-	function setup_featured_tags() {
-		self::$tag_en = $en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'featured' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
-
-		self::$tag_fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'en avant' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
-
-		$options = array(
-			'hide-tag' => 1,
-			'tag-id'   => $en,
-			'tag-name' => 'featured',
-		);
-
-		update_option( 'featured-content', $options );
-	}
-
-	function test_option_featured_content() {
-		$this->setup_featured_tags();
-
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
-		$settings = Featured_Content::get_setting();
-		$this->assertEquals( self::$tag_en, $settings['tag-id'] );
-
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$settings = Featured_Content::get_setting();
-		$this->assertEquals( self::$tag_fr, $settings['tag-id'] );
-	}
-
-	function test_featured_content_ids() {
-		$this->setup_featured_tags();
-
-		$en = $this->factory->post->create( array( 'tags_input' => array( 'featured' ) ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
-
-		$fr = $this->factory->post->create( array( 'tags_input' => array( 'en avant' ) ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-
-		do_action_ref_array( 'pll_init', array( &self::$polylang ) ); // to pass the test in PLL_Plugins_Compat::twenty_fourteen_featured_content_ids
-
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
-		$this->assertEquals( array( get_post( $en ) ), twentyfourteen_get_featured_posts() );
-
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$this->assertEquals( array( get_post( $fr ) ), twentyfourteen_get_featured_posts() );
-	}
-}
 
 } // file_exists

--- a/tests/phpunit/tests/themes/test-twenty-seventeen.php
+++ b/tests/phpunit/tests/themes/test-twenty-seventeen.php
@@ -4,63 +4,63 @@ $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( file_exists( $_tests_dir . '../wordpress/wp-content/themes/twentyseventeen/style.css' ) ) {
 
-class Twenty_Seventeen_Test extends PLL_UnitTestCase {
-	static $stylesheet;
+	class Twenty_Seventeen_Test extends PLL_UnitTestCase {
+		static $stylesheet;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+		static function wpSetUpBeforeClass() {
+			parent::wpSetUpBeforeClass();
 
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
+			self::create_language( 'en_US' );
+			self::create_language( 'fr_FR' );
 
-		require_once PLL_INC . '/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
+			require_once PLL_INC . '/api.php';
+			$GLOBALS['polylang'] = &self::$polylang;
 
-		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
-		switch_theme( 'twentyseventeen' );
+			self::$stylesheet = get_option( 'stylesheet' ); // save default theme
+			switch_theme( 'twentyseventeen' );
+		}
+
+		function setUp() {
+			parent::setUp();
+
+			require_once get_template_directory() . '/functions.php';
+		}
+
+		static function wpTearDownAfterClass() {
+			parent::wpTearDownAfterClass();
+
+			unset( $GLOBALS['polylang'] );
+			switch_theme( self::$stylesheet );
+		}
+
+		function test_front_page_panels() {
+			$en = self::factory()->post->create( [ 'post_title' => 'section 1 EN' ] );
+			self::$polylang->model->post->set_language( $en, 'en' );
+
+			$fr = self::factory()->post->create( [ 'post_title' => 'section 1 FR' ] );
+			self::$polylang->model->post->set_language( $fr, 'fr' );
+
+			self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+
+			set_theme_mod( 'panel_1', $en );
+
+			self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+			self::$polylang->init();
+			do_action( 'pll_init' );
+			PLL_Plugins_Compat::instance()->twenty_seventeen_init(); // Called manually as the constructor of PLL_Plugins_Compat is called before activation of Twenty Seventeen
+
+			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+
+			ob_start();
+			twentyseventeen_front_page_section( null, 1 );
+			$this->assertNotFalse( strpos( ob_get_clean(), 'section 1 FR' ) );
+
+			self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+
+			ob_start();
+			twentyseventeen_front_page_section( null, 1 );
+			$this->assertNotFalse( strpos( ob_get_clean(), 'section 1 EN' ) );
+		}
 	}
-
-	function setUp() {
-		parent::setUp();
-
-		require_once get_template_directory() . '/functions.php';
-	}
-
-	static function wpTearDownAfterClass() {
-		parent::wpTearDownAfterClass();
-
-		unset( $GLOBALS['polylang'] );
-		switch_theme( self::$stylesheet );
-	}
-
-	function test_front_page_panels() {
-		$en = self::factory()->post->create( array( 'post_title' => 'section 1 EN' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
-
-		$fr = self::factory()->post->create( array( 'post_title' => 'section 1 FR' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
-
-		set_theme_mod( 'panel_1', $en );
-
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
-		do_action( 'pll_init' );
-		PLL_Plugins_Compat::instance()->twenty_seventeen_init(); // Called manually as the constructor of PLL_Plugins_Compat is called before activation of Twenty Seventeen
-
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
-
-		ob_start();
-		twentyseventeen_front_page_section( null, 1 );
-		$this->assertNotFalse( strpos( ob_get_clean(), 'section 1 FR' ) );
-
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
-
-		ob_start();
-		twentyseventeen_front_page_section( null, 1 );
-		$this->assertNotFalse( strpos( ob_get_clean(), 'section 1 EN' ) );
-	}
-}
 
 } // file_exists

--- a/uninstall.php
+++ b/uninstall.php
@@ -27,8 +27,7 @@ class PLL_Uninstall {
 				$this->uninstall();
 			}
 			restore_current_blog();
-		}
-		else {
+		} else {
 			$this->uninstall();
 		}
 	}
@@ -60,15 +59,22 @@ class PLL_Uninstall {
 		}
 
 		// Need to register the taxonomies
-		$pll_taxonomies = array( 'language', 'term_language', 'post_translations', 'term_translations' );
+		$pll_taxonomies = [ 'language', 'term_language', 'post_translations', 'term_translations' ];
 		foreach ( $pll_taxonomies as $taxonomy ) {
-			register_taxonomy( $taxonomy, null, array( 'label' => false, 'public' => false, 'query_var' => false, 'rewrite' => false ) );
+			register_taxonomy(
+				$taxonomy, null, [
+					'label' => false,
+					'public' => false,
+					'query_var' => false,
+					'rewrite' => false,
+				]
+			);
 		}
 
-		$languages = get_terms( 'language', array( 'hide_empty' => false ) );
+		$languages = get_terms( 'language', [ 'hide_empty' => false ] );
 
 		// Delete users options
-		foreach ( get_users( array( 'fields' => 'ID' ) ) as $user_id ) {
+		foreach ( get_users( [ 'fields' => 'ID' ] ) as $user_id ) {
 			delete_user_meta( $user_id, 'pll_filter_content' );
 			delete_user_meta( $user_id, 'pll_duplicate_content' );
 			foreach ( $languages as $lang ) {
@@ -77,13 +83,15 @@ class PLL_Uninstall {
 		}
 
 		// Delete menu language switchers
-		$ids = get_posts( array(
-			'post_type'   => 'nav_menu_item',
-			'numberposts' => -1,
-			'nopaging'    => true,
-			'fields'      => 'ids',
-			'meta_key'    => '_pll_menu_item',
-		) );
+		$ids = get_posts(
+			[
+				'post_type'   => 'nav_menu_item',
+				'numberposts' => -1,
+				'nopaging'    => true,
+				'fields'      => 'ids',
+				'meta_key'    => '_pll_menu_item',
+			]
+		);
 
 		foreach ( $ids as $id ) {
 			wp_delete_post( $id, true );
@@ -96,22 +104,29 @@ class PLL_Uninstall {
 		}
 
 		// Delete the strings translations 1.2+
-		register_post_type( 'polylang_mo', array( 'rewrite' => false, 'query_var' => false ) );
-		$ids = get_posts( array(
-			'post_type'   => 'polylang_mo',
-			'post_status' => 'any',
-			'numberposts' => -1,
-			'nopaging'    => true,
-			'fields'      => 'ids',
-		) );
+		register_post_type(
+			'polylang_mo', [
+				'rewrite' => false,
+				'query_var' => false,
+			]
+		);
+		$ids = get_posts(
+			[
+				'post_type'   => 'polylang_mo',
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'nopaging'    => true,
+				'fields'      => 'ids',
+			]
+		);
 		foreach ( $ids as $id ) {
 			wp_delete_post( $id, true );
 		}
 
 		// Delete all what is related to languages and translations
-		foreach ( get_terms( $pll_taxonomies, array( 'hide_empty' => false ) ) as $term ) {
+		foreach ( get_terms( $pll_taxonomies, [ 'hide_empty' => false ] ) as $term ) {
 			$term_ids[] = (int) $term->term_id;
-			$tt_ids[] = (int) $term->term_taxonomy_id;
+			$tt_ids[]   = (int) $term->term_taxonomy_id;
 		}
 
 		if ( ! empty( $term_ids ) ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -131,12 +131,15 @@ class PLL_Uninstall {
 
 		if ( ! empty( $term_ids ) ) {
 			$term_ids = array_unique( $term_ids );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->terms WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->term_taxonomy WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' );
 		}
 
 		if ( ! empty( $tt_ids ) ) {
 			$tt_ids = array_unique( $tt_ids );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->term_relationships WHERE term_taxonomy_id IN ( " . implode( ',', $tt_ids ) . ' )' );
 		}
 


### PR DESCRIPTION
There was a lot of legit usage where the wpdb->prepare was used prior to the query. I'm no longer concerned about any security issues with wpdb usage in the plugin.

Changing some of the queries into native core functions may be doable but would be quite complex to refactor. Not worth the time right now for little gain.

Added caching to the term_exists() function and made one of the slow queries into a background process.