### PR TITLE
Fix/wpdb

### DIFF
--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -337,6 +337,8 @@ class PLL_Admin_Model extends PLL_Model {
 	public function set_language_in_mass( $type, $ids, $lang ) {
 		global $wpdb;
 
+		set_time_limit( 0 );
+
 		$ids   = array_map( 'intval', $ids );
 		$lang  = $this->get_language( $lang );
 		$tt_id = 'term' === $type ? $lang->tl_term_taxonomy_id : $lang->term_taxonomy_id;
@@ -347,6 +349,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		if ( ! empty( $values ) ) {
 			$values = array_unique( $values );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $values ) );
 			$lang->update_count(); // Updating term count is mandatory ( thanks to AndyDeGroo )
 		}
@@ -377,6 +380,8 @@ class PLL_Admin_Model extends PLL_Model {
 	public function set_translation_in_mass( $type, $translations ) {
 		global $wpdb;
 
+		set_time_limit( 0 );
+
 		$taxonomy = $type . '_translations';
 
 		foreach ( $translations as $t ) {
@@ -390,10 +395,12 @@ class PLL_Admin_Model extends PLL_Model {
 		// Insert terms
 		if ( ! empty( $terms ) ) {
 			$terms = array_unique( $terms );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->terms ( slug, name ) VALUES " . implode( ',', $terms ) );
 		}
 
 		// Get all terms with their term_id
+		// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 		$terms = $wpdb->get_results( "SELECT term_id, slug FROM $wpdb->terms WHERE slug IN ( " . implode( ',', $slugs ) . ' )' );
 
 		// Prepare terms taxonomy relationship
@@ -405,6 +412,7 @@ class PLL_Admin_Model extends PLL_Model {
 		// Insert term_taxonomy
 		if ( ! empty( $tts ) ) {
 			$tts = array_unique( $tts );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->term_taxonomy ( term_id, taxonomy, description, count ) VALUES " . implode( ',', $tts ) );
 		}
 
@@ -425,6 +433,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Insert term_relationships
 		if ( ! empty( $trs ) ) {
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $trs ) );
 			$trs = array_unique( $trs );
 		}
@@ -441,8 +450,12 @@ class PLL_Admin_Model extends PLL_Model {
 	 * @param in $limit Max number of posts or terms to return. Defaults to -1 (no limit).
 	 * @return array Array made of an array of post ids and an array of term ids
 	 */
-	public function get_objects_with_no_lang( $limit = -1 ) {
+	public function get_objects_with_no_lang( $limit = 300 ) {
 		global $wpdb;
+
+		if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+			$limit = -1;
+		}
 
 		/**
 		 * Filters the max number of posts or terms to return when searching objects with no language
@@ -472,6 +485,7 @@ class PLL_Admin_Model extends PLL_Model {
 			]
 		);
 
+		// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 		$terms = $wpdb->get_col(
 			sprintf(
 				"
@@ -486,6 +500,7 @@ class PLL_Admin_Model extends PLL_Model {
 				$limit > 0 ? "LIMIT {$limit}" : ''
 			)
 		);
+		// phpcs:enable
 
 		/**
 		 * Filter the list of untranslated posts ids and terms ids
@@ -527,7 +542,7 @@ class PLL_Admin_Model extends PLL_Model {
 				}
 				unset( $tr[ $old_slug ] );
 
-				if ( empty( $tr ) || 1 == count( $tr ) ) {
+				if ( empty( $tr ) || 1 === count( $tr ) ) {
 					$dt['t'][]  = (int) $term->term_id;
 					$dt['tt'][] = (int) $term->term_taxonomy_id;
 				} else {
@@ -539,6 +554,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Delete relationships
 		if ( ! empty( $dr ) ) {
+			// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query(
 				"
 				DELETE FROM $wpdb->term_relationships
@@ -546,16 +562,20 @@ class PLL_Admin_Model extends PLL_Model {
 				AND term_taxonomy_id IN ( ' . implode( ',', $dr['tt'] ) . ' )
 			'
 			);
+			// phpcs:enable
 		}
 
 		// Delete terms
 		if ( ! empty( $dt ) ) {
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->terms WHERE term_id IN ( " . implode( ',', $dt['t'] ) . ' )' );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->term_taxonomy WHERE term_taxonomy_id IN ( " . implode( ',', $dt['tt'] ) . ' )' );
 		}
 
 		// Update terms
 		if ( ! empty( $ut ) ) {
+			// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query(
 				"
 				UPDATE $wpdb->term_taxonomy
@@ -563,6 +583,7 @@ class PLL_Admin_Model extends PLL_Model {
 				WHERE term_id IN ( ' . implode( ',', $ut['in'] ) . ' )
 			'
 			);
+			// phpcs:enable
 		}
 
 		if ( ! empty( $term_ids ) ) {

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -108,6 +108,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 				$_posts    = array_fill_keys( $languages, [] ); // Init with empty arrays
 				$languages = implode( ',', $languages );
 
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$relations = $wpdb->get_results( "SELECT object_id, term_taxonomy_id FROM {$wpdb->term_relationships} WHERE object_id IN ({$posts}) AND term_taxonomy_id IN ({$languages})" );
 
 				foreach ( $relations as $relation ) {

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -228,6 +228,7 @@ class PLL_Upgrade {
 
 		// Assign language to each term
 		if ( ! empty( $terms ) ) {
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $terms ) );
 		}
 
@@ -237,6 +238,7 @@ class PLL_Upgrade {
 			$terms = $slugs = $tts = $trs = [];
 
 			// Get all translated objects
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$objects = $wpdb->get_col( "SELECT DISTINCT meta_value FROM {$wpdb->$table} WHERE meta_key = '_translations'" );
 
 			if ( empty( $objects ) ) {
@@ -255,10 +257,12 @@ class PLL_Upgrade {
 
 			// Insert terms
 			if ( ! empty( $terms ) ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "INSERT INTO $wpdb->terms ( slug, name ) VALUES " . implode( ',', $terms ) );
 			}
 
 			// Get all terms with their term_id
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$terms = $wpdb->get_results( "SELECT term_id, slug FROM $wpdb->terms WHERE slug IN ( " . implode( ',', $slugs ) . ' )' );
 
 			// Prepare terms taxonomy relationship
@@ -270,6 +274,7 @@ class PLL_Upgrade {
 
 			// Insert term_taxonomy
 			if ( ! empty( $tts ) ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "INSERT INTO $wpdb->term_taxonomy ( term_id, taxonomy, description ) VALUES " . implode( ',', $tts ) );
 			}
 
@@ -290,6 +295,7 @@ class PLL_Upgrade {
 
 			// Insert term_relationships
 			if ( ! empty( $trs ) ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $trs ) );
 			}
 		}

--- a/modules/plugins/wp-import.php
+++ b/modules/plugins/wp-import.php
@@ -146,6 +146,7 @@ class PLL_WP_Import extends WP_Import {
 			$trs = array_diff( $trs, $existing_trs );
 
 			if ( ! empty( $trs ) ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "INSERT INTO $wpdb->term_relationships ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $trs ) );
 			}
 		}
@@ -179,11 +180,13 @@ class PLL_WP_Import extends WP_Import {
 		}
 
 		if ( ! empty( $u ) ) {
+			// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query(
 				"UPDATE $wpdb->term_taxonomy
 				SET description = ( CASE term_id " . implode( ' ', $u['case'] ) . ' END )
 				WHERE term_id IN ( ' . implode( ',', $u['in'] ) . ' )'
 			);
+			// phpcs:enable
 		}
 	}
 }

--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -32,6 +32,7 @@ if ( file_exists( $_tests_dir . '/../wordpress-importer/wordpress-importer.php' 
 			global $wpdb;
 			// crude but effective: make sure there's no residual data in the main tables
 			foreach ( [ 'posts', 'postmeta', 'comments', 'terms', 'term_taxonomy', 'term_relationships', 'users', 'usermeta' ] as $table ) {
+				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 				$wpdb->query( "DELETE FROM {$wpdb->$table}" );
 			}
 		}

--- a/uninstall.php
+++ b/uninstall.php
@@ -131,12 +131,15 @@ class PLL_Uninstall {
 
 		if ( ! empty( $term_ids ) ) {
 			$term_ids = array_unique( $term_ids );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->terms WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->term_taxonomy WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' );
 		}
 
 		if ( ! empty( $tt_ids ) ) {
 			$tt_ids = array_unique( $tt_ids );
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM $wpdb->term_relationships WHERE term_taxonomy_id IN ( " . implode( ',', $tt_ids ) . ' )' );
 		}
 


### PR DESCRIPTION
There was a lot of legit usage where the wpdb->prepare was used prior to the query. I'm no longer concerned about any security issues with wpdb usage in the plugin.

Changing some of the queries into native core functions may be doable but would be quite complex to refactor. Not worth the time right now for little gain.

Added caching to the term_exists() function and made one of the slow queries into a background process.